### PR TITLE
Compile before assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Currently supports text document level events and diagnostics.
 # Build the jar
 
 ```shell
-sbt "project lsp-server; assembly;"
+sbt "compile; lsp-server/assembly"
 ```
 
 Look in `target` folder: `.../ralph-lsp/lsp-server/target/scala-2.13/ralph-lsp.jar`


### PR DESCRIPTION
Noticed with the help of someone from the community that tested the `ralph-lsp`

If we don't compile first, the dependencies aren't downloaded. I also tried to add the download to the assembly task, but currently failed as sbt is a nightmare ^^

We didn't notice that as we always compile and have the std-interfaces since a long time on our machines.

I could reproduce locally, it then gives 
```
Failed to download dependency: std
java.lang.NullPointerException: Cannot invoke "java.net.URL.getProtocol()" because "stdURL" is null
```

Once we'll have a release, people will download directly a proper assembled jar 