### PR TITLE
Remove the usage of `.replaceFirst` from code completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ local function ralph_init()
 
    vim.lsp.start({
      name = 'ralph-lsp',
-     cmd = {'java', '-jar', '-DRALPH_LSP_HOME=<path-to-your-log-folder>', '<path-to-your-jar>/ralph-lsp.jar'},
+     cmd = {'java', '-jar', '-DRALPH_LSP_LOG_HOME=<path-to-your-log-folder>', '<path-to-your-jar>/ralph-lsp.jar'},
      root_dir = root_dir,
      capabilities = capabilities
    })
@@ -80,7 +80,8 @@ You can use the following sample as reference:
     "ignoreCheckExternalCallerWarnings": false
   },
   "contractPath": "contracts",
-  "artifactPath": "artifacts"
+  "artifactPath": "artifacts",
+  "dependencyPath": "dependencies"
 }
 ```
 

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/RalphParserExtension.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/RalphParserExtension.scala
@@ -6,7 +6,7 @@ import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndex
 
 /** Functions that extend ralphc's default parser */
-private object RalphParserExtension {
+object RalphParserExtension {
 
   /**
    * An extension to Ralphc's parse function [[org.alephium.ralph.StatefulParser.multiContract]]
@@ -25,6 +25,16 @@ private object RalphParserExtension {
           statements = statements,
           index = index
         )
+    }
+
+  /** Parse an import identifier ignoring errors */
+  def lazyParseImportIdentifier(identifier: String): Option[Tree.Import] =
+    fastparse.parse(s"import \"$identifier\"", importStatement(_)) match {
+      case Parsed.Success(tree, _) =>
+        Some(tree)
+
+      case _: Parsed.Failure =>
+        None
     }
 
   /** A statement can be an import or ralphc's contract */
@@ -56,7 +66,7 @@ private object RalphParserExtension {
    *
    * On error, ignore parse.
    *
-   * @param stringLiteral The String literal to parse.
+   * @param name The String value to parse.
    */
   private def parsePath(name: Tree.Name): Option[Tree.ImportPath] =
     fastparse.parse(name.value, importPaths(_)) match {

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/RalphParserExtension.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/RalphParserExtension.scala
@@ -18,7 +18,7 @@ private object RalphParserExtension {
       case (fromIndex, statements, toIndex) =>
         val index =
           SourceIndex(
-            index = fromIndex,
+            from = fromIndex,
             width = toIndex - fromIndex
           )
 
@@ -38,7 +38,7 @@ private object RalphParserExtension {
       case (fromIndex, stringLiteral, toIndex) =>
         val importIndex =
           SourceIndex(
-            index = fromIndex,
+            from = fromIndex,
             width = toIndex - fromIndex
           )
 
@@ -59,16 +59,16 @@ private object RalphParserExtension {
    *
    * @param stringLiteral The String literal to parse.
    */
-  private def parsePath(stringLiteral: StringLiteral): Option[Tree.Path] =
+  private def parsePath(stringLiteral: StringLiteral): Option[Tree.ImportPath] =
     fastparse.parse(stringLiteral.name.value, importPaths(_)) match {
       case Parsed.Success((packagePath, filePath), _) =>
         // the above parse occurs on a string value, add the offset such
         // that the indexes are set according to the entire source-code.
         val offsetIndex =
-          stringLiteral.name.index.index
+          stringLiteral.name.index.from
 
         val path =
-          Tree.Path(
+          Tree.ImportPath(
             folder = packagePath.copy(index = packagePath.index + offsetIndex),
             file = filePath.copy(index = filePath.index + offsetIndex),
             index = stringLiteral.name.index
@@ -86,13 +86,13 @@ private object RalphParserExtension {
       case (fromPackageIndex, packageName, toPackageIndex, fromFileNameIndex, fileName, toFileNameIndex) =>
         val packageIndex =
           SourceIndex(
-            index = fromPackageIndex,
+            from = fromPackageIndex,
             width = toPackageIndex - fromPackageIndex
           )
 
         val fileIndex =
           SourceIndex(
-            index = fromFileNameIndex,
+            from = fromFileNameIndex,
             width = toFileNameIndex - fromFileNameIndex
           )
 
@@ -124,7 +124,7 @@ private object RalphParserExtension {
       case (fromIndex, code, toIndex) =>
         val index =
           SourceIndex(
-            index = fromIndex,
+            from = fromIndex,
             width = toIndex - fromIndex
           )
 
@@ -147,7 +147,7 @@ private object RalphParserExtension {
       case (fromIndex, nameFromIndex, string, nameToIndex, toIndex) =>
         val index =
           SourceIndex(
-            index = fromIndex,
+            from = fromIndex,
             width = toIndex - fromIndex
           )
 
@@ -155,7 +155,7 @@ private object RalphParserExtension {
           Tree.Name(
             value = string getOrElse "",
             index = SourceIndex(
-              index = nameFromIndex,
+              from = nameFromIndex,
               width = nameToIndex - nameFromIndex
             )
           )

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/Tree.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/Tree.scala
@@ -40,7 +40,13 @@ object Tree {
 
   sealed trait Literal extends Tree
 
-  case class StringLiteral(name: Name,
+  /**
+   * @param value The string value with quotes.
+   * @param name  The string value without quotes.
+   * @param index [[SourceIndex]] of the string with quotes.
+   */
+  case class StringLiteral(value: String,
+                           name: Name,
                            index: SourceIndex) extends Literal
 
   case class Name(value: String,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/Tree.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/Tree.scala
@@ -28,12 +28,12 @@ object Tree {
    * @param index  Index of the full import statement.
    */
   case class Import(string: StringLiteral,
-                    path: Option[Path],
+                    path: Option[ImportPath],
                     index: SourceIndex) extends Statement
 
-  case class Path(folder: Name,
-                  file: Name,
-                  index: SourceIndex) extends Tree
+  case class ImportPath(folder: Name,
+                        file: Name,
+                        index: SourceIndex) extends Tree
 
   case class Source(ast: Ast.ContractWithState,
                     index: SourceIndex) extends Statement

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/CompilerMessage.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/CompilerMessage.scala
@@ -30,7 +30,7 @@ object CompilerMessage {
 
     final def index: SourceIndex =
       SourceIndex(
-        index = error.position,
+        from = error.position,
         width = error.foundLength
       )
   }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndex.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndex.scala
@@ -5,7 +5,7 @@ object SourceIndex {
   /** Empty range */
   val empty: SourceIndex =
     SourceIndex(
-      index = 0,
+      from = 0,
       width = 0
     )
 
@@ -22,25 +22,25 @@ object SourceIndex {
       SourceIndex.empty
     else
       SourceIndex(
-        index = index,
+        from = index,
         width = width
       )
 }
 
 /**
- * @param index Source position within the program.
+ * @param from  Source position within the program.
  * @param width Width of targeted token/code trailing the `index`.
  */
 
-final case class SourceIndex(index: Int, width: Int) { self =>
-  def toIndex =
-    self.index + width
+final case class SourceIndex(from: Int, width: Int) {
+  def to: Int =
+    from + width
 
   /** Checks if the given index is within this SourceIndex's from and to index */
   def contains(index: Int): Boolean =
-    index >= self.index && index <= toIndex
+    index >= from && index <= to
 
   /** Offset this SourceIndex */
   def +(right: Int): SourceIndex =
-    copy(self.index + right)
+    copy(from + right)
 }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/error/ImportError.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/error/ImportError.scala
@@ -7,7 +7,7 @@ sealed trait ImportError extends CompilerMessage.Error
 
 object ImportError {
   final case class Unknown(ast: Tree.Import) extends ImportError {
-    val message: String = s"Unknown import: \"${ast.string.name.value}\""
+    val message: String = s"Unknown import: ${ast.string.value}"
 
     override def index: SourceIndex =
       ast.string.index

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/file/FileAccess.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/file/FileAccess.scala
@@ -1,9 +1,10 @@
 package org.alephium.ralph.lsp.access.file
 
-import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
-import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage.AnyError
+import org.alephium.ralph.lsp.access.compiler.message.error.ThrowableError
+import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, SourceIndex}
 
 import java.net.URI
+import java.nio.file.Path
 
 object FileAccess {
   // disk file-io
@@ -21,7 +22,8 @@ trait FileAccess {
    *
    * @param fileURI source-file location
    */
-  def exists(fileURI: URI): Either[AnyError, Boolean]
+  def exists(fileURI: URI,
+             index: SourceIndex): Either[CompilerMessage.AnyError, Boolean]
 
   /**
    * Fetch all workspace source file locations.
@@ -36,5 +38,10 @@ trait FileAccess {
    * @param fileURI source-code location.
    */
   def read(fileURI: URI): Either[CompilerMessage.AnyError, String]
+
+  /** Write string to the given file URI. */
+  def write(fileURI: URI,
+            string: String,
+            index: SourceIndex): Either[ThrowableError, Path]
 
 }

--- a/lsp-server/src/main/resources/logback.xml
+++ b/lsp-server/src/main/resources/logback.xml
@@ -5,13 +5,13 @@
               value="%-63(%date{ISO8601} [%.13thread]) %-5level %-50(%logger{20}) - %msg%n"/>
 
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${RALPH_LSP_HOME:-${user.home}/.ralph-lsp}/logs/ralph-lsp.log</file>
+        <file>${RALPH_LSP_LOG_HOME:-${user.home}/.ralph-lsp}/logs/ralph-lsp.log</file>
         <append>true</append>
         <encoder>
             <pattern>${filePattern}</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>${RALPH_LSP_HOME:-${user.home}/.ralph-lsp}/logs/ralph-lsp.%i.log</fileNamePattern>
+            <fileNamePattern>${RALPH_LSP_LOG_HOME:-${user.home}/.ralph-lsp}/logs/ralph-lsp.%i.log</fileNamePattern>
             <minIndex>1</minIndex>
             <maxIndex>10</maxIndex>
         </rollingPolicy>

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
@@ -315,7 +315,7 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
           CodeCompleter.complete(
             line = line,
             character = character,
-            uri = fileURI,
+            fileURI = fileURI,
             workspace = sourceAware
           )
 
@@ -326,8 +326,8 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
               suggestions
 
             case Some(Left(error)) =>
-              // Completion failed: Notify the client of the failure
-              getClient() show ResponseError.StringInternalError(error.message)
+              // Completion failed: Log the error message
+              logger.error("Code completion failed: " + error.message)
               ArraySeq.empty[Suggestion]
 
             case None =>

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/ResponseError.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/ResponseError.scala
@@ -55,6 +55,12 @@ object ResponseError {
       message = exception.toString
     )
 
+  case class StringInternalError(message: String) extends
+    ResponseError(
+      errorCode = ResponseErrorCode.InternalError,
+      message = message
+    )
+
   case object WorkspaceNotCompiled extends
     ResponseError(
       errorCode = ResponseErrorCode.InternalError,

--- a/plugin-vscode/src/extension.ts
+++ b/plugin-vscode/src/extension.ts
@@ -23,7 +23,7 @@ function build_args(release: boolean) {
         args = ["-jar", jarPath]; // arguments for plugin release
     } else {
         const logsPath = path.resolve(dirName, "../../"); // path for logs
-        args = ["-jar", `-DRALPH_LSP_HOME=${logsPath}`, jarPath]; // arguments for local development
+        args = ["-jar", `-DRALPH_LSP_LOG_HOME=${logsPath}`, jarPath]; // arguments for local development
     }
 
     return args;

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/completion/CodeCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/completion/CodeCompleter.scala
@@ -17,7 +17,7 @@ object CodeCompleter extends StrictImplicitLogging {
    *
    * @param line      Line position in a document (zero-based).
    * @param character Character offset on a line in a document (zero-based).
-   * @param fileURI       The text document's uri.
+   * @param fileURI   The text document's uri.
    * @param workspace Current workspace state.
    * @return
    */

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/completion/CodeCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/completion/CodeCompleter.scala
@@ -84,7 +84,7 @@ object CodeCompleter extends StrictImplicitLogging {
   private def complete(line: Int,
                        character: Int,
                        workspace: WorkspaceState.IsSourceAware,
-                       sourceCode: SourceCodeState.Parsed): ArraySeq[Suggestion] = {
+                       sourceCode: SourceCodeState.Parsed)(implicit logger: ClientLogger): ArraySeq[Suggestion] = {
     // fetch the requested index from line number and character number.
     val cursorIndex =
       StringUtil.computeIndex(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/completion/ImportCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/completion/ImportCompleter.scala
@@ -1,12 +1,13 @@
 package org.alephium.ralph.lsp.pc.completion
 
 import org.alephium.ralph.lsp.access.compiler.ast.Tree
+import org.alephium.ralph.lsp.pc.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 
 import scala.collection.immutable.ArraySeq
 
-object ImportCompleter {
+object ImportCompleter extends StrictImplicitLogging {
 
   /**
    * Perform import code completion within the given dependency.
@@ -18,13 +19,13 @@ object ImportCompleter {
    */
   def complete(cursorIndex: Int,
                dependency: Option[WorkspaceState.Compiled],
-               imported: Tree.Import): ArraySeq[Suggestion.Field] =
+               imported: Tree.Import)(implicit logger: ClientLogger): ArraySeq[Suggestion.Field] =
     if (imported.string.name.index contains cursorIndex) // suggest if cursor is between the quoted String
       dependency match {
         case Some(dependency) =>
           complete(
             cursorIndex = cursorIndex,
-            sourceCode = dependency.sourceCode,
+            dependencySourceCode = dependency.sourceCode,
             imported = imported
           )
 
@@ -35,24 +36,31 @@ object ImportCompleter {
       ArraySeq.empty
 
   private def complete(cursorIndex: Int,
-                       sourceCode: ArraySeq[SourceCodeState.Compiled],
-                       imported: Tree.Import): ArraySeq[Suggestion.Field] =
-    sourceCode flatMap {
+                       dependencySourceCode: ArraySeq[SourceCodeState.Compiled],
+                       imported: Tree.Import)(implicit logger: ClientLogger): ArraySeq[Suggestion.Field] =
+    dependencySourceCode flatMap {
       compiled =>
         compiled.importIdentifier map {
-          importIdentifier =>
+          dependencyIdentifier =>
             val insert =
               imported.path match {
-                case Some(path) => // user input import statement has some text
-                  if (path.file.index contains cursorIndex) // does it belong to text after the forward slash?
-                    // FIXME: String manipulations like these are not good.
-                    //        Temporarily to make the suggestion cleaner, remove package name from suggestions.
-                    importIdentifier.replaceFirst(path.folder.value + "/", "") // Yes! Suggest only the file names e.g. `nft_interface`
+                case Some(importPath) => // user input import statement has some text
+                  if (importPath.file.index contains cursorIndex) // does the cursorIndex belong to text after the forward slash?
+                    dependencyIdentifier.path match {
+                      case Some(path) => // Yes it does and the path exists.
+                        path.file.value // Suggest only the file names e.g. `nft_interface`
+
+                      case None =>
+                        // This should never be the case. Dependencies should always have a path e.g. `std/nft_interface`.
+                        logger.error(s"Dependency's Import-identifier without path: ${dependencyIdentifier.string.value}")
+                        dependencyIdentifier.string.name.value // path does not exist, suggest full importIdentifier
+                    }
+
                   else
-                    importIdentifier // else suggest the package and file name e.g. `std/nft_interface`
+                    dependencyIdentifier.string.name.value // else suggest the package and file name e.g. `std/nft_interface`
 
                 case None =>
-                  importIdentifier // suggest the package and file name e.g. `std/nft_interface`
+                  dependencyIdentifier.string.name.value // suggest the package and file name e.g. `std/nft_interface`
               }
 
             Suggestion.Field(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/gotodef/GoToDefinition.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/gotodef/GoToDefinition.scala
@@ -1,0 +1,77 @@
+package org.alephium.ralph.lsp.pc.gotodef
+
+import org.alephium.ralph.lsp.access.compiler.ast.Tree
+import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
+import org.alephium.ralph.lsp.pc.log.StrictImplicitLogging
+import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
+import org.alephium.ralph.lsp.pc.util.StringUtil
+import org.alephium.ralph.lsp.pc.workspace.{Workspace, WorkspaceState}
+
+import java.net.URI
+import scala.collection.immutable.ArraySeq
+
+object GoToDefinition extends StrictImplicitLogging {
+
+  /**
+   * Provides go-to definition for the cursor position within the current workspace state.
+   *
+   * @param line          Line position in a document (zero-based).
+   * @param character     Character offset on a line in a document (zero-based).
+   * @param fileURI       The text document's uri.
+   * @param dependencyDir Directory where the dependency code exists.
+   * @param workspace     Current workspace state.
+   * @return
+   */
+  def goTo(line: Int,
+           character: Int,
+           fileURI: URI,
+           workspace: WorkspaceState.IsSourceAware): Option[Either[CompilerMessage.Error, ArraySeq[URI]]] =
+    Workspace.findParsed(
+      fileURI = fileURI,
+      workspace = workspace
+    ) map {
+      result =>
+        result map {
+          parsed =>
+            goTo(
+              line = line,
+              character = character,
+              workspace = workspace,
+              sourceCode = parsed
+            )
+        }
+    }
+
+  private def goTo(line: Int,
+                   character: Int,
+                   workspace: WorkspaceState.IsSourceAware,
+                   sourceCode: SourceCodeState.Parsed): ArraySeq[URI] = {
+    // fetch the requested index from line number and character number.
+    val cursorIndex =
+      StringUtil.computeIndex(
+        lines = sourceCode.codeLines,
+        line = line,
+        character = character
+      )
+
+    // find the statement where this cursorIndex sits.
+    sourceCode.ast.statements.find(_.index contains cursorIndex) match {
+      case Some(statement) =>
+        statement match {
+          case importStatement: Tree.Import =>
+            // request is for import go-to definition
+            GoToImport.goTo(
+              cursorIndex = cursorIndex,
+              dependency = workspace.build.dependency,
+              importStatement = importStatement
+            )
+
+          case _: Tree.Source =>
+            ArraySeq.empty // TODO: Provide source level go-to definition.
+        }
+
+      case None =>
+        ArraySeq.empty
+    }
+  }
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/gotodef/GoToImport.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/gotodef/GoToImport.scala
@@ -1,0 +1,46 @@
+package org.alephium.ralph.lsp.pc.gotodef
+
+import org.alephium.ralph.lsp.access.compiler.ast.Tree
+import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
+import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
+
+import java.net.URI
+import scala.collection.immutable.ArraySeq
+
+object GoToImport {
+
+  def goTo(cursorIndex: Int,
+           dependency: Option[WorkspaceState.Compiled],
+           importStatement: Tree.Import): ArraySeq[URI] =
+    dependency match {
+      case Some(dependency) =>
+        goTo(
+          cursorIndex = cursorIndex,
+          dependency = dependency,
+          importStatement = importStatement
+        ).map(_.fileURI)
+
+      case None =>
+        ArraySeq.empty
+    }
+
+  private def goTo(cursorIndex: Int,
+                   dependency: WorkspaceState.Compiled,
+                   importStatement: Tree.Import): ArraySeq[SourceCodeState.Compiled] =
+    importStatement.path match {
+      case Some(importPath) =>
+        if (importPath.folder.index contains cursorIndex) // check: is the cursor on a folder
+          dependency // return all files that are within the folder
+            .sourceCode
+            .filter(_.importIdentifier.exists(_.path.exists(_.folder.value == importPath.folder.value)))
+        else if (importPath.file.index contains cursorIndex) // check: is the cursor for a file
+          dependency // find the file
+            .sourceCode
+            .filter(_.importIdentifier.exists(_.string.name.value == importStatement.string.name.value))
+        else
+          ArraySeq.empty
+
+      case None =>
+        ArraySeq.empty
+    }
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
@@ -1,10 +1,11 @@
 package org.alephium.ralph.lsp.pc.sourcecode
 
+import org.alephium.ralph.CompilerOptions
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
+import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.access.file.FileAccess
-import org.alephium.ralph.CompilerOptions
-import org.alephium.ralph.lsp.access.compiler.ast.Tree
+import org.alephium.ralph.lsp.pc.sourcecode.error._
 import org.alephium.ralph.lsp.pc.sourcecode.imports.Importer
 import org.alephium.ralph.lsp.pc.util.CollectionUtil._
 import org.alephium.ralph.lsp.pc.util.URIUtil
@@ -159,6 +160,46 @@ private[pc] object SourceCode {
               sourceCode.filter(_.fileURI != fileURI)
             }
         }
+    }
+
+
+  /**
+   * Find the parsed state ([[SourceCodeState.Parsed]]) for the given file URI.
+   *
+   * @param fileURI    The file URI of the parsed source-code.
+   * @param sourceCode The source code files to search.
+   * @return - Right: If the parsed state was found.
+   *         - Left: An error, if the source-code is not in a parsed state.
+   */
+  def findParsed(fileURI: URI,
+                 sourceCode: ArraySeq[SourceCodeState]): Either[CompilerMessage.Error, SourceCodeState.Parsed] =
+    sourceCode.find(_.fileURI == fileURI) match {
+      case Some(source) =>
+        source match {
+          case _: SourceCodeState.OnDisk | _: SourceCodeState.UnCompiled =>
+            Left(SourceCodeIsNotCompiled(fileURI))
+
+          case _: SourceCodeState.ErrorAccess =>
+            Left(SourceCodeAccessFailed(fileURI))
+
+          case parsed: SourceCodeState.Parsed =>
+            Right(parsed)
+
+          case compiled: SourceCodeState.Compiled =>
+            Right(compiled.parsed)
+
+          case errored: SourceCodeState.ErrorSource =>
+            errored.previous match {
+              case Some(previousParsed) =>
+                Right(previousParsed)
+
+              case None =>
+                Left(SourceCodeHasCompilationErrors(fileURI))
+            }
+        }
+
+      case None =>
+        Left(SourceCodeNotFound(fileURI))
     }
 
   /**

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
@@ -3,7 +3,7 @@ package org.alephium.ralph.lsp.pc.sourcecode
 import org.alephium.ralph.CompilerOptions
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.compiler.ast.Tree
-import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
+import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, SourceIndex}
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.sourcecode.error._
 import org.alephium.ralph.lsp.pc.sourcecode.imports.Importer
@@ -137,7 +137,7 @@ private[pc] object SourceCode {
 
       case None =>
         // no source code sent from client, check it still exists.
-        file.exists(fileURI) match {
+        file.exists(fileURI, SourceIndex.empty) match {
           case Left(error) =>
             // failed to check
             val newState =

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
@@ -1,5 +1,6 @@
 package org.alephium.ralph.lsp.pc.sourcecode
 
+import org.alephium.ralph.lsp.access.compiler.RalphParserExtension
 import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.access.compiler.message.warning.StringWarning
@@ -12,8 +13,10 @@ sealed trait SourceCodeState {
   def fileURI: URI
 
   /** @see [[URIUtil.importIdentifier]] */
-  def importIdentifier: Option[String] =
-    URIUtil.importIdentifier(fileURI)
+  def importIdentifier: Option[Tree.Import] =
+    URIUtil
+      .importIdentifier(fileURI)
+      .flatMap(RalphParserExtension.lazyParseImportIdentifier)
 }
 
 object SourceCodeState {
@@ -35,7 +38,7 @@ object SourceCodeState {
   sealed trait IsCodeAware extends SourceCodeState {
     def code: String
 
-    /** Lazily executed. Can have concurrent access. Use by code completion. */
+    /** Lazily executed. Can have concurrent access. Used by code completion. */
     lazy val codeLines: Array[String] =
       StringUtil.codeLines(code)
   }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
@@ -12,8 +12,13 @@ import java.net.URI
 sealed trait SourceCodeState {
   def fileURI: URI
 
-  /** @see [[URIUtil.importIdentifier]] */
-  def importIdentifier: Option[Tree.Import] =
+  /**
+   * Lazily initialise import statements for all files.
+   *
+   * Can be concurrently accessed or not accessed at all.
+   *
+   * @see [[URIUtil.importIdentifier]] */
+  lazy val importIdentifier: Option[Tree.Import] =
     URIUtil
       .importIdentifier(fileURI)
       .flatMap(RalphParserExtension.lazyParseImportIdentifier)

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/error/SourceCodeAccessFailed.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/error/SourceCodeAccessFailed.scala
@@ -1,0 +1,13 @@
+package org.alephium.ralph.lsp.pc.sourcecode.error
+
+import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, SourceIndex}
+
+import java.net.URI
+
+case class SourceCodeAccessFailed(uri: URI) extends CompilerMessage.Error {
+  override def message: String =
+    s"Source code errored on access. URI: $uri"
+
+  override def index: SourceIndex =
+    SourceIndex.empty
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/error/SourceCodeHasCompilationErrors.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/error/SourceCodeHasCompilationErrors.scala
@@ -1,0 +1,13 @@
+package org.alephium.ralph.lsp.pc.sourcecode.error
+
+import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, SourceIndex}
+
+import java.net.URI
+
+case class SourceCodeHasCompilationErrors(uri: URI) extends CompilerMessage.Error {
+  override def message: String =
+    s"Source code has compilation error(s). URI: $uri"
+
+  override def index: SourceIndex =
+    SourceIndex.empty
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/error/SourceCodeIsNotCompiled.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/error/SourceCodeIsNotCompiled.scala
@@ -1,0 +1,13 @@
+package org.alephium.ralph.lsp.pc.sourcecode.error
+
+import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, SourceIndex}
+
+import java.net.URI
+
+case class SourceCodeIsNotCompiled(uri: URI) extends CompilerMessage.Error {
+  override def message: String =
+    s"Source code is on-disk and not compiled. URI: $uri"
+
+  override def index: SourceIndex =
+    SourceIndex.empty
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/error/SourceCodeNotFound.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/error/SourceCodeNotFound.scala
@@ -1,0 +1,13 @@
+package org.alephium.ralph.lsp.pc.sourcecode.error
+
+import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, SourceIndex}
+
+import java.net.URI
+
+case class SourceCodeNotFound(uri: URI) extends CompilerMessage.Error {
+  override def message: String =
+    s"Source code not found. URI: $uri"
+
+  override def index: SourceIndex =
+    SourceIndex.empty
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/Importer.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/Importer.scala
@@ -61,7 +61,7 @@ object Importer {
         case imported: Tree.Import => // type all import statements
           // TODO: Build a cached Map stored in BuildState instead of doing this linear search.
           // import statement should exists in dependant code.
-          dependency.find(_.importIdentifier contains imported.string.name.value) match {
+          dependency.find(_.importIdentifier.map(_.string.name.value) contains imported.string.name.value) match {
             case Some(dependency) =>
               Right(dependency) // Import exists! Good!
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/state/PCStateDiagnostics.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/state/PCStateDiagnostics.scala
@@ -214,7 +214,7 @@ object PCStateDiagnostics {
     val ((fromLine, fromCharacter), (toLine, toCharacter)) =
       code match {
         case Some(code) =>
-          val fastParseLineNumber = IndexedParserInput(code).prettyIndex(message.index.index)
+          val fastParseLineNumber = IndexedParserInput(code).prettyIndex(message.index.from)
           val sourcePosition = SourcePosition.parse(fastParseLineNumber)
 
           val start = (sourcePosition.rowIndex, sourcePosition.colIndex)

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/Workspace.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/Workspace.scala
@@ -1,6 +1,7 @@
 package org.alephium.ralph.lsp.pc.workspace
 
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
+import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceCode, SourceCodeState}
@@ -562,4 +563,28 @@ object Workspace extends StrictImplicitLogging {
         }
     }
 
+
+  /**
+   * Find a parsed state [[SourceCodeState.Parsed]] for the given file URI.
+   *
+   * @param fileURI   The file URI of the parsed source-code.
+   * @param workspace Current workspace.
+   * @return - None: If this file does not support completion.
+   *         - Right: If a parsed state was found.
+   *         - Left: If the source-code is in one of the non-parsed states.
+   */
+  def findParsed(fileURI: URI,
+                 workspace: WorkspaceState.IsSourceAware): Option[Either[CompilerMessage.Error, SourceCodeState.Parsed]] =
+    // file must belong to the workspace contractURI and must be a ralph source file
+    if (URIUtil.contains(workspace.build.contractURI, fileURI) && URIUtil.getFileExtension(fileURI) == CompilerAccess.RALPH_FILE_EXTENSION) {
+      val parsedOrError =
+        SourceCode.findParsed(
+          fileURI = fileURI,
+          sourceCode = workspace.sourceCode
+        )
+
+      Some(parsedOrError)
+    } else {
+      None
+    }
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildState.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildState.scala
@@ -5,7 +5,7 @@ import org.alephium.ralph.lsp.pc.workspace.build.RalphcConfig.{RalphcCompiledCon
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 
 import java.net.URI
-import java.nio.file.Paths
+import java.nio.file.{Path, Paths}
 import scala.collection.immutable.ArraySeq
 
 sealed trait BuildState {
@@ -34,6 +34,7 @@ object BuildState {
   case class BuildCompiled(buildURI: URI,
                            code: String,
                            dependency: Option[WorkspaceState.Compiled],
+                           dependencyPath: Path,
                            config: RalphcCompiledConfig) extends BuildState.IsCompiled {
     def contractURI: URI =
       config.contractPath.toUri

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/RalphcConfig.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/RalphcConfig.scala
@@ -27,14 +27,16 @@ object RalphcConfig {
 
   case class RalphcParsedConfig(compilerOptions: CompilerOptions,
                                 contractPath: String,
-                                artifactPath: String)
+                                artifactPath: String,
+                                dependencyPath: String)
 
   /** Default parsed config */
   val defaultParsedConfig: RalphcParsedConfig =
     RalphcParsedConfig(
       compilerOptions = CompilerOptions.Default,
       contractPath = "contracts",
-      artifactPath = "artifacts"
+      artifactPath = "artifacts",
+      dependencyPath = "dependencies"
     )
 
   def parse(buildURI: URI,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/Dependency.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/Dependency.scala
@@ -4,11 +4,11 @@ import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndex
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.log.ClientLogger
-import org.alephium.ralph.lsp.pc.workspace.build.BuildState._
 import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState}
 import org.alephium.ralph.lsp.pc.workspace.{Workspace, WorkspaceState}
 import org.alephium.ralphc.Config
 
+import java.nio.file.Path
 import scala.collection.immutable.ArraySeq
 
 object Dependency {
@@ -20,22 +20,29 @@ object Dependency {
    * @param currentBuild Current compiled build.
    * @return
    */
-  def compile(parsed: BuildParsed,
+  def compile(parsed: BuildState.BuildParsed,
               currentBuild: Option[BuildState.IsCompiled])(implicit file: FileAccess,
                                                            compiler: CompilerAccess,
-                                                           logger: ClientLogger): BuildState.IsCompiled =
+                                                           logger: ClientLogger): BuildState.IsCompiled = {
+    val (_, _, _, absoluteDependenciesPath) =
+      Build.getAbsolutePaths(parsed)
+
     currentBuild.flatMap(_.dependency) match {
-      case Some(dependency) =>
+      case Some(dependency) if absoluteDependenciesPath == dependency.build.dependencyPath =>
         // Existing build already has compiled dependency. Re-use it.
         toBuildState(
           parentWorkspaceBuild = parsed,
           dependencyResult = dependency
         )
 
-      case None =>
+      case _ =>
         // Existing code requires a dependency build.
-        downloadAndCompileStd(parsed)
+        downloadAndCompileStd(
+          parsed = parsed,
+          absoluteDependenciesPath = absoluteDependenciesPath
+        )
     }
+  }
 
   /**
    * Download and compile standard/std dependency for a parsed Build [[BuildState.BuildParsed]].
@@ -45,10 +52,14 @@ object Dependency {
    *         the parent workspace. If there are errors, they will be in
    *         the field [[BuildState.BuildErrored.dependency]] as a regular workspace errors.
    */
-  def downloadAndCompileStd(parsed: BuildParsed)(implicit file: FileAccess,
-                                                 compiler: CompilerAccess,
-                                                 logger: ClientLogger): BuildState.IsCompiled =
-    DependencyDownloader.downloadStd(errorIndex = SourceIndex.empty) match { // download std
+  def downloadAndCompileStd(parsed: BuildState.BuildParsed,
+                            absoluteDependenciesPath: Path)(implicit file: FileAccess,
+                                                            compiler: CompilerAccess,
+                                                            logger: ClientLogger): BuildState.IsCompiled =
+    DependencyDownloader.downloadStd(
+      dependencyPath = absoluteDependenciesPath,
+      errorIndex = SourceIndex.empty
+    ) match { // download std
       case Left(errors) =>
         // report all download errors at build file level.
         BuildState.BuildErrored(
@@ -82,7 +93,7 @@ object Dependency {
                            dependencyResult: WorkspaceState.IsParsedAndCompiled): BuildState.IsCompiled =
     dependencyResult match {
       case compiledStd: WorkspaceState.Compiled => // Dependency compiled OK. Convert the build state to compiled.
-        val (_, absoluteContractPath, absoluteArtifactPath) =
+        val (_, absoluteContractPath, absoluteArtifactPath, absoluteDependenciesPath) =
           Build.getAbsolutePaths(parentWorkspaceBuild)
 
         val config =
@@ -97,6 +108,7 @@ object Dependency {
           buildURI = parentWorkspaceBuild.buildURI,
           code = parentWorkspaceBuild.code,
           dependency = Some(compiledStd), // store the compiled dependency in the build.
+          dependencyPath = absoluteDependenciesPath,
           config = config
         )
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/DependencyDB.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/DependencyDB.scala
@@ -1,0 +1,74 @@
+package org.alephium.ralph.lsp.pc.workspace.build.dependency
+
+import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, SourceIndex}
+import org.alephium.ralph.lsp.access.file.FileAccess
+import org.alephium.ralph.lsp.pc.log.{ClientLogger, StrictImplicitLogging}
+import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
+import org.alephium.ralph.lsp.pc.workspace.build.BuildState
+
+import java.nio.file.{Path, Paths}
+
+object DependencyDB extends StrictImplicitLogging {
+
+  /**
+   * Persist dependencies of a compiled build.
+   *
+   * @param parentBuild Build of the parent workspace.
+   * @return Compiled compiled or build errors.
+   */
+  def persist(parentBuild: BuildState.IsCompiled,
+              index: SourceIndex)(implicit file: FileAccess,
+                                  logger: ClientLogger): BuildState.IsCompiled =
+    parentBuild match {
+      case build: BuildState.BuildCompiled =>
+        val result =
+          build
+            .dependency
+            .map(_.sourceCode.map(persistSource(_, index)))
+
+        result match {
+          case Some(result) =>
+            val (errors, _) =
+              result partitionMap identity
+
+            if (errors.nonEmpty)
+              BuildState.BuildErrored(
+                buildURI = build.buildURI,
+                code = Some(build.code),
+                errors = errors,
+                dependency = None,
+                activateWorkspace = None
+              )
+            else
+              build
+
+          case None =>
+            build
+        }
+
+      case errored: BuildState.BuildErrored =>
+        errored
+    }
+
+  private def persistSource(source: SourceCodeState.Compiled,
+                            index: SourceIndex)(implicit file: FileAccess,
+                                                logger: ClientLogger): Either[CompilerMessage.AnyError, Path] =
+    file.exists(
+      fileURI = source.fileURI,
+      index = index
+    ) flatMap {
+      exists =>
+        if (!exists) {
+          logger.trace(s"Writing dependency code. URI: ${source.fileURI}")
+          file.write(
+            fileURI = source.fileURI,
+            string = source.code,
+            index = index
+          )
+        } else {
+          logger.trace(s"Dependency code already exists. URI: ${source.fileURI}")
+          Right(Paths.get(source.fileURI))
+        }
+    }
+
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/DependencyDownloader.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/DependencyDownloader.scala
@@ -1,15 +1,13 @@
 package org.alephium.ralph.lsp.pc.workspace.build.dependency
 
-import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
-import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.CompilerOptions
 import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, SourceIndex}
 import org.alephium.ralph.lsp.pc.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.lsp.pc.sourcecode.imports.StdInterface
+import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState, RalphcConfig}
-import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorDownloadingDependency
 
-import java.nio.file.Paths
+import java.nio.file.Path
 import scala.collection.immutable.ArraySeq
 
 object DependencyDownloader extends StrictImplicitLogging {
@@ -19,12 +17,16 @@ object DependencyDownloader extends StrictImplicitLogging {
    *
    * @param errorIndex Use this index to report any errors processing the download.
    */
-  def downloadStd(errorIndex: SourceIndex)(implicit logger: ClientLogger): Either[ArraySeq[CompilerMessage.AnyError], WorkspaceState.UnCompiled] =
-    downloadStdFromJar(errorIndex) match {
+  def downloadStd(dependencyPath: Path,
+                  errorIndex: SourceIndex)(implicit logger: ClientLogger): Either[ArraySeq[CompilerMessage.AnyError], WorkspaceState.UnCompiled] =
+    StdInterface.stdInterfaces(
+      dependencyPath = dependencyPath,
+      errorIndex = errorIndex
+    ) match {
       case Right(source) =>
         // a default build file.
         val build =
-          defaultBuildForStd()
+          defaultBuildForStd(dependencyPath)
 
         val state =
           WorkspaceState.UnCompiled(
@@ -39,48 +41,15 @@ object DependencyDownloader extends StrictImplicitLogging {
     }
 
   /**
-   * Download std code from local jar file.
-   *
-   * TODO: Downloading source-code should be installable.
-   * See issue <a href="https://github.com/alephium/ralph-lsp/issues/44">#44</a>.
-   */
-  private def downloadStdFromJar(errorIndex: SourceIndex)(implicit logger: ClientLogger): Either[ErrorDownloadingDependency, Iterable[SourceCodeState.UnCompiled]] =
-    try {
-      // Errors must be reported to the user. See https://github.com/alephium/ralph-lsp/issues/41.
-      val code =
-        StdInterface.stdInterfaces map {
-          case (path, code) =>
-            SourceCodeState.UnCompiled(
-              fileURI = path.toUri,
-              code = code
-            )
-        }
-
-      Right(code)
-    } catch {
-      case throwable: Throwable =>
-        val error =
-          ErrorDownloadingDependency(
-            dependencyID = StdInterface.stdFolder,
-            throwable = throwable,
-            index = errorIndex
-          )
-
-        logger.error(error.title, throwable)
-
-        Left(error)
-    }
-
-  /**
    * Currently dependencies do not contain a `ralph.json` file.
    * This function create a default one for the `std` package.
    */
-  private def defaultBuildForStd(): BuildState.BuildCompiled = {
+  private def defaultBuildForStd(dependencyPath: Path): BuildState.BuildCompiled = {
     val workspaceDir =
-      Paths.get(StdInterface.stdFolder)
+      dependencyPath resolve StdInterface.stdFolder
 
     val buildDir =
-      workspaceDir.resolve(Build.BUILD_FILE_NAME)
+      workspaceDir resolve Build.BUILD_FILE_NAME
 
     val compiledConfig =
       org.alephium.ralphc.Config(
@@ -95,8 +64,9 @@ object DependencyDownloader extends StrictImplicitLogging {
     BuildState.BuildCompiled(
       buildURI = buildDir.toUri,
       code = json,
-      config = compiledConfig,
-      dependency = None
+      dependency = None,
+      dependencyPath = workspaceDir,
+      config = compiledConfig
     )
   }
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/completion/TestCodeCompleter.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/completion/TestCodeCompleter.scala
@@ -2,6 +2,7 @@ package org.alephium.ralph.lsp.pc.completion
 
 import org.alephium.ralph.lsp.TestFile
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
+import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.alephium.ralph.lsp.pc.log.ClientLogger
@@ -11,6 +12,8 @@ import org.alephium.ralph.lsp.pc.workspace.build.TestBuild
 import org.alephium.ralph.lsp.pc.workspace.{TestWorkspace, Workspace, WorkspaceState}
 import org.scalacheck.Gen
 import org.scalatest.Assertions.fail
+import org.scalatest.EitherValues._
+import org.scalatest.OptionValues._
 
 import java.nio.file.Paths
 import scala.collection.immutable.ArraySeq
@@ -55,7 +58,7 @@ object TestCodeCompleter {
         // delete the workspace
         TestWorkspace delete workspace
 
-        completion
+        completion.value
 
       case None =>
         fail(s"Completion location indicator '$completion_indicator' not provided")
@@ -72,7 +75,7 @@ object TestCodeCompleter {
    */
   private def apply(line: Int,
                     character: Int,
-                    code: Gen[String]): (ArraySeq[Suggestion], WorkspaceState.IsParsedAndCompiled) = {
+                    code: Gen[String]): (Either[CompilerMessage.Error, ArraySeq[Suggestion]], WorkspaceState.IsParsedAndCompiled) = {
     implicit val clientLogger: ClientLogger = TestClientLogger
     implicit val file: FileAccess = FileAccess.disk
     implicit val compiler: CompilerAccess = CompilerAccess.ralphc
@@ -114,10 +117,10 @@ object TestCodeCompleter {
       CodeCompleter.complete(
         line = line,
         character = character,
-        uri = sourceCode.fileURI,
+        fileURI = sourceCode.fileURI,
         workspace = compiledWorkspace
       )
 
-    (completionResult, compiledWorkspace)
+    (completionResult.value, compiledWorkspace)
   }
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodePutOrRemoveSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodePutOrRemoveSpec.scala
@@ -94,7 +94,7 @@ class SourceCodePutOrRemoveSpec extends AnyWordSpec with Matchers with MockFacto
 
         // return an error accessing disk
         (file.exists _)
-          .expects(onDisk.fileURI)
+          .expects(onDisk.fileURI, *)
           .returns(Left(ioError))
 
         // insert

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/ImporterSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/ImporterSpec.scala
@@ -158,19 +158,19 @@ class ImporterSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenProper
                     value = my_package_file,
                     index =
                       SourceIndex(
-                        index = myCode.code.lastIndexOf(my_package_file),
+                        from = myCode.code.lastIndexOf(my_package_file),
                         width = my_package_file.length
                       )
                   ),
                 index =
                   SourceIndex(
-                    index = myCode.code.lastIndexOf(my_package_file_quoted),
+                    from = myCode.code.lastIndexOf(my_package_file_quoted),
                     width = my_package_file_quoted.length
                   )
               ),
             path =
               Some(
-                Tree.Path(
+                Tree.ImportPath(
                   folder = Tree.Name(my_package, SourceIndex(myCode.code.lastIndexOf(my_package), my_package.length)),
                   file = Tree.Name(my_file, SourceIndex(myCode.code.lastIndexOf(my_file), my_file.length)),
                   index = SourceIndex(myCode.code.lastIndexOf(my_package_file), my_package_file.length)
@@ -178,7 +178,7 @@ class ImporterSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenProper
               ),
             index =
               SourceIndex(
-                index = myCode.code.lastIndexOf(import_statement),
+                from = myCode.code.lastIndexOf(import_statement),
                 width = import_statement.length
               )
           )

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/ImporterSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/ImporterSpec.scala
@@ -146,13 +146,14 @@ class ImporterSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenProper
         val expectedAST = {
           val my_package = "my_package"
           val my_file = "my_file"
-          val my_package_file = "my_package/my_file"
+          val my_package_file = s"$my_package/$my_file"
           val my_package_file_quoted = s""""$my_package_file""""
           val import_statement = s"""import $my_package_file_quoted"""
 
           Tree.Import(
             string =
               Tree.StringLiteral(
+                value = my_package_file_quoted,
                 name =
                   Tree.Name(
                     value = my_package_file,

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/StdInterfaceSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/StdInterfaceSpec.scala
@@ -1,25 +1,41 @@
 package org.alephium.ralph.lsp.pc.sourcecode.imports
 
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndex
+import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.EitherValues._
+
+import java.nio.file.Paths
 
 class StdInterfaceSpec extends AnyWordSpec with Matchers {
 
+  implicit val logger: TestClientLogger.type =
+    TestClientLogger
+
   "stdInterfaces" should {
+    val stdInterfaces =
+      StdInterface.stdInterfaces(
+        dependencyPath = Paths.get("my_workspace"),
+        errorIndex = SourceIndex.empty
+      ).value
+
     "be defined" in {
       //Will fail if web3 wasn't download correctly
-      StdInterface.stdInterfaces.size > 0 shouldBe true
+      stdInterfaces.nonEmpty shouldBe true
     }
 
     "respect `std/` structure" in {
-      StdInterface.stdInterfaces.foreach { case (interface, _)=>
-        interface.toString.contains("std/") shouldBe true
+      stdInterfaces foreach {
+        source =>
+          source.fileURI.toString.contains("std/") shouldBe true
       }
     }
 
     "have some code" in {
-      StdInterface.stdInterfaces.foreach { case (_, code)=>
-        code.isEmpty shouldBe false
+      stdInterfaces foreach {
+        source =>
+          source.code.isEmpty shouldBe false
       }
     }
   }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuild1Spec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuild1Spec.scala
@@ -8,7 +8,7 @@ import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.sourcecode.TestSourceCode
 import org.alephium.ralph.lsp.pc.workspace.build.error.{ErrorBuildFileNotFound, ErrorInvalidBuildSyntax}
-import org.alephium.ralph.lsp.pc.workspace.build.{BuildState, TestBuild}
+import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState, TestBuild}
 import org.scalacheck.Gen
 import org.scalatest.EitherValues._
 import org.scalatest.matchers.should.Matchers
@@ -176,7 +176,10 @@ class WorkspaceBuild1Spec extends AnyWordSpec with Matchers with ScalaCheckDrive
 
               // expect the build to be compiled
               val expectedBuild =
-                TestBuild.toCompiled(build)
+                Build.compile(
+                  parsed = build,
+                  currentBuild = None
+                ).asInstanceOf[BuildState.BuildCompiled]
 
               // expect the workspace to be in un-compiled state, containing all source-code
               val expectedWorkspace =

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceFindParsedSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceFindParsedSpec.scala
@@ -1,0 +1,113 @@
+package org.alephium.ralph.lsp.pc.workspace
+
+import org.alephium.ralph.lsp.access.compiler.CompilerAccess
+import org.alephium.ralph.lsp.access.file.FileAccess
+import org.alephium.ralph.lsp.pc.client.TestClientLogger
+import org.alephium.ralph.lsp.pc.log.ClientLogger
+import org.alephium.ralph.lsp.pc.workspace.build.TestBuild
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.EitherValues._
+import org.scalatest.OptionValues._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+import java.net.URI
+import scala.collection.immutable.ArraySeq
+
+/**
+ * Test cases for [[Workspace.parse]] function.
+ */
+class WorkspaceFindParsedSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks with MockFactory {
+
+  implicit val clientLogger: ClientLogger =
+    TestClientLogger
+
+  "return None" when {
+    "file does not belong to the contract URI folder" in {
+      implicit val file: FileAccess =
+        FileAccess.disk
+
+      implicit val compiler: CompilerAccess =
+        CompilerAccess.ralphc
+
+      forAll(TestBuild.genCompiledWithSourceCode()) {
+        case (build, _sourceCode) =>
+          val sourceCode =
+            _sourceCode.to(ArraySeq)
+
+          // create a workspace for the build file
+          val workspace =
+            WorkspaceState.UnCompiled(
+              build = build,
+              sourceCode = sourceCode
+            )
+
+          // file is not in the workspace
+          Workspace.findParsed(
+            fileURI = URI.create("file:///blah.ral"),
+            workspace = workspace
+          ) shouldBe None
+
+          // not a .ral file
+          Workspace.findParsed(
+            fileURI = build.buildURI,
+            workspace = workspace
+          ) shouldBe None
+
+          // file is in the root workspace directory and not in contract-uri
+          Workspace.findParsed(
+            fileURI = build.workspaceURI.resolve("blah.ral"),
+            workspace = workspace
+          ) shouldBe None
+
+          // file is in the artifact directory
+          Workspace.findParsed(
+            fileURI = build.artifactURI.resolve("blah.ral"),
+            workspace = workspace
+          ) shouldBe None
+      }
+    }
+  }
+
+  "pass" when {
+    "belongs to the contract URI folder" in {
+      implicit val file: FileAccess =
+        FileAccess.disk
+
+      implicit val compiler: CompilerAccess =
+        CompilerAccess.ralphc
+
+      forAll(TestBuild.genCompiledWithSourceCode(minSourceCount = 1)) {
+        case (build, _sourceCode) =>
+          val sourceCode =
+            _sourceCode.to(ArraySeq)
+
+          // create a workspace for the build file
+          val unCompiledWorkspace =
+            WorkspaceState.UnCompiled(
+              build = build,
+              sourceCode = sourceCode
+            )
+
+          // workspace is successfully compiled
+          val compiledWorkspace =
+            Workspace
+              .parseAndCompile(unCompiledWorkspace)
+              .asInstanceOf[WorkspaceState.Compiled]
+
+          // find each source code
+          sourceCode foreach {
+            sourceCode =>
+              val parsedSource =
+                Workspace.findParsed(
+                  fileURI = sourceCode.fileURI,
+                  workspace = compiledWorkspace
+                ).value
+
+              parsedSource.value.fileURI shouldBe sourceCode.fileURI
+          }
+      }
+    }
+  }
+}

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestRalphc.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestRalphc.scala
@@ -31,10 +31,12 @@ object TestRalphc {
       compilerOptions <- compilerOptions
       contractsFolderName <- genName
       artifactsFolderName <- genName
+      dependenciesFolderName <- genName
     } yield
       RalphcParsedConfig(
         compilerOptions = compilerOptions,
         contractPath = contractsFolderName,
-        artifactPath = artifactsFolderName
+        artifactPath = artifactsFolderName,
+        dependencyPath = dependenciesFolderName
       )
 }


### PR DESCRIPTION
- Resolves [this FIXME](https://github.com/alephium/ralph-lsp/blob/f7e1be6fc93f6b02918fbc44b3d1b3abd27f060c/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/completion/ImportCompleter.scala#L48).
- Stores the quoted string lit in the AST.
- Minor code refactoring.