### PR TITLE
Normalize config path

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildValidator.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildValidator.scala
@@ -184,8 +184,8 @@ object BuildValidator {
    */
   private def getAbsolutePaths(parsed: BuildParsed): (Path, Path, Path) = {
     val workspacePath = Paths.get(parsed.workspaceURI)
-    val absoluteContractPath = workspacePath.resolve(parsed.config.contractPath)
-    val absoluteArtifactPath = workspacePath.resolve(parsed.config.artifactPath)
+    val absoluteContractPath = workspacePath.resolve(Paths.get(parsed.config.contractPath).normalize)
+    val absoluteArtifactPath = workspacePath.resolve(Paths.get(parsed.config.artifactPath).normalize)
     (workspacePath, absoluteContractPath, absoluteArtifactPath)
   }
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildValidatorSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildValidatorSpec.scala
@@ -40,7 +40,7 @@ class BuildValidatorSpec extends AnyWordSpec with Matchers {
         config = config2
       )
 
-      BuildValidator.validate(parsed1) should not be BuildValidator.validate(parsed2)
+      BuildValidator.validate(parsed1) shouldBe BuildValidator.validate(parsed2)
     }
   }
 }


### PR DESCRIPTION
I still add the problem of path looking like `/home/thomas/dev/ralph-test/./contracts`

In the first commit is showing the error, notice the `should not be`, while we want `contracts` and `./contracts` to resolves to the same thing.

The second commit is doing the fix