### PR TITLE
Enable trace setting (VSCode)

### DIFF
--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/ResponseError.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/ResponseError.scala
@@ -36,6 +36,12 @@ object ResponseError {
       message = s"Unknown file type: $fileURI"
     )
 
+  case class InvalidTraceSetting(setting: String) extends
+    ResponseError(
+      errorCode = ResponseErrorCode.InvalidRequest,
+      message = s"Invalid trace setting: $setting"
+    )
+
   case object ShutdownRequested extends
     ResponseError(
       errorCode = ResponseErrorCode.InvalidRequest,

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/state/ServerState.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/state/ServerState.scala
@@ -16,10 +16,12 @@ import java.util.concurrent.{Future => JFuture}
  *                    - On successful build compilation, this gets set to [[None]] and the workspace is updated with the new build file.
  *                    - If there are build errors, the workspace still handles requests using the most recent valid and compiled build file
  *                      until this build file is error-free and successfully compiled.
+ * @param trace       Client configured setting. See also [[org.eclipse.lsp4j.TraceValue]].
  */
 case class ServerState(client: Option[RalphLangClient],
                        listener: Option[JFuture[Void]],
                        workspace: Option[WorkspaceState],
                        buildErrors: Option[BuildState.BuildErrored],
                        clientAllowsWatchedFilesDynamicRegistration: Boolean,
+                       trace: Trace,
                        shutdownReceived: Boolean)

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/state/Trace.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/state/Trace.scala
@@ -1,0 +1,23 @@
+package org.alephium.ralph.lsp.server.state
+
+import org.alephium.ralph.lsp.server.ResponseError.InvalidTraceSetting
+
+/**
+ * @see [[org.eclipse.lsp4j.TraceValue]].
+ */
+sealed trait Trace
+object Trace {
+  case object Off extends Trace
+  case object Messages extends Trace
+  case object Verbose extends Trace
+
+  def apply(string: String): Either[InvalidTraceSetting, Trace] =
+    if (string equalsIgnoreCase Trace.Off.productPrefix)
+      Right(Trace.Off)
+    else if (string equalsIgnoreCase Trace.Messages.productPrefix)
+      Right(Trace.Messages)
+    else if (string equalsIgnoreCase Trace.Verbose.productPrefix)
+      Right(Trace.Verbose)
+    else
+      Left(InvalidTraceSetting(string))
+}

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/state/Trace.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/state/Trace.scala
@@ -12,7 +12,9 @@ object Trace {
   case object Verbose extends Trace
 
   def apply(string: String): Either[InvalidTraceSetting, Trace] =
-    if (string equalsIgnoreCase Trace.Off.productPrefix)
+    if (string == null)
+      Right(Trace.Off)
+    else if (string equalsIgnoreCase Trace.Off.productPrefix)
       Right(Trace.Off)
     else if (string equalsIgnoreCase Trace.Messages.productPrefix)
       Right(Trace.Messages)

--- a/lsp-server/src/test/scala/org/alephium/ralph/lsp/server/RalphLangServerSpec.scala
+++ b/lsp-server/src/test/scala/org/alephium/ralph/lsp/server/RalphLangServerSpec.scala
@@ -3,7 +3,7 @@ package org.alephium.ralph.lsp.server
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
-import org.alephium.ralph.lsp.server.state.ServerState
+import org.alephium.ralph.lsp.server.state.{ServerState, Trace}
 import org.eclipse.lsp4j._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
@@ -49,6 +49,7 @@ class RalphLangServerSpec extends AnyWordSpec with Matchers with MockFactory wit
           workspace = Some(WorkspaceState.Created(workspaceURI)),
           buildErrors = None,
           clientAllowsWatchedFilesDynamicRegistration = false,
+          trace = Trace.Off,
           shutdownReceived = false
         )
     }

--- a/plugin-vscode/package.json
+++ b/plugin-vscode/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "ralph-lsp-client",
+  "name": "ralph-lsp",
   "description": "LSP client for Ralph - The smart contract programming language for the Alephium blockchain",
   "author": "Alephium",
   "license": "LGPL-3.0",
   "version": "0.0.1",
-  "publisher": "vscode",
+  "publisher": "Alephium",
   "repository": {
     "type": "git",
     "url": "https://github.com/alephium/ralph-lsp"

--- a/plugin-vscode/package.json
+++ b/plugin-vscode/package.json
@@ -18,6 +18,23 @@
     "workspaceContains:ralph.json"
   ],
   "main": "./out/extension",
+  "contributes": {
+    "configuration": {
+      "properties": {
+        "ralph-lsp.trace.server": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between VS Code and Ralph language server."
+        }
+      }
+    }
+  },
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -b",

--- a/plugin-vscode/src/extension.ts
+++ b/plugin-vscode/src/extension.ts
@@ -23,8 +23,8 @@ export function activate(context: ExtensionContext) {
 
     // Create the client and store it.
     client = new LanguageClient(
-        'ralph-lsp-client',
-        'LSP client for Ralph',
+        'ralph-lsp',
+        'Ralph LSP',
         serverOptions,
         clientOptions
     );


### PR DESCRIPTION
- Towards #76.
- Enables setting for tracing client and server communication in VSCode.

![image](https://github.com/alephium/ralph-lsp/assets/1773953/d952f1e5-7d28-4e90-9456-2a32f46d2a03)
