### PR TITLE
Introduce `release` workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    tags: [ "v[0-9]+.[0-9]+.[0-9]+*" ]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Get the version
+        id: get_version
+        run: |
+          version=$(echo ${GITHUB_REF/refs\/tags\//} | cut -c 2-)
+          echo ::set-output name=VERSION::$version
+        shell: bash
+      - run: sbt "compile; lsp-server/assembly"
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.get_version.outputs.VERSION }}
+          release_name: v${{ steps.get_version.outputs.VERSION }}
+          body: Some solid code
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: app/target/scala-2.13/ralph-lsp-${{ steps.get_version.outputs.VERSION }}.jar
+          asset_name: ralph-lsp-${{ steps.get_version.outputs.VERSION }}.jar
+          asset_content_type: application/java-archive
+


### PR DESCRIPTION
This was copy/pasted from our explorer-backend.
This will only release the jar file for now.