### PR TITLE
Report failure to download

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/StdInterface.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/StdInterface.scala
@@ -46,7 +46,10 @@ object StdInterface extends StrictLogging {
   } match {
     case Success(value) => value
     case Failure(error) =>
-      logger.error(s"Cannot get std interfaces: $error")
-      Map.empty
+      logger.error("Cannot get std interfaces", error)
+      // FIXME: Temporary solution for https://github.com/alephium/ralph-lsp/issues/41.
+      //        This will be properly resolved in https://github.com/alephium/ralph-lsp/issues/63.
+      //        We should NOT throw exceptions.
+      throw error
   }
 }


### PR DESCRIPTION
- Resolves #41 
  - Implements a temporary solution until #63 is resolved (will be implemented along side of #8).
  - How to implement this is also dependant on #44.
- This resolves all the issues required for Internal release. Next step is to do #7 ourselves.

# Test

Failure to download std is reported to the user. "Something went wrong" is a manually injected exception for this test.

![image](https://github.com/alephium/ralph-lsp/assets/1773953/cdd6e815-c357-4a05-9e4d-652451275f00)

Exception is logged to a file

> java.lang.Exception: Something went wrong
	at org.alephium.ralph.lsp.pc.sourcecode.imports.StdInterface$.$anonfun$stdInterfaces$1(StdInterface.scala:30)
	at scala.util.Using$Manager.scala$util$Using$Manager$$manage(Using.scala:168)
	at scala.util.Using$Manager$.apply(Using.scala:221)
... 
2023-11-21 16:30:17,314 [ol-1-thread-1]                         ERROR o.a.r.l.p.w.b.d.DependencyDownloader$              - Failed to download dependency: std
java.lang.Exception: Something went wrong
	at org.alephium.ralph.lsp.pc.sourcecode.imports.StdInterface$.$anonfun$stdInterfaces$1(StdInterface.scala:30)

