### PR TITLE
Hooks for code completion

### DIFF
--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/ResponseError.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/ResponseError.scala
@@ -54,4 +54,10 @@ object ResponseError {
       errorCode = ResponseErrorCode.InternalError,
       message = exception.toString
     )
+
+  case object WorkspaceNotCompiled extends
+    ResponseError(
+      errorCode = ResponseErrorCode.InternalError,
+      message = "Workspace is not compiled"
+    )
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/completion/CodeCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/completion/CodeCompleter.scala
@@ -3,37 +3,22 @@ package org.alephium.ralph.lsp.pc.completion
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 
 import java.net.URI
-import scala.util.Random
 
 object CodeCompleter {
 
   /**
-   * Execute code completing given the current workspace state.
+   * Provides code completion for the given workspace state.
+   *
+   * @param line      Line position in a document (zero-based).
+   * @param character Character offset on a line in a document (zero-based).
+   * @param uri       The text document's uri.
+   * @param workspace Current workspace state.
+   * @return
    */
   def complete(line: Int,
                character: Int,
                uri: URI,
-               workspace: WorkspaceState): Array[Suggestion] = {
-    val randomFunctionName = List("deposit", "transfer", "allocate", "upgrade", "assert")
-    val randomParamName = List("id", "name", "address", "addr")
-    val inputTypes = List("U256", "Address", "Bool")
-    val returnTypes = inputTypes ++ List("()")
-
-    def dummySuggestion() = {
-      val functionName = Random.shuffle(randomFunctionName).head
-      val paramName = Random.shuffle(randomParamName).head
-      val typeName = Random.shuffle(inputTypes).head
-      val returnType = Random.shuffle(returnTypes).head
-
-      Suggestion.Function(
-        label = s"$functionName($paramName: $typeName) -> $returnType",
-        insert = s"$functionName(???)",
-        detail = s"$functionName detailed",
-        documentation = s"documentation for $functionName"
-      )
-    }
-
-    Array.fill(Random.nextInt(10) max 3)(dummySuggestion())
-  }
+               workspace: WorkspaceState.IsSourceAware): Array[Suggestion] =
+    Array.empty[Suggestion] // TODO
 
 }


### PR DESCRIPTION
- Towards #98
- Implements LSP functions to enable code completion.
- TODO: Implement completion/suggestion providers [here](https://github.com/alephium/ralph-lsp/blob/7776e41a929ad7f7e22b736f790c9f97929bd99b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/completion/CodeCompleter.scala#L22).