### PR TITLE
Fix windows CI and source index issue

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -17,11 +17,11 @@ jobs:
           java-version: 17
       - run: sbt "compile;test"
 
-#  test-windows:
-#    runs-on: windows-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: actions/setup-java@v1
-#        with:
-#          java-version: 17
-#      - run: sbt "compile;test"
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      - run: sbt "compile;test"


### PR DESCRIPTION
Windows CI was failing, because the line index was not correct.
The culprit is [this guy ](https://github.com/com-lihaoyi/fastparse/blob/2.3.3/fastparse/src/fastparse/internal/Util.scala#L48-L75)which we use when[ calling prettyIndex](https://github.com/com-lihaoyi/fastparse/blob/49ba3cf46705a5068541537991ce1c2167760a2b/fastparse/src/fastparse/ParserInput.scala#L122-L130).

Issue is present on the fastparse version we use v2.3.3, but it seems to have been fixed in [this PR](https://github.com/com-lihaoyi/fastparse/pull/282) 

As we depend on the full node for the fastparse version, I wrote a fix directly here.

When we update fastparse, we could rollback to the previous version if we want.