### PR TITLE
Clear struct's `tpe` on recompilation

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/Tree.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/Tree.scala
@@ -46,6 +46,22 @@ object Tree {
      * */
     lazy val rootNode: Node[Ast.Positioned] =
       NodeBuilder.buildRootNode(ast, index)
+
+    /**
+     * Solution for issue <a href="https://github.com/alephium/ralph-lsp/issues/135">#135</a>.
+     *
+     * Clear AST cached objects to enable recompilation of [[Ast.Struct]].
+     */
+    def clearStructCache(): Unit =
+      rootNode
+        .walkDown
+        .map(_.data)
+        .foreach {
+          case typed: Ast.StructCtor[_] =>
+            typed.tpe = None
+
+          case _ =>
+        }
   }
 
   sealed trait Literal extends Tree

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
@@ -266,6 +266,7 @@ private[pc] object SourceCode {
               .collect {
                 // collect only the source-code ignoring all import statements.
                 case source: Tree.Source =>
+                  source.clearStructCache()
                   source.ast
               }
         }


### PR DESCRIPTION
- Resolves #135
- Added a function to clear a cached `tpe` within `Ast.StructCtor` that is stored by ralphc.

#61 is a similar issue, but we still need to figure out which AST cached objects must be cleared.