### PR TITLE
Mandatory `fileURI` for internal `SourceIndex` related functions

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/CompilerAccess.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/CompilerAccess.scala
@@ -33,9 +33,12 @@ trait CompilerAccess {
 
   /**
    * Given the parsed AST and compiler options, compile the contracts.
+   *
+   * @param workspaceErrorURI The [[URI]] to report errors to when `fileURI` is absent from compilation errors.
    */
   def compileContracts(contracts: Seq[Ast.ContractWithState],
-                       options: CompilerOptions): Either[CompilerMessage.AnyError, (Array[CompiledContract], Array[CompiledScript])]
+                       options: CompilerOptions,
+                       workspaceErrorURI: URI): Either[CompilerMessage.AnyError, (Array[CompiledContract], Array[CompiledScript])]
 
   /**
    * Compile the entire workspace from disk and prepare for deployment.

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/RalphCompilerAccess.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/RalphCompilerAccess.scala
@@ -31,11 +31,12 @@ private object RalphCompilerAccess extends CompilerAccess {
         case failure: Parsed.Failure =>
           Left(FastParseError(failure))
       }
-    catch TryUtil.catchAllThrows
+    catch TryUtil.catchAllThrows(fileURI)
 
   /** @inheritdoc */
   def compileContracts(contracts: Seq[Ast.ContractWithState],
-                       options: CompilerOptions): Either[CompilerMessage.AnyError, (Array[CompiledContract], Array[CompiledScript])] =
+                       options: CompilerOptions,
+                       workspaceErrorURI: URI): Either[CompilerMessage.AnyError, (Array[CompiledContract], Array[CompiledScript])] =
     try {
       val multiContract =
         Ast.MultiContract(contracts, None)
@@ -52,7 +53,7 @@ private object RalphCompilerAccess extends CompilerAccess {
         extendedContracts.genStatefulScripts()(options)
 
       Right((statefulContracts.toArray, statefulScripts.toArray))
-    } catch TryUtil.catchAllThrows
+    } catch TryUtil.catchAllThrows(workspaceErrorURI)
 
   /** @inheritdoc */
   override def compileForDeployment(workspaceURI: URI,
@@ -61,12 +62,12 @@ private object RalphCompilerAccess extends CompilerAccess {
       val ralphc = RalphC(config)
       ralphc.compileProject() match {
         case Left(error) =>
-          Left(StringError(error))
+          Left(StringError(error, workspaceURI))
 
         case Right(result) =>
           Right(buildSuccessfulCompilation(result, ralphc.metaInfos))
       }
-    } catch TryUtil.catchAllThrows
+    } catch TryUtil.catchAllThrows(workspaceURI)
 
   private def buildSuccessfulCompilation(result: CompileProjectResult,
                                          metaInfos: mutable.Map[String, MetaInfo]): (Array[CompiledContract], Array[CompiledScript]) = {

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
@@ -3,10 +3,16 @@ package org.alephium.ralph.lsp.access.compiler.message
 import fastparse.IndexedParserInput
 import org.alephium.ralph.{SourceIndex, SourcePosition}
 
+import java.net.URI
+
 object SourceIndexExtra {
 
-  val zero: SourceIndex =
-    org.alephium.ralph.SourceIndex.empty
+  def zero(fileURI: URI): SourceIndex =
+    SourceIndex(
+      index = 0,
+      width = 0,
+      fileURI = Some(fileURI)
+    )
 
   /**
    * Sending negative index to the client would be incorrect.
@@ -16,14 +22,16 @@ object SourceIndexExtra {
    *
    * @see Issue <a href="https://github.com/alephium/ralph-lsp/issues/17">#17</a>.
    */
-  def ensurePositive(index: Int, width: Int): SourceIndex =
+  def ensurePositive(index: Int,
+                     width: Int,
+                     fileURI: URI): SourceIndex =
     if (index < 0)
-      zero
+      zero(fileURI)
     else
       new SourceIndex(
         index = index,
         width = width,
-        None
+        fileURI = Some(fileURI)
       )
 
   implicit class SourceIndexExtension(val sourceIndex: SourceIndex) extends AnyVal {

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/error/StringError.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/error/StringError.scala
@@ -3,11 +3,14 @@ package org.alephium.ralph.lsp.access.compiler.message.error
 import org.alephium.ralph.SourceIndex
 import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, SourceIndexExtra}
 
+import java.net.URI
+
 object StringError {
-  @inline def apply(message: String): StringError =
+  @inline def apply(message: String,
+                    fileURI: URI): StringError =
     StringError(
       message = message,
-      index = SourceIndexExtra.zero
+      index = SourceIndexExtra.zero(fileURI)
     )
 }
 /**

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/error/ThrowableError.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/error/ThrowableError.scala
@@ -3,13 +3,17 @@ package org.alephium.ralph.lsp.access.compiler.message.error
 import org.alephium.ralph.SourceIndex
 import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, SourceIndexExtra}
 
+import java.net.URI
+
 object ThrowableError {
 
   /** Without title */
-  def apply(throwable: Throwable): ThrowableError =
+  def apply(throwable: Throwable,
+            fileURI: URI): ThrowableError =
     new ThrowableError(
       title = "",
-      throwable = throwable
+      throwable = throwable,
+      index = SourceIndexExtra.zero(fileURI)
     )
 
 }
@@ -21,7 +25,7 @@ object ThrowableError {
  */
 case class ThrowableError(title: String,
                           throwable: Throwable,
-                          index: SourceIndex = SourceIndexExtra.zero) extends CompilerMessage.Error {
+                          index: SourceIndex) extends CompilerMessage.Error {
   override def message: String =
     if (title.isBlank)
       throwable.getMessage

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/warning/StringWarning.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/warning/StringWarning.scala
@@ -3,14 +3,17 @@ package org.alephium.ralph.lsp.access.compiler.message.warning
 import org.alephium.ralph.SourceIndex
 import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, SourceIndexExtra}
 
+import java.net.URI
+
 /**
  * String warning reported by `ralphc` not containing source-location information.
  */
 object StringWarning {
-  @inline def apply(message: String): StringWarning =
+  @inline def apply(message: String,
+                    fileURI: URI): StringWarning =
     StringWarning(
       message = message,
-      index = SourceIndexExtra.zero
+      index = SourceIndexExtra.zero(fileURI)
     )
 }
 

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/file/DiskFileAccess.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/file/DiskFileAccess.scala
@@ -49,13 +49,13 @@ private object DiskFileAccess extends FileAccess {
           ).map(_.toUri)
 
       Right(uris)
-    } catch TryUtil.catchAllThrows
+    } catch TryUtil.catchAllThrows(workspaceURI)
 
   /** @inheritdoc */
   override def read(fileURI: URI): Either[CompilerMessage.AnyError, String] =
     Using(Source.fromFile(fileURI))(_.mkString) match {
       case Failure(exception) =>
-        TryUtil.catchAllThrows(exception)
+        TryUtil.catchAllThrows(fileURI)(exception)
 
       case Success(code) =>
         Right(code)

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/util/TryUtil.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/util/TryUtil.scala
@@ -4,15 +4,17 @@ import org.alephium.ralph.error.CompilerError.FormattableError
 import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.access.compiler.message.error._
 
+import java.net.URI
+
 object TryUtil {
 
   /** Catch all exceptions thrown by `ralphc` and file-io */
-  def catchAllThrows[T]: PartialFunction[Throwable, Either[CompilerMessage.AnyError, T]] = {
+  def catchAllThrows[T](fileURI: URI): PartialFunction[Throwable, Either[CompilerMessage.AnyError, T]] = {
     case error: FormattableError =>
       Left(FormattedError(error))
 
     case error: Throwable =>
-      Left(ThrowableError(error))
+      Left(ThrowableError(error, fileURI))
   }
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
@@ -81,10 +81,10 @@ object SourceCodeState {
     def warnings: Seq[StringWarning] =
       compiledCode flatMap {
         case Left(value) =>
-          value.warnings map (StringWarning(_))
+          value.warnings map (StringWarning(_, fileURI))
 
         case Right(value) =>
-          value.warnings map (StringWarning(_))
+          value.warnings map (StringWarning(_, fileURI))
       }
   }
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/error/SourceCodeAccessFailed.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/error/SourceCodeAccessFailed.scala
@@ -10,5 +10,5 @@ case class SourceCodeAccessFailed(uri: URI) extends CompilerMessage.Error {
     s"Source code errored on access. URI: $uri"
 
   override def index: SourceIndex =
-    SourceIndexExtra.zero
+    SourceIndexExtra.zero(uri)
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/error/SourceCodeHasCompilationErrors.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/error/SourceCodeHasCompilationErrors.scala
@@ -10,5 +10,5 @@ case class SourceCodeHasCompilationErrors(uri: URI) extends CompilerMessage.Erro
     s"Source code has compilation error(s). URI: $uri"
 
   override def index: SourceIndex =
-    SourceIndexExtra.zero
+    SourceIndexExtra.zero(uri)
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/error/SourceCodeIsNotCompiled.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/error/SourceCodeIsNotCompiled.scala
@@ -10,5 +10,5 @@ case class SourceCodeIsNotCompiled(uri: URI) extends CompilerMessage.Error {
     s"Source code is on-disk and not compiled. URI: $uri"
 
   override def index: SourceIndex =
-    SourceIndexExtra.zero
+    SourceIndexExtra.zero(uri)
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/error/SourceCodeNotFound.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/error/SourceCodeNotFound.scala
@@ -10,5 +10,5 @@ case class SourceCodeNotFound(uri: URI) extends CompilerMessage.Error {
     s"Source code not found. URI: $uri"
 
   override def index: SourceIndex =
-    SourceIndexExtra.zero
+    SourceIndexExtra.zero(uri)
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/Workspace.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/Workspace.scala
@@ -269,7 +269,8 @@ object Workspace extends StrictImplicitLogging {
       SourceCode.compile(
         sourceCode = workspace.sourceCode,
         dependency = workspace.build.dependency.map(_.sourceCode),
-        compilerOptions = workspace.build.config.compilerOptions
+        compilerOptions = workspace.build.config.compilerOptions,
+        workspaceErrorURI = workspace.workspaceURI
       )
 
     WorkspaceStateBuilder.toWorkspaceState(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/Build.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/Build.scala
@@ -110,7 +110,7 @@ object Build {
                       currentBuild: Option[BuildState.IsCompiled])(implicit file: FileAccess,
                                                                    compiler: CompilerAccess,
                                                                    logger: ClientLogger): BuildState.IsCompiled =
-    file.exists(buildURI, SourceIndexExtra.zero) match {
+    file.exists(buildURI, SourceIndexExtra.zero(buildURI)) match {
       case Left(error) =>
         BuildErrored(
           buildURI = buildURI,
@@ -130,7 +130,7 @@ object Build {
           BuildErrored(
             buildURI = buildURI,
             code = None,
-            errors = ArraySeq(ErrorBuildFileNotFound),
+            errors = ArraySeq(ErrorBuildFileNotFound(buildURI)),
             dependency = currentBuild.flatMap(_.dependency),
             activateWorkspace = None
           )
@@ -261,13 +261,15 @@ object Build {
     val contractPathIndex =
       SourceIndexExtra.ensurePositive(
         index = parsed.code.lastIndexOf(contractPath), // TODO: lastIndexOf is temporary solution until an AST is available.
-        width = contractPath.length
+        width = contractPath.length,
+        fileURI = parsed.buildURI
       )
 
     val artifactPathIndex =
       SourceIndexExtra.ensurePositive(
         index = parsed.code.lastIndexOf(artifactPath), // TODO: lastIndexOf is temporary solution until an AST is available.
-        width = artifactPath.length
+        width = artifactPath.length,
+        fileURI = parsed.buildURI
       )
 
     val dependencyPathIndex =
@@ -284,7 +286,8 @@ object Build {
 
     SourceIndexExtra.ensurePositive(
       index = parsed.code.lastIndexOf(errorIndexToken), // TODO: lastIndexOf is temporary solution until an AST is available.
-      width = errorIndexToken.length
+      width = errorIndexToken.length,
+      fileURI = parsed.buildURI
     )
   }
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildValidator.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildValidator.scala
@@ -25,7 +25,7 @@ object BuildValidator {
   def validateBuildURI(buildURI: URI,
                        workspaceURI: URI): Either[CompilerMessage.Error, URI] =
     if (!URIUtil.isFileName(buildURI, Build.BUILD_FILE_NAME))
-      Left(ErrorBuildFileNotFound)
+      Left(ErrorBuildFileNotFound(buildURI))
     else if (!URIUtil.isFirstChild(workspaceURI, buildURI)) // Build file must be in the root workspace directory.
       Left(
         ErrorInvalidBuildFileLocation(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/RalphcConfig.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/RalphcConfig.scala
@@ -70,7 +70,7 @@ object RalphcConfig {
         val error =
           ErrorInvalidBuildSyntax(
             fileURI = buildURI,
-            index = SourceIndexExtra.zero.copy(fileURI = Some(buildURI)),
+            index = SourceIndexExtra.zero(buildURI),
             message = throwable.getMessage
           )
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/Dependency.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/Dependency.scala
@@ -90,7 +90,7 @@ object Dependency {
                                                                     logger: ClientLogger): BuildState.IsCompiled =
     DependencyDownloader.downloadStd(
       dependencyPath = absoluteDependenciesPath,
-      errorIndex = SourceIndexExtra.zero
+      errorIndex = SourceIndexExtra.zero(parsed.buildURI)
     ) match { // download std
       case Left(errors) =>
         // report all download errors at build file level.

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/error/ErrorBuildFileNotFound.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/error/ErrorBuildFileNotFound.scala
@@ -4,10 +4,12 @@ import org.alephium.ralph.SourceIndex
 import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, SourceIndexExtra}
 import org.alephium.ralph.lsp.pc.workspace.build.Build
 
-case object ErrorBuildFileNotFound extends CompilerMessage.Error {
+import java.net.URI
+
+case class ErrorBuildFileNotFound(buildURI: URI) extends CompilerMessage.Error {
   override def message: String =
     s"Build file not found. Create a '${Build.BUILD_FILE_NAME}' file in the project's root folder."
 
   override def index: SourceIndex =
-    SourceIndexExtra.zero
+    SourceIndexExtra.zero(buildURI)
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/error/ErrorInvalidBuildFileLocation.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/error/ErrorInvalidBuildFileLocation.scala
@@ -11,5 +11,5 @@ case class ErrorInvalidBuildFileLocation(buildURI: URI,
     "Build file must be placed in the root workspace directory"
 
   override def index: SourceIndex =
-    SourceIndexExtra.zero
+    SourceIndexExtra.zero(buildURI)
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/error/ErrorUnknownFileType.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/error/ErrorUnknownFileType.scala
@@ -10,5 +10,5 @@ case class ErrorUnknownFileType(fileURI: URI) extends CompilerMessage.Error {
     s"Unknown file type: $fileURI"
 
   override def index: SourceIndex =
-    SourceIndexExtra.zero
+    SourceIndexExtra.zero(fileURI)
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeCompileSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeCompileSpec.scala
@@ -1,15 +1,17 @@
 package org.alephium.ralph.lsp.pc.sourcecode
 
-import org.alephium.ralph.lsp.TestCode
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.TestDependency
+import org.alephium.ralph.lsp.{TestCode, TestFile}
 import org.alephium.ralph.{CompiledContract, CompiledScript, CompilerOptions}
 import org.scalatest.EitherValues._
+import org.scalatest.OptionValues._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
+import java.nio.file.Paths
 import scala.collection.immutable.ArraySeq
 
 class SourceCodeCompileSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks {
@@ -24,7 +26,8 @@ class SourceCodeCompileSpec extends AnyWordSpec with Matchers with ScalaCheckDri
           SourceCode.compile(
             sourceCode = ArraySeq.empty,
             dependency = None,
-            compilerOptions = CompilerOptions.Default
+            compilerOptions = CompilerOptions.Default,
+            workspaceErrorURI = TestFile.genFolderURI().sample.value
           ).value
 
         result shouldBe empty
@@ -41,7 +44,8 @@ class SourceCodeCompileSpec extends AnyWordSpec with Matchers with ScalaCheckDri
           SourceCode.compile(
             sourceCode = ArraySeq.empty,
             dependency = dependencyBuild.dependency.map(_.sourceCode),
-            compilerOptions = CompilerOptions.Default
+            compilerOptions = CompilerOptions.Default,
+            workspaceErrorURI = TestFile.genFolderURI().sample.value
           ).value
 
         result shouldBe empty
@@ -74,7 +78,8 @@ class SourceCodeCompileSpec extends AnyWordSpec with Matchers with ScalaCheckDri
             .compile(
               sourceCode = source,
               dependency = None,
-              compilerOptions = CompilerOptions.Default
+              compilerOptions = CompilerOptions.Default,
+              workspaceErrorURI = Paths.get(source.head.fileURI).getParent.toUri // workspace URI
             )
             .value
             .map(_.asInstanceOf[SourceCodeState.Compiled])

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeParseSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeParseSpec.scala
@@ -79,6 +79,7 @@ class SourceCodeParseSpec extends AnyWordSpec with Matchers with ScalaCheckDrive
                   sourceCode = ArraySeq(parsed),
                   dependency = None,
                   compilerOptions = compilerOptions,
+                  workspaceErrorURI = parsed.fileURI
                 )
 
             // compilation successful

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
@@ -152,7 +152,8 @@ object TestSourceCode {
       SourceCode.compile(
         sourceCode = ArraySeq(parsed),
         dependency = None,
-        compilerOptions = CompilerOptions.Default
+        compilerOptions = CompilerOptions.Default,
+        workspaceErrorURI = parsed.fileURI
       )
 
     result.value should have size 1

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/StdInterfaceSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/StdInterfaceSpec.scala
@@ -1,8 +1,10 @@
 package org.alephium.ralph.lsp.pc.sourcecode.imports
 
+import org.alephium.ralph.lsp.TestFile
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra
 import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.scalatest.EitherValues._
+import org.scalatest.OptionValues._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -17,7 +19,7 @@ class StdInterfaceSpec extends AnyWordSpec with Matchers {
     val stdInterfaces =
       StdInterface.stdInterfaces(
         dependencyPath = Paths.get("my_workspace"),
-        errorIndex = SourceIndexExtra.zero
+        errorIndex = SourceIndexExtra.zero(TestFile.genFolderURI().sample.value)
       ).value
 
     "be defined" in {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuild1Spec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuild1Spec.scala
@@ -49,7 +49,7 @@ class WorkspaceBuild1Spec extends AnyWordSpec with Matchers with ScalaCheckDrive
                 BuildState.BuildErrored(
                   buildURI = workspace.buildURI,
                   code = None,
-                  errors = ArraySeq(ErrorBuildFileNotFound),
+                  errors = ArraySeq(ErrorBuildFileNotFound(workspace.buildURI)),
                   dependency = None,
                   activateWorkspace = None
                 )
@@ -75,7 +75,7 @@ class WorkspaceBuild1Spec extends AnyWordSpec with Matchers with ScalaCheckDrive
                 BuildState.BuildErrored(
                   buildURI = workspace.buildURI,
                   code = None,
-                  errors = ArraySeq(ErrorBuildFileNotFound),
+                  errors = ArraySeq(ErrorBuildFileNotFound(workspace.buildURI)),
                   dependency = None,
                   activateWorkspace = None
                 )

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceDeleteOrCreateSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceDeleteOrCreateSpec.scala
@@ -66,7 +66,7 @@ class WorkspaceDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCh
                     BuildState.BuildErrored(
                       buildURI = build.buildURI,
                       code = None, // because workspace is in created state
-                      errors = ArraySeq(ErrorBuildFileNotFound), // the error is reported
+                      errors = ArraySeq(ErrorBuildFileNotFound(build.buildURI)), // the error is reported
                       dependency = None, // because workspace is in created state
                       activateWorkspace = None
                     )
@@ -131,7 +131,7 @@ class WorkspaceDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCh
                     BuildState.BuildErrored(
                       buildURI = build.buildURI,
                       code = None, // no code is stored because the build is deleted
-                      errors = ArraySeq(ErrorBuildFileNotFound), // the error is reported
+                      errors = ArraySeq(ErrorBuildFileNotFound(build.buildURI)), // the error is reported
                       dependency = build.dependency, // dependency from previous build is carried
                       activateWorkspace = Some(workspace) // the same workspace with inside-code and outside-code is stored.
                     )

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceInitialiseSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceInitialiseSpec.scala
@@ -82,7 +82,7 @@ class WorkspaceInitialiseSpec extends AnyWordSpec with Matchers with ScalaCheckD
             mock[FileAccess]
 
           val errorIO =
-            StringError("Kaboom!")
+            StringError("Kaboom!", initialBuild.buildURI)
 
           // inject IO error
           (file.list _)

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildSpec.scala
@@ -177,7 +177,7 @@ class BuildSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyC
             BuildState.BuildErrored(
               buildURI = buildURI,
               code = None,
-              errors = ArraySeq(ErrorBuildFileNotFound),
+              errors = ArraySeq(ErrorBuildFileNotFound(buildURI)),
               dependency = None,
               activateWorkspace = None
             )

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildValidatorSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildValidatorSpec.scala
@@ -72,9 +72,9 @@ class BuildValidatorSpec extends AnyWordSpec with Matchers {
         actual.value.errors should contain theSameElementsAs
           ArraySeq(
             // error for field dependencyPath
-            ErrorDependencyPathIsWithinContractPath(SourceIndex(build.code.lastIndexOf(config.dependencyPath.value), config.dependencyPath.value.length, None)),
+            ErrorDependencyPathIsWithinContractPath(SourceIndex(build.code.lastIndexOf(config.dependencyPath.value), config.dependencyPath.value.length, Some(build.buildURI))),
             // error for field contractPath
-            ErrorDependencyPathIsWithinContractPath(SourceIndex(build.code.lastIndexOf(config.contractPath), config.contractPath.length, None))
+            ErrorDependencyPathIsWithinContractPath(SourceIndex(build.code.lastIndexOf(config.contractPath), config.contractPath.length, Some(build.buildURI)))
           )
 
         TestBuild delete build


### PR DESCRIPTION
The PR #128 adds `Option[fileURI]` to `SourceIndex` in node. For us, `fileURL` is mandatory and available everywhere. This PR updates `SourceIndex` related extension functions to also make `fileURI` mandatory and non-optional, ensuring that we do not create a `SourceIndex` without `fileURI`.