### PR TITLE
Fix config path resolution

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildState.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildState.scala
@@ -18,11 +18,12 @@ object BuildState {
     val workspaceURI: URI =
       Paths.get(buildURI).getParent.toUri
 
+
     def contractURI: URI =
-      config.contractPath.toUri
+      workspaceURI.resolve(s"${config.contractPath}")
 
     def artifactURI: URI =
-      config.artifactPath.toUri
+      workspaceURI.resolve(s"${config.artifactPath}")
   }
 
   case class BuildErrored(buildURI: URI,

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/WorkspaceBuildSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/WorkspaceBuildSpec.scala
@@ -74,4 +74,16 @@ class WorkspaceBuildSpec extends AnyWordSpec with Matchers {
         )
     }
   }
+
+  "BuildCompiled" should {
+    "correctly resolve pathes" in {
+      val workspacePath = Files.createTempDirectory("workspace_URI")
+      val config = WorkspaceBuild.defaultRalphcConfig
+      val buildPath = workspacePath.resolve(WorkspaceBuild.BUILD_FILE_NAME)
+      val buildCompiled = BuildState.BuildCompiled(buildURI = buildPath.toUri, code = "", config = config)
+
+      buildCompiled.contractURI shouldBe workspacePath.resolve("contracts").toUri
+      buildCompiled.artifactURI shouldBe workspacePath.resolve("artifacts").toUri
+    }
+  }
 }


### PR DESCRIPTION
When doing some tested I had an error because my single `ral` file was included twiced, I notice some weird stuff in the pathes, it was at the same time `OnDisk` and `Uncompiled`, but with a different path:

![image](https://github.com/alephium/ralph-lsp/assets/2979182/8b38f249-8fd6-45d7-9377-d74a118a7e00)

notice the weird `/./` in first path?

It comes from our `BuildState` resolution of paths. When doing `config.contractPath.toUri` it actually just take the uri from where it's called and blindly add `./contracts`.

For example in tests, it was not using the temporary workspace, but it was resolving to `/home/thomas/dev/ralph-lsp/./contracts`

![image](https://github.com/alephium/ralph-lsp/assets/2979182/97e62ef3-73bc-43e3-aaf4-56ffd2f5575d)

With the fix in this PR it looks fine:

![image](https://github.com/alephium/ralph-lsp/assets/2979182/27842870-339a-48c3-8be1-51291b073d39)

But maybe you could just launch the test on your Mac to see if it's fine to? Path/URI are weird.

Using this also fixed my issue when opening my single ral file.