### PR TITLE
Enable client side logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,11 @@ You can use the following sample as reference:
   "artifactPath": "artifacts"
 }
 ```
+
+## Configure trace (VSCode)
+
+![image](https://github.com/alephium/ralph-lsp/assets/1773953/ac537faf-492f-468a-ab88-a39323e6e821)
+
+- `off` - Enables `info`, `warning` and `error`.
+- `messages` - Enables all the above including `debug`.
+- `verbose` - Enables all the above including `trace`.

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangClient.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangClient.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.CompletableFuture
 /**
  * The Ralph-LSP client.
  *
- * Implements functions to accessing [[LanguageClient]] APIs.
+ * Implements functions accessing [[LanguageClient]] APIs.
  */
 case class RalphLangClient(private val client: LanguageClient) {
 

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangClient.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangClient.scala
@@ -15,6 +15,21 @@ case class RalphLangClient(private val client: LanguageClient) {
     error
   }
 
+  def error(message: String): Unit =
+    client.logMessage(new MessageParams(MessageType.Error, message))
+
+  def warning(message: String): Unit =
+    client.logMessage(new MessageParams(MessageType.Warning, message))
+
+  def info(message: String): Unit =
+    client.logMessage(new MessageParams(MessageType.Info, message))
+
+  def log(message: String): Unit =
+    client.logMessage(new MessageParams(MessageType.Log, message))
+
+  def trace(message: String): Unit =
+    client.logTrace(new LogTraceParams(message))
+
   /**
    * @see [[RalphLangClient.registerCapability]]
    */

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangClient.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangClient.scala
@@ -1,5 +1,6 @@
 package org.alephium.ralph.lsp.server
 
+import org.alephium.ralph.lsp.pc.util.ExceptionUtil
 import org.eclipse.lsp4j._
 import org.eclipse.lsp4j.services.LanguageClient
 
@@ -7,6 +8,8 @@ import java.util.concurrent.CompletableFuture
 
 /**
  * The Ralph-LSP client.
+ *
+ * Implements functions to accessing [[LanguageClient]] APIs.
  */
 case class RalphLangClient(private val client: LanguageClient) {
 
@@ -17,6 +20,16 @@ case class RalphLangClient(private val client: LanguageClient) {
 
   def error(message: String): Unit =
     client.logMessage(new MessageParams(MessageType.Error, message))
+
+  def error(message: String, cause: Throwable): Unit = {
+    val clientMessage =
+      ExceptionUtil.mergeToString(
+        message = message,
+        cause = cause
+      )
+
+    error(clientMessage)
+  }
 
   def warning(message: String): Unit =
     client.logMessage(new MessageParams(MessageType.Warning, message))

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangClientLogger.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangClientLogger.scala
@@ -1,0 +1,56 @@
+package org.alephium.ralph.lsp.server
+
+import com.typesafe.scalalogging.Logger
+import org.alephium.ralph.lsp.pc.log.ClientLogger
+import org.alephium.ralph.lsp.pc.util.ExceptionUtil
+import org.alephium.ralph.lsp.server.state.Trace
+
+/**
+ * Logs messages to local slf4j configuration and to remote LSP client.
+ *
+ * @param client The remote client proxy.
+ * @param trace  Current trace setting configured by the LSP client.
+ */
+case class RalphLangClientLogger(client: RalphLangClient,
+                                 trace: Trace) extends ClientLogger {
+
+  override def info(message: String)(implicit logger: Logger): Unit = {
+    logger.info(message)
+    client.info(message)
+  }
+
+  override def warning(message: String)(implicit logger: Logger): Unit = {
+    logger.warn(message)
+    client.warning(message)
+  }
+
+  override def error(message: String)(implicit logger: Logger): Unit = {
+    logger.error(message)
+    client.error(message)
+  }
+
+  override def error(message: String, cause: Throwable)(implicit logger: Logger): Unit = {
+    logger.error(message, cause)
+
+    val stringStackTrace = ExceptionUtil.toStringStackTrace(cause)
+
+    val clientMessage =
+      s"""$message
+         |Cause: $stringStackTrace
+         |""".stripMargin
+
+    client.error(clientMessage)
+  }
+
+  override def debug(message: String)(implicit logger: Logger): Unit = {
+    logger.debug(message)
+    if (trace != Trace.Off)
+      client.log(s"[Debug] $message")
+  }
+
+  override def trace(message: String)(implicit logger: Logger): Unit = {
+    logger.trace(message)
+    if (trace == Trace.Verbose)
+      client.trace(message)
+  }
+}

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangClientLogger.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangClientLogger.scala
@@ -2,7 +2,6 @@ package org.alephium.ralph.lsp.server
 
 import com.typesafe.scalalogging.Logger
 import org.alephium.ralph.lsp.pc.log.ClientLogger
-import org.alephium.ralph.lsp.pc.util.ExceptionUtil
 import org.alephium.ralph.lsp.server.state.Trace
 
 /**
@@ -31,15 +30,7 @@ case class RalphLangClientLogger(client: RalphLangClient,
 
   override def error(message: String, cause: Throwable)(implicit logger: Logger): Unit = {
     logger.error(message, cause)
-
-    val stringStackTrace = ExceptionUtil.toStringStackTrace(cause)
-
-    val clientMessage =
-      s"""$message
-         |Cause: $stringStackTrace
-         |""".stripMargin
-
-    client.error(clientMessage)
+    client.error(message, cause)
   }
 
   override def debug(message: String)(implicit logger: Logger): Unit = {

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
@@ -1,8 +1,8 @@
 package org.alephium.ralph.lsp.server
 
-import com.typesafe.scalalogging.StrictLogging
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.file.FileAccess
+import org.alephium.ralph.lsp.pc.log.StrictImplicitLogging
 import org.alephium.ralph.lsp.pc.workspace._
 import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorUnknownFileType
 import org.alephium.ralph.lsp.server
@@ -98,10 +98,16 @@ object RalphLangServer {
  * All mutable state management occurs here.
  */
 class RalphLangServer private(@volatile private var state: ServerState)(implicit compiler: CompilerAccess,
-                                                                        file: FileAccess) extends LanguageServer with TextDocumentService with WorkspaceService with StrictLogging { thisServer =>
+                                                                        file: FileAccess) extends LanguageServer with TextDocumentService with WorkspaceService with StrictImplicitLogging { thisServer =>
 
   def getState(): ServerState =
     thisServer.state
+
+  private implicit def logger: RalphLangClientLogger =
+    RalphLangClientLogger(
+      client = getClient(),
+      trace = state.trace
+    )
 
   /**
    * An initial call to this function is required before this server can start processing request.

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
@@ -25,7 +25,7 @@ object RalphLangServer {
   def apply(client: RalphLangClient,
             listener: JFuture[Void],
             clientAllowsWatchedFilesDynamicRegistration: Boolean = false)(implicit compiler: CompilerAccess,
-                                     file: FileAccess): RalphLangServer = {
+                                                                          file: FileAccess): RalphLangServer = {
     val initialState =
       ServerState(
         client = Some(client),

--- a/lsp-server/src/test/scala/org/alephium/ralph/lsp/server/RalphLangServerSpec.scala
+++ b/lsp-server/src/test/scala/org/alephium/ralph/lsp/server/RalphLangServerSpec.scala
@@ -69,8 +69,14 @@ class RalphLangServerSpec extends AnyWordSpec with Matchers with MockFactory wit
     val listener = CompletableFuture.runAsync(() => ())
 
     "return true, set `shutdownReceived` to true, but not cancel the listener" in {
-      val client = RalphLangClient(null)
+      val client = mock[RalphLangClient]
+
       val server = RalphLangServer(client, listener)
+
+      // ignore calls to info
+      (client.info _)
+        .expects(*)
+        .anyNumberOfTimes()
 
       server.getState().shutdownReceived shouldBe false
       server.shutdown().asScala.futureValue shouldBe true
@@ -79,10 +85,22 @@ class RalphLangServerSpec extends AnyWordSpec with Matchers with MockFactory wit
     }
 
     "return an `InvalidRequest` when receiving more than one shutdown request" in {
-      val client = RalphLangClient(null)
+      val client = mock[RalphLangClient]
+
       val server = RalphLangServer(client, listener)
 
+      // ignore calls to info
+      (client.info _)
+        .expects(*)
+        .anyNumberOfTimes()
+
       server.shutdown().asScala.futureValue shouldBe true
+
+      // shutdown error message is logged to the client once
+      (client.error(_: String, _: Throwable))
+        .expects(ResponseError.ShutdownRequested.getMessage, *)
+        .once()
+
       //Testing messages as the two java classes aren't consider equal
       server.shutdown().asScala.failed.futureValue.getMessage shouldBe ResponseError.ShutdownRequested.toResponseErrorException.getMessage
     }
@@ -91,12 +109,17 @@ class RalphLangServerSpec extends AnyWordSpec with Matchers with MockFactory wit
   "exit" should {
     implicit val compiler: CompilerAccess = CompilerAccess.ralphc
     implicit val file: FileAccess = FileAccess.disk
-    val client: RalphLangClient = RalphLangClient(null)
-
     //We use a Promise to have a non-completed future
     val listener = Promise[Void]().future.asJava.asInstanceOf[JFuture[Void]]
 
     "cancel listener and exit successfully if shutdown was triggered" in {
+      val client = mock[RalphLangClient]
+
+      // ignore calls to info
+      (client.info _)
+        .expects(*)
+        .anyNumberOfTimes()
+
       val server = RalphLangServer(client, listener)
 
       server.getState().listener.get.isCancelled shouldBe false
@@ -107,6 +130,13 @@ class RalphLangServerSpec extends AnyWordSpec with Matchers with MockFactory wit
     }
 
     "exit with error if shutdown wasn't requested" in {
+      val client = mock[RalphLangClient]
+
+      // ignore calls to info
+      (client.info _)
+        .expects(*)
+        .anyNumberOfTimes()
+
       val server = RalphLangServer(client, listener)
 
       server.exitWithCode() shouldBe 1

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/log/ClientLogger.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/log/ClientLogger.scala
@@ -2,6 +2,7 @@ package org.alephium.ralph.lsp.pc.log
 
 import com.typesafe.scalalogging.Logger
 
+/** Defines APIs for publishing logs to an LSP client */
 trait ClientLogger {
 
   def info(message: String)(implicit logger: Logger): Unit

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/log/ClientLogger.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/log/ClientLogger.scala
@@ -1,0 +1,19 @@
+package org.alephium.ralph.lsp.pc.log
+
+import com.typesafe.scalalogging.Logger
+
+trait ClientLogger {
+
+  def info(message: String)(implicit logger: Logger): Unit
+
+  def warning(message: String)(implicit logger: Logger): Unit
+
+  def error(message: String)(implicit logger: Logger): Unit
+
+  def error(message: String, cause: Throwable)(implicit logger: Logger): Unit
+
+  def debug(message: String)(implicit logger: Logger): Unit
+
+  def trace(message: String)(implicit logger: Logger): Unit
+
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/log/StrictImplicitLogging.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/log/StrictImplicitLogging.scala
@@ -1,0 +1,12 @@
+package org.alephium.ralph.lsp.pc.log
+
+import com.typesafe.scalalogging.Logger
+import org.slf4j.LoggerFactory
+
+/** Copy of [[com.typesafe.scalalogging.StrictLogging]] */
+trait StrictImplicitLogging {
+
+  protected implicit val loggerSLF4J: Logger =
+    Logger(LoggerFactory.getLogger(getClass.getName))
+
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/util/ExceptionUtil.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/util/ExceptionUtil.scala
@@ -12,4 +12,12 @@ object ExceptionUtil {
     sw.toString
   }
 
+  /** Merge a message and exception into a String */
+  def mergeToString(message: String, cause: Throwable): String = {
+    val stringStackTrace = toStringStackTrace(cause)
+
+    s"""$message
+       |Cause: $stringStackTrace""".stripMargin
+  }
+
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/util/ExceptionUtil.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/util/ExceptionUtil.scala
@@ -1,0 +1,15 @@
+package org.alephium.ralph.lsp.pc.util
+
+import java.io.{PrintWriter, StringWriter}
+
+object ExceptionUtil {
+
+  /** Emit stack-trace as String */
+  def toStringStackTrace(throwable: Throwable): String = {
+    val sw = new StringWriter()
+    val pw = new PrintWriter(sw)
+    throwable.printStackTrace(pw)
+    sw.toString
+  }
+
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/Build.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/Build.scala
@@ -2,6 +2,7 @@ package org.alephium.ralph.lsp.pc.workspace.build
 
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.file.FileAccess
+import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.workspace.build.error._
 import org.alephium.ralph.lsp.pc.workspace.build.BuildState._
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.Dependency
@@ -69,7 +70,8 @@ object Build {
   /** Compile a parsed build */
   def compile(parsed: BuildState.IsParsed,
               currentBuild: Option[BuildState.IsCompiled])(implicit file: FileAccess,
-                                                           compiler: CompilerAccess): BuildState.IsCompiled =
+                                                           compiler: CompilerAccess,
+                                                           logger: ClientLogger): BuildState.IsCompiled =
     parsed match {
       case errored: BuildErrored =>
         // there are parsing errors
@@ -91,7 +93,8 @@ object Build {
   /** Parse and compile from disk */
   def parseAndCompile(buildURI: URI,
                       currentBuild: Option[BuildState.IsCompiled])(implicit file: FileAccess,
-                                                                   compiler: CompilerAccess): BuildState.IsCompiled =
+                                                                   compiler: CompilerAccess,
+                                                                   logger: ClientLogger): BuildState.IsCompiled =
     file.exists(buildURI) match {
       case Left(error) =>
         BuildErrored(
@@ -122,7 +125,8 @@ object Build {
   def parseAndCompile(buildURI: URI,
                       code: String,
                       currentBuild: Option[BuildState.IsCompiled])(implicit file: FileAccess,
-                                                                   compiler: CompilerAccess): BuildState.IsCompiled = {
+                                                                   compiler: CompilerAccess,
+                                                                   logger: ClientLogger): BuildState.IsCompiled = {
     // Code is already read. Parse and validate it.
     val parsed =
       parse(
@@ -139,7 +143,8 @@ object Build {
   def parseAndCompile(buildURI: URI,
                       code: Option[String],
                       currentBuild: Option[BuildState.IsCompiled])(implicit file: FileAccess,
-                                                                   compiler: CompilerAccess): BuildState.IsCompiled =
+                                                                   compiler: CompilerAccess,
+                                                                   logger: ClientLogger): BuildState.IsCompiled =
     code match {
       case Some(code) =>
         parseAndCompile(
@@ -162,7 +167,8 @@ object Build {
   def parseAndCompile(buildURI: URI,
                       code: Option[String],
                       currentBuild: BuildState.BuildCompiled)(implicit file: FileAccess,
-                                                              compiler: CompilerAccess): Option[BuildState.IsCompiled] =
+                                                              compiler: CompilerAccess,
+                                                              logger: ClientLogger): Option[BuildState.IsCompiled] =
     BuildValidator.validateBuildURI(
       buildURI = buildURI,
       workspaceURI = currentBuild.workspaceURI

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/Dependency.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/Dependency.scala
@@ -4,6 +4,7 @@ import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.compiler.message.error.StringError
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndex
 import org.alephium.ralph.lsp.access.file.FileAccess
+import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.workspace.{Workspace, WorkspaceState}
 import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState}
 import org.alephium.ralph.lsp.pc.workspace.build.BuildState._
@@ -22,7 +23,8 @@ object Dependency {
    */
   def compile(parsed: BuildParsed,
               currentBuild: Option[BuildState.IsCompiled])(implicit file: FileAccess,
-                                                           compiler: CompilerAccess): BuildState.IsCompiled =
+                                                           compiler: CompilerAccess,
+                                                           logger: ClientLogger): BuildState.IsCompiled =
     currentBuild.flatMap(_.dependency) match {
       case Some(dependency) =>
         // Existing build already has compiled dependency. Re-use it.
@@ -45,7 +47,8 @@ object Dependency {
    *         the field [[BuildState.BuildErrored.dependency]] as a regular workspace errors.
    */
   def downloadAndCompileStd(parsed: BuildParsed)(implicit file: FileAccess,
-                                                 compiler: CompilerAccess): BuildState.IsCompiled =
+                                                 compiler: CompilerAccess,
+                                                 logger: ClientLogger): BuildState.IsCompiled =
     DependencyDownloader.downloadStd(errorIndex = SourceIndex.empty) match { // download std
       case Left(errors) =>
         // report all download errors at build file level.

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/DependencyDownloader.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/DependencyDownloader.scala
@@ -1,10 +1,10 @@
 package org.alephium.ralph.lsp.pc.workspace.build.dependency
 
-import com.typesafe.scalalogging.LazyLogging
 import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.CompilerOptions
 import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, SourceIndex}
+import org.alephium.ralph.lsp.pc.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.lsp.pc.sourcecode.imports.StdInterface
 import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState, RalphcConfig}
 import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorDownloadingDependency
@@ -12,14 +12,14 @@ import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorDownloadingDependenc
 import java.nio.file.Paths
 import scala.collection.immutable.ArraySeq
 
-object DependencyDownloader extends LazyLogging {
+object DependencyDownloader extends StrictImplicitLogging {
 
   /**
    * Download the Std package and return an un-compiled workspace for compilation.
    *
    * @param errorIndex Use this index to report any errors processing the download.
    */
-  def downloadStd(errorIndex: SourceIndex): Either[ArraySeq[CompilerMessage.AnyError], WorkspaceState.UnCompiled] =
+  def downloadStd(errorIndex: SourceIndex)(implicit logger: ClientLogger): Either[ArraySeq[CompilerMessage.AnyError], WorkspaceState.UnCompiled] =
     downloadStdFromJar(errorIndex) match {
       case Right(source) =>
         // a default build file.
@@ -44,7 +44,7 @@ object DependencyDownloader extends LazyLogging {
    * TODO: Downloading source-code should be installable.
    * See issue <a href="https://github.com/alephium/ralph-lsp/issues/44">#44</a>.
    */
-  private def downloadStdFromJar(errorIndex: SourceIndex): Either[ErrorDownloadingDependency, Iterable[SourceCodeState.UnCompiled]] =
+  private def downloadStdFromJar(errorIndex: SourceIndex)(implicit logger: ClientLogger): Either[ErrorDownloadingDependency, Iterable[SourceCodeState.UnCompiled]] =
     try {
       // Errors must be reported to the user. See https://github.com/alephium/ralph-lsp/issues/41.
       val code =

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/client/FileClientLogger.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/client/FileClientLogger.scala
@@ -1,0 +1,26 @@
+package org.alephium.ralph.lsp.pc.client
+
+import com.typesafe.scalalogging.Logger
+import org.alephium.ralph.lsp.pc.log.ClientLogger
+
+/** Test logger that has no remote client. This simply logs to a file. */
+object FileClientLogger extends ClientLogger {
+
+  override def info(message: String)(implicit logger: Logger): Unit =
+    logger.info(message)
+
+  override def warning(message: String)(implicit logger: Logger): Unit =
+    logger.warn(message)
+
+  override def error(message: String)(implicit logger: Logger): Unit =
+    logger.error(message)
+
+  override def error(message: String, cause: Throwable)(implicit logger: Logger): Unit =
+    logger.error(message, cause)
+
+  override def debug(message: String)(implicit logger: Logger): Unit =
+    logger.debug(message)
+
+  override def trace(message: String)(implicit logger: Logger): Unit =
+    logger.trace(message)
+}

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceInitialiseSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceInitialiseSpec.scala
@@ -6,14 +6,14 @@ import org.alephium.ralph.lsp.FileIO
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndex
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.file.FileAccess
-import org.alephium.ralph.lsp.pc.workspace.build.dependency.Dependency
+import org.alephium.ralph.lsp.pc.client.FileClientLogger
+import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.workspace.build.error.{ErrorBuildFileNotFound, ErrorInvalidBuildSyntax}
 import org.alephium.ralphc.Config
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.EitherValues._
-import org.scalatest.OptionValues._
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import java.nio.file.Paths
@@ -23,6 +23,9 @@ import scala.collection.immutable.ArraySeq
  * Test cases for [[Workspace.build]] function.
  */
 class WorkspaceInitialiseSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+
+  implicit val clientLogger: ClientLogger =
+    FileClientLogger
 
   "initialise" when {
     /**

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildSpec.scala
@@ -5,6 +5,8 @@ import org.alephium.ralph.lsp.pc.workspace.build.error.{ErrorBuildFileNotFound, 
 import org.alephium.ralph.lsp.FileIO
 import org.alephium.ralph.lsp.GenCommon.genFolderURI
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
+import org.alephium.ralph.lsp.pc.client.FileClientLogger
+import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.workspace.build.GenBuild._
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
@@ -16,6 +18,9 @@ import java.nio.file.Paths
 import scala.collection.immutable.ArraySeq
 
 class BuildSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+
+  implicit val clientLogger: ClientLogger =
+    FileClientLogger
 
   "build" should {
     "fail" when {
@@ -29,7 +34,7 @@ class BuildSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyC
           GenBuild
             .genBuildParsed()
             .map(persist)
-            .map(Build.compile(_, None)(FileAccess.disk, CompilerAccess.ralphc))
+            .map(Build.compile(_, None)(FileAccess.disk, CompilerAccess.ralphc, clientLogger))
             .map(_.asInstanceOf[BuildState.BuildCompiled])
 
         forAll(outSideBuildGen, insideBuildGen) {
@@ -80,7 +85,7 @@ class BuildSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyC
           GenBuild
             .genBuildParsed()
             .map(persist)
-            .map(Build.compile(_, None)(FileAccess.disk, CompilerAccess.ralphc))
+            .map(Build.compile(_, None)(FileAccess.disk, CompilerAccess.ralphc, clientLogger))
             .map(_.asInstanceOf[BuildState.BuildCompiled])
 
         val generator =

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/RalphcConfigSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/RalphcConfigSpec.scala
@@ -2,6 +2,8 @@ package org.alephium.ralph.lsp.pc.workspace.build
 
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.file.FileAccess
+import org.alephium.ralph.lsp.pc.client.FileClientLogger
+import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.Dependency
 import org.alephium.ralphc.Config
 import org.scalatest.matchers.should.Matchers
@@ -13,6 +15,9 @@ import java.net.URI
 import java.nio.file.{Files, Paths}
 
 class RalphcConfigSpec extends AnyWordSpec with Matchers {
+
+  implicit val clientLogger: ClientLogger =
+    FileClientLogger
 
   "persist & read valid ralphc config" in {
     // create workspace structure with config file


### PR DESCRIPTION
- Resolves #76

It's not longer mandatory for the client to configure the flag `-DRALPH_LSP_HOME` to enable logging. All logs are dispatched to the client using the protocol's [log](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_logMessage) and [trace](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#logTrace) APIs.

## VSCode trace configuration

[TraceValue options](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#traceValue).

![image](https://github.com/alephium/ralph-lsp/assets/1773953/ac537faf-492f-468a-ab88-a39323e6e821)

- `off` - Enables `info`, `warning` and `error`
- `messages` - Enables all the above including `debug`
- `verbose` - Enables all the above including `trace`