### PR TITLE
Transform compilation errors to `SourceCode` errors immediately, if `SourceIndex.fileURI` exists

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
@@ -251,7 +251,7 @@ private[pc] object SourceCode {
    */
   private def compileSource(sourceCode: ArraySeq[SourceCodeState.Parsed],
                             importedCode: ArraySeq[SourceCodeState.Parsed],
-                            compilerOptions: CompilerOptions)(implicit compiler: CompilerAccess): Either[CompilerMessage.AnyError, ArraySeq[SourceCodeState.IsCompiled]] = {
+                            compilerOptions: CompilerOptions)(implicit compiler: CompilerAccess): Either[CompilerMessage.AnyError, ArraySeq[SourceCodeState.IsParsed]] = {
     val allCode =
       sourceCode ++ importedCode
 


### PR DESCRIPTION
Implements [review comment](https://github.com/alephium/ralph-lsp/pull/128#discussion_r1519139407).