### PR TITLE
Multiple line highlighting

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
@@ -54,12 +54,19 @@ object SourceIndexExtra {
 
     /** Convert [[SourceIndex]] that contains index information to [[LineRange]] that contains line and character information */
     def toLineRange(code: String): LineRange = {
-      val fastParseLineNumber = IndexedParserInput(code).prettyIndex(sourceIndex.from)
-      val sourcePosition = SourcePosition.parse(fastParseLineNumber)
+      val parserInput = IndexedParserInput(code)
 
-      val start = LinePosition(sourcePosition.rowIndex, sourcePosition.colIndex)
-      val end = LinePosition(sourcePosition.rowIndex, sourcePosition.colIndex + sourceIndex.width)
-      LineRange(start, end)
+      // Build the 'from' line position information
+      val fromLineNumber = parserInput.prettyIndex(sourceIndex.from)
+      val fromSourcePosition = SourcePosition.parse(fromLineNumber)
+      val from = LinePosition(fromSourcePosition.rowIndex, fromSourcePosition.colIndex)
+
+      // Build the 'to' line position information
+      val toLineNumber = parserInput.prettyIndex(sourceIndex.to)
+      val toSourcePosition = SourcePosition.parse(toLineNumber)
+      val to = LinePosition(toSourcePosition.rowIndex, toSourcePosition.colIndex)
+
+      LineRange(from, to)
     }
   }
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
@@ -87,9 +87,6 @@ object TestCodeProvider {
     val goToStart = lines.filter(_._1.contains(">>"))
     val goToEnd = lines.filter(_._1.contains("<<"))
 
-    /**
-     * FIXME: Simplify this function.
-     */
     val expectedLineRanges =
       if (goToStart.length != goToEnd.length)
         fail(s"Matching GoTo location indicators '<< and >>' not provided")
@@ -98,29 +95,11 @@ object TestCodeProvider {
           .zip(goToEnd)
           .map {
             case ((startLine, startLineIndex), (endLine, endLineIndex)) =>
-              if (startLine != endLine) { // start line is not the same as end line
-                // Create a LineRange such that `from` and `to` both have the same `startLine`.
-                val from =
-                  LinePosition(startLineIndex, startLine.indexOf(">>"))
-
-                // adjust the `endLineIndex` such that its range starts from `startLineIndex`
-                val adjustedEndLineIndex =
-                  startLineIndex +
-                    (startLine.length - 1 - from.character) + // add text length after the `>>` symbol
-                    endLine.indexOf("<<") // add the text length upto the `<<` symbol
-
-                LineRange(
-                  from = from,
-                  // `to` can now have the `startLineIndex`
-                  to = LinePosition(startLineIndex, adjustedEndLineIndex)
-                )
-              } else {
-                // Code range should be where << and >> are located
-                LineRange(
-                  from = LinePosition(startLineIndex, startLine.indexOf(">>")),
-                  to = LinePosition(endLineIndex, endLine.replaceFirst(">>", "").indexOf("<<"))
-                )
-              }
+              // Code range should be where << and >> are located
+              LineRange(
+                from = LinePosition(startLineIndex, startLine.indexOf(">>")),
+                to = LinePosition(endLineIndex, endLine.replaceFirst(">>", "").indexOf("<<"))
+              )
           }
 
     // remove << and >>

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToLocalVariableSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToLocalVariableSpec.scala
@@ -48,7 +48,7 @@ class GoToLocalVariableSpec extends AnyWordSpec with Matchers {
           |    >>let varA = 123
           |    <<let varB = var@@A
           |    >>let varA = ABC
-          |<<  }
+          |  <<}
           |
           |}
           |""".stripMargin


### PR DESCRIPTION
- Allow multiple line highlighting for go-to definition and diagnostics.
- The `toLineRange()` function currently computes a `LineRange` with start and end `LinePosition`s containing the same line number but different character numbers. This PR updates the calculation of the end `LinePosition` to be independent of the start `LinePosition`.

This PR will create a merge conflict after #139 is merged. Will rebase this PR accordingly.