### PR TITLE
Split `SourceCodeState.ErrorSource`

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
@@ -49,13 +49,19 @@ object SourceCodeState {
       StringUtil.codeLines(code)
   }
 
-  /** Represents: Code is parsed */
+  /** Represents: Code that is parsed. */
   sealed trait IsParsed extends IsCodeAware
 
-  /** Represents: Code errored */
+  /** Represents: Code that is compiled. */
+  sealed trait IsCompiled extends IsParsed
+
+  /** Represents: Code that contains error(s). */
   sealed trait IsError extends SourceCodeState
 
-  sealed trait IsCompiled extends IsParsed
+  /** Represents: Code that errored during parsing or compilation. */
+  sealed trait IsParserOrCompilationError extends IsError with IsCodeAware {
+    def errors: Seq[CompilerMessage.AnyError]
+  }
 
   /** The code is on disk */
   case class OnDisk(fileURI: URI) extends IsInitialised
@@ -73,6 +79,12 @@ object SourceCodeState {
                     code: String,
                     ast: Tree.Root) extends IsParsed
 
+
+  /** Represents: Error during the parser phase. */
+  case class ErrorParser(fileURI: URI,
+                         code: String,
+                         errors: Seq[CompilerMessage.AnyError]) extends IsParserOrCompilationError with IsParsed
+
   /** Represents: Code is successfully compiled */
   case class Compiled(fileURI: URI,
                       code: String,
@@ -88,13 +100,11 @@ object SourceCodeState {
       }
   }
 
-  /**
-   * Represents: Failed during the parse or compilation phase.
-   * If the parse phase was successfully but compilation failed, the parsed state is stored here for features like code-completion.
-   * */
-  case class ErrorSource(fileURI: URI,
-                         code: String,
-                         errors: Seq[CompilerMessage.AnyError],
-                         previous: Option[SourceCodeState.Parsed]) extends IsError with IsCompiled
+  /** Represents: Error during the compilation phase. */
+  case class ErrorCompilation(fileURI: URI,
+                              code: String,
+                              errors: Seq[CompilerMessage.AnyError],
+                              parsed: SourceCodeState.Parsed) extends IsParserOrCompilationError with IsCompiled
+
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeStateBuilder.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeStateBuilder.scala
@@ -27,7 +27,7 @@ private object SourceCodeStateBuilder {
     compilationResult match {
       case Left(error) =>
         // update the error to SourceCodeState
-        toSourceCodeError(
+        toCompilationError(
           parsedCode = parsedCode,
           error = error
         ) match {
@@ -52,7 +52,7 @@ private object SourceCodeStateBuilder {
 
   /**
    * If `fileURI` exists in the given compilation error, this function updates the current [[SourceCodeState]] at
-   * that `fileURI` with an error state [[SourceCodeState.ErrorSource]] indicating that this source file errored
+   * that `fileURI` with an error state [[SourceCodeState.ErrorCompilation]] indicating that this source file errored
    * during compilation.
    *
    * @param parsedCode The parsed code used for compilation.
@@ -60,8 +60,8 @@ private object SourceCodeStateBuilder {
    * @return An [[ArraySeq]] of [[SourceCodeState]]s if the `fileURI` is defined in the
    *         error's [[org.alephium.ralph.SourceIndex]], otherwise, [[None]].
    */
-  private def toSourceCodeError(parsedCode: ArraySeq[SourceCodeState.Parsed],
-                                error: CompilerMessage.AnyError): Option[ArraySeq[SourceCodeState.IsParsed]] =
+  private def toCompilationError(parsedCode: ArraySeq[SourceCodeState.Parsed],
+                                 error: CompilerMessage.AnyError): Option[ArraySeq[SourceCodeState.IsParsed]] =
     error
       .index
       .fileURI
@@ -73,11 +73,11 @@ private object SourceCodeStateBuilder {
               parsed =>
                 // Update the target file to an error state.
                 val sourceError =
-                  SourceCodeState.ErrorSource(
+                  SourceCodeState.ErrorCompilation(
                     fileURI = fileURI,
                     code = parsed.code,
                     errors = ArraySeq(error),
-                    previous = Some(parsed)
+                    parsed = parsed
                   )
 
                 // replace the source-code state.
@@ -131,11 +131,11 @@ private object SourceCodeStateBuilder {
           matchedCode partitionMap identity
 
         if (errors.nonEmpty) // if true, return errors
-          SourceCodeState.ErrorSource(
+          SourceCodeState.ErrorCompilation(
             fileURI = sourceCodeState.fileURI,
             code = sourceCodeState.code,
             errors = errors,
-            previous = Some(sourceCodeState)
+            parsed = sourceCodeState
           )
         else // else, return successfully compiled
           SourceCodeState.Compiled(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/Importer.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/Importer.scala
@@ -17,7 +17,7 @@ object Importer {
    *         - Right: The imported code.
    */
   def typeCheck(sourceCode: ArraySeq[SourceCodeState.Parsed],
-                dependency: Option[ArraySeq[SourceCodeState.Compiled]]): Either[ArraySeq[SourceCodeState.ErrorSource], ArraySeq[SourceCodeState.Compiled]] = {
+                dependency: Option[ArraySeq[SourceCodeState.Compiled]]): Either[ArraySeq[SourceCodeState.ErrorCompilation], ArraySeq[SourceCodeState.Compiled]] = {
     val dependencyOrEmpty =
       dependency getOrElse ArraySeq.empty
 
@@ -55,7 +55,7 @@ object Importer {
    *         - Right: The imported code.
    */
   def typeCheck(sourceCode: SourceCodeState.Parsed,
-                dependency: ArraySeq[SourceCodeState.Compiled]): Either[SourceCodeState.ErrorSource, Seq[SourceCodeState.Compiled]] = {
+                dependency: ArraySeq[SourceCodeState.Compiled]): Either[SourceCodeState.ErrorCompilation, Seq[SourceCodeState.Compiled]] = {
     val imported =
       sourceCode.ast.statements collect {
         case imported: Tree.Import => // type all import statements
@@ -80,11 +80,11 @@ object Importer {
     if (importErrors.nonEmpty) {
       // build a source-code state that reports all import errors in this file.
       val sourceError =
-        SourceCodeState.ErrorSource(
+        SourceCodeState.ErrorCompilation(
           fileURI = sourceCode.fileURI,
           code = sourceCode.code,
           errors = importErrors,
-          previous = Some(sourceCode)
+          parsed = sourceCode
         )
 
       Left(sourceError)

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/state/PCStateDiagnostics.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/state/PCStateDiagnostics.scala
@@ -253,7 +253,7 @@ object PCStateDiagnostics {
   /** Fetch source-code level diagnostics */
   def toSourceCodeDiagnostics(state: WorkspaceState.IsSourceAware): Iterable[FileDiagnostic] =
     state.sourceCode collect {
-      case state: SourceCodeState.ErrorSource =>
+      case state: SourceCodeState.IsParserOrCompilationError =>
         // transform multiple source code errors to diagnostics.
         val diagnostics =
           state.errors map {

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceStateBuilder.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceStateBuilder.scala
@@ -23,7 +23,7 @@ private object WorkspaceStateBuilder {
       case Right(compiledSource) =>
         val (errors, compiled) =
           compiledSource partitionMap {
-            case error: SourceCodeState.ErrorSource =>
+            case error: SourceCodeState.IsParserOrCompilationError =>
               Left(error)
 
             case parsed: SourceCodeState.Parsed =>

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeParseSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeParseSpec.scala
@@ -168,7 +168,7 @@ class SourceCodeParseSpec extends AnyWordSpec with Matchers with ScalaCheckDrive
 
         // ErrorSource state means the source-code has already been parsed and it previously errored.
         // Re-parsing will not yield a different result so expect no disk-IO or compiler-IO
-        forAll(TestSourceCode.genErrorSource()) {
+        forAll(TestSourceCode.genParserError()) {
           error =>
             SourceCode.parse(error) shouldBe error
         }
@@ -189,11 +189,10 @@ class SourceCodeParseSpec extends AnyWordSpec with Matchers with ScalaCheckDrive
 
           // expect error state is returned
           newState shouldBe
-            SourceCodeState.ErrorSource(
+            SourceCodeState.ErrorParser(
               fileURI = onDisk.fileURI,
               code = code,
-              errors = Seq(compiler.parseContracts(onDisk.fileURI, code).left.value),
-              previous = None
+              errors = Seq(compiler.parseContracts(onDisk.fileURI, code).left.value)
             )
 
           TestSourceCode.delete(onDisk)

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
@@ -65,7 +65,8 @@ object TestSourceCode {
                     code: Gen[String] = TestCode.genGoodCode()): Gen[SourceCodeState.IsError] =
     Gen.oneOf(
       genErrorAccess(state),
-      genErrorSource(state, code)
+      genParserError(state, code)
+      // TODO: Add genCompilationError
     )
 
   /**
@@ -82,18 +83,17 @@ object TestSourceCode {
         error = error
       )
 
-  def genErrorSource(state: Gen[SourceCodeState] = genOnDisk(),
-                     code: Gen[String] = TestCode.genGoodCode()): Gen[SourceCodeState.ErrorSource] =
+  def genParserError(state: Gen[SourceCodeState] = genOnDisk(),
+                     code: Gen[String] = TestCode.genGoodCode()): Gen[SourceCodeState.ErrorParser] =
     for {
       _state <- state
       _code <- code
       errors <- Gen.listOf(TestError.genError())
     } yield
-      SourceCodeState.ErrorSource(
+      SourceCodeState.ErrorParser(
         fileURI = _state.fileURI,
         code = _code,
-        errors = errors,
-        previous = None
+        errors = errors
       )
 
   def genUnCompiled(code: Gen[String] = TestCode.genGoodCode(),

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/ImporterSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/ImporterSpec.scala
@@ -14,8 +14,6 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import scala.collection.immutable.ArraySeq
 
-import java.net.URI
-
 class ImporterSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
   "typeCheck" should {
@@ -205,10 +203,10 @@ class ImporterSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenProper
           ImportError.Unknown(expectedAST)
 
         val expectedError =
-          SourceCodeState.ErrorSource(
+          SourceCodeState.ErrorCompilation(
             fileURI = myCode.fileURI,
             code = myCode.code,
-            previous = Some(myCode),
+            parsed = myCode,
             errors = ArraySeq(expectedImportError),
           )
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceParseSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceParseSpec.scala
@@ -51,7 +51,7 @@ class WorkspaceParseSpec extends AnyWordSpec with Matchers with ScalaCheckDriven
           val expectedSourceCodeStates =
             sourceCode
               .map(SourceCode.parse)
-              .map(_.asInstanceOf[SourceCodeState.ErrorSource])
+              .map(_.asInstanceOf[SourceCodeState.ErrorParser])
 
           val expectedWorkspace =
             WorkspaceState.UnCompiled(


### PR DESCRIPTION
Splits `SourceCodeState.ErrorSource` into two separate states: 
- `ErrorParser`, for errors occurring during the parsing phase. 
- `ErrorCompilation`, for errors occurring during the compilation phase.