### PR TITLE
Windows - Fix all the things

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
@@ -54,12 +54,19 @@ object SourceIndexExtra {
 
     /** Convert [[SourceIndex]] that contains index information to [[LineRange]] that contains line and character information */
     def toLineRange(code: String): LineRange = {
-      val fastParseLineNumber = IndexedParserInput(code).prettyIndex(sourceIndex.from)
-      val sourcePosition = SourcePosition.parse(fastParseLineNumber)
+      val parserInput = IndexedParserInput(code)
 
-      val start = LinePosition(sourcePosition.rowIndex, sourcePosition.colIndex)
-      val end = LinePosition(sourcePosition.rowIndex, sourcePosition.colIndex + sourceIndex.width)
-      LineRange(start, end)
+      // Build the 'from' line position information
+      val fromLineNumber = parserInput.prettyIndex(sourceIndex.from)
+      val fromSourcePosition = SourcePosition.parse(fromLineNumber)
+      val from = LinePosition(fromSourcePosition.rowIndex, fromSourcePosition.colIndex)
+
+      // Build the 'to' line position information
+      val toLineNumber = parserInput.prettyIndex(sourceIndex.to)
+      val toSourcePosition = SourcePosition.parse(toLineNumber)
+      val to = LinePosition(toSourcePosition.rowIndex, toSourcePosition.colIndex)
+
+      LineRange(from, to)
     }
   }
 }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
@@ -2,6 +2,7 @@ package org.alephium.ralph.lsp.access.compiler.message
 
 import fastparse.IndexedParserInput
 import org.alephium.ralph.{SourceIndex, SourcePosition}
+import org.alephium.ralph.lsp.access.util.StringUtil._
 
 import java.net.URI
 
@@ -66,10 +67,11 @@ object SourceIndexExtra {
        * Our current fastparse version is having issue with return lines on Windows.
        * The following workaround is inspired by fastparse ParserInput.prettyIndex
        */
+
+      val separatorLength = lineSeparatorLength(code)
       val lineNumberLookup =
-        code
-         .split(System.lineSeparator())
-         .foldLeft(Seq(0))((acc, line) => acc :+ (acc.last +line.size + System.lineSeparator().length))
+        codeLines(code)
+         .foldLeft(Seq(0))((acc, line) => acc :+ (acc.last + line.size + separatorLength))
 
       val start = linePosition(lineNumberLookup, sourceIndex.from)
       val end = linePosition(lineNumberLookup, sourceIndex.to)

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/util/StringUtil.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/util/StringUtil.scala
@@ -1,4 +1,4 @@
-package org.alephium.ralph.lsp.pc.util
+package org.alephium.ralph.lsp.access.util
 
 object StringUtil {
 
@@ -6,19 +6,22 @@ object StringUtil {
    * This method calculates the index of a character in the source code
    * given its line number and position within that line.
    *
-   * @param lines     An array containing each line of the source code
+   * @param code      The source code
    * @param line      The line number of the character
    * @param character The position of the character within the line
    * @return The index of the character in the source code
    */
-  def computeIndex(lines: Array[String],
+  def computeIndex(code: String,
                    line: Int,
                    character: Int): Int = {
+
+    val separatorLength = lineSeparatorLength(code)
+    val lines = codeLines(code)
     var index = 0
 
     var i = 0
     while (i < line && i < lines.length) {
-      index += lines(i).length + System.lineSeparator().length
+      index += lines(i).length + separatorLength
       i += 1
     }
 
@@ -29,4 +32,7 @@ object StringUtil {
   def codeLines(code: String): Array[String] =
     code.split("\r\n|\r|\n")
 
+  def lineSeparatorLength(code: String): Int =
+    if(code.contains("\r\n")) 2 else 1
 }
+

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
@@ -7,6 +7,7 @@ import org.alephium.ralph.lsp.pc.search.CodeProvider
 import org.alephium.ralph.lsp.pc.search.completion.Suggestion
 import org.alephium.ralph.lsp.pc.search.gotodef.data.GoToLocation
 import org.alephium.ralph.lsp.pc.state.{PCState, PCStateDiagnostics}
+import org.alephium.ralph.lsp.pc.util.URIUtil.uri
 import org.alephium.ralph.lsp.pc.workspace._
 import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorUnknownFileType
 import org.alephium.ralph.lsp.server
@@ -200,7 +201,7 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
   /** @inheritdoc */
   override def didOpen(params: DidOpenTextDocumentParams): Unit =
     runSync {
-      val fileURI = new URI(params.getTextDocument.getUri)
+      val fileURI = uri(params.getTextDocument.getUri)
       val code = Option(params.getTextDocument.getText)
 
       logger.debug(s"didOpen. fileURI: $fileURI. code.isDefined: ${code.isDefined}")
@@ -214,7 +215,7 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
   /** @inheritdoc */
   override def didChange(params: DidChangeTextDocumentParams): Unit =
     runSync {
-      val fileURI = new URI(params.getTextDocument.getUri)
+      val fileURI = uri(params.getTextDocument.getUri)
       val code = Option(params.getContentChanges.get(0).getText)
 
       logger.debug(s"didChange. fileURI: $fileURI. code.isDefined: ${code.isDefined}")
@@ -228,7 +229,7 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
   /** @inheritdoc */
   override def didClose(params: DidCloseTextDocumentParams): Unit =
     runSync {
-      val fileURI = new URI(params.getTextDocument.getUri)
+      val fileURI = uri(params.getTextDocument.getUri)
 
       logger.debug(s"didClose. fileURI: $fileURI")
 
@@ -241,7 +242,7 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
   /** @inheritdoc */
   override def didSave(params: DidSaveTextDocumentParams): Unit =
     runSync {
-      val fileURI = new URI(params.getTextDocument.getUri)
+      val fileURI = uri(params.getTextDocument.getUri)
       val code = Option(params.getText)
 
       logger.debug(s"didSave. fileURI: $fileURI. code.isDefined: ${code.isDefined}")
@@ -266,10 +267,10 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
           .map(event => (event.getType, event))
           .collect {
             case (FileChangeType.Deleted, event) =>
-              WorkspaceFileEvent.Deleted(new URI(event.getUri))
+              WorkspaceFileEvent.Deleted(uri(event.getUri))
 
             case (FileChangeType.Created, event) =>
-              WorkspaceFileEvent.Created(new URI(event.getUri))
+              WorkspaceFileEvent.Created(uri(event.getUri))
           }
 
       if (events.nonEmpty) {
@@ -298,7 +299,7 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
   override def completion(params: CompletionParams): CompletableFuture[messages.Either[util.List[CompletionItem], CompletionList]] =
     runAsync {
       cancelChecker =>
-        val fileURI = new URI(params.getTextDocument.getUri)
+        val fileURI = uri(params.getTextDocument.getUri)
         val line = params.getPosition.getLine
         val character = params.getPosition.getCharacter
 
@@ -349,7 +350,7 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
   override def definition(params: DefinitionParams): CompletableFuture[messages.Either[util.List[_ <: Location], util.List[_ <: LocationLink]]] =
     runAsync {
       cancelChecker =>
-        val fileURI = new URI(params.getTextDocument.getUri)
+        val fileURI = uri(params.getTextDocument.getUri)
         val line = params.getPosition.getLine
         val character = params.getPosition.getCharacter
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/CodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/CodeProvider.scala
@@ -1,12 +1,12 @@
 package org.alephium.ralph.lsp.pc.search
 
 import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
+import org.alephium.ralph.lsp.access.util.StringUtil
 import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.search.completion.{CodeCompletionProvider, Suggestion}
 import org.alephium.ralph.lsp.pc.search.gotodef.GoToDefinitionProvider
 import org.alephium.ralph.lsp.pc.search.gotodef.data.GoToLocation
 import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
-import org.alephium.ralph.lsp.pc.util.StringUtil
 import org.alephium.ralph.lsp.pc.workspace.{Workspace, WorkspaceState}
 
 import java.net.URI
@@ -67,7 +67,7 @@ object CodeProvider {
             // fetch the requested index from line number and character number.
             val cursorIndex =
               StringUtil.computeIndex(
-                lines = parsed.codeLines,
+                code = parsed.code,
                 line = line,
                 character = character
               )

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
@@ -4,7 +4,8 @@ import org.alephium.ralph.lsp.access.compiler.RalphParserExtension
 import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.access.compiler.message.warning.StringWarning
-import org.alephium.ralph.lsp.pc.util.{StringUtil, URIUtil}
+import org.alephium.ralph.lsp.access.util.StringUtil
+import org.alephium.ralph.lsp.pc.util.URIUtil
 import org.alephium.ralph.{CompiledContract, CompiledScript}
 
 import java.net.URI
@@ -43,10 +44,6 @@ object SourceCodeState {
   /** Represents: States where the code text is known */
   sealed trait IsCodeAware extends SourceCodeState {
     def code: String
-
-    /** Lazily executed. Can have concurrent access or no access at all. Used by code completion. */
-    lazy val codeLines: Array[String] =
-      StringUtil.codeLines(code)
   }
 
   /** Represents: Code that is parsed. */

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/util/URIUtil.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/util/URIUtil.scala
@@ -6,6 +6,16 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
 
 object URIUtil {
 
+  /**
+   * Build URI and clean it from escaped characters. Happen on Windows
+   */
+  def uri(string: String): URI =
+    if (scala.util.Properties.isWin) {
+      new URI(java.net.URLDecoder.decode(string, "UTF-8"))
+    } else {
+      new URI(string)
+    }
+
   def getFileName(uri: URI): String =
     Paths.get(uri).toFile.getName
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
@@ -4,11 +4,11 @@ import org.alephium.ralph.lsp.TestFile
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, LinePosition, LineRange}
 import org.alephium.ralph.lsp.access.file.FileAccess
+import org.alephium.ralph.lsp.access.util.StringUtil
 import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.search.gotodef.data.GoToLocation
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, TestSourceCode}
-import org.alephium.ralph.lsp.pc.util.StringUtil
 import org.alephium.ralph.lsp.pc.workspace.build.TestBuild
 import org.alephium.ralph.lsp.pc.workspace.{TestWorkspace, Workspace, WorkspaceState}
 import org.scalacheck.Gen

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
@@ -87,9 +87,6 @@ object TestCodeProvider {
     val goToStart = lines.filter(_._1.contains(">>"))
     val goToEnd = lines.filter(_._1.contains("<<"))
 
-    /**
-     * FIXME: Simplify this function.
-     */
     val expectedLineRanges =
       if (goToStart.length != goToEnd.length)
         fail(s"Matching GoTo location indicators '<< and >>' not provided")
@@ -98,29 +95,11 @@ object TestCodeProvider {
           .zip(goToEnd)
           .map {
             case ((startLine, startLineIndex), (endLine, endLineIndex)) =>
-              if (startLine != endLine) { // start line is not the same as end line
-                // Create a LineRange such that `from` and `to` both have the same `startLine`.
-                val from =
-                  LinePosition(startLineIndex, startLine.indexOf(">>"))
-
-                // adjust the `endLineIndex` such that its range starts from `startLineIndex`
-                val adjustedEndLineIndex =
-                  startLineIndex +
-                    (startLine.length - 1 - from.character) + // add text length after the `>>` symbol
-                    endLine.indexOf("<<") // add the text length upto the `<<` symbol
-
-                LineRange(
-                  from = from,
-                  // `to` can now have the `startLineIndex`
-                  to = LinePosition(startLineIndex, adjustedEndLineIndex)
-                )
-              } else {
-                // Code range should be where << and >> are located
-                LineRange(
-                  from = LinePosition(startLineIndex, startLine.indexOf(">>")),
-                  to = LinePosition(endLineIndex, endLine.replaceFirst(">>", "").indexOf("<<"))
-                )
-              }
+              // Code range should be where << and >> are located
+              LineRange(
+                from = LinePosition(startLineIndex, startLine.indexOf(">>")),
+                to = LinePosition(endLineIndex, endLine.replaceFirst(">>", "").indexOf("<<"))
+              )
           }
 
     // remove << and >>

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToLocalVariableSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToLocalVariableSpec.scala
@@ -48,7 +48,7 @@ class GoToLocalVariableSpec extends AnyWordSpec with Matchers {
           |    >>let varA = 123
           |    <<let varB = var@@A
           |    >>let varA = ABC
-          |<<  }
+          |  <<}
           |
           |}
           |""".stripMargin

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/util/URIUtilSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/util/URIUtilSpec.scala
@@ -1,0 +1,23 @@
+package org.alephium.ralph.lsp.pc.util
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.net.URI
+import java.net.URLDecoder.decode
+
+class URIUtilSpec extends AnyWordSpec with Matchers {
+
+  "URIUtil" should {
+    "build and clean uri" when {
+      "Windows uri contains escaped characters" in {
+        if (scala.util.Properties.isWin) {
+          val uri = "file:///c%3A/Users/user/test.ral"
+          val expected = "file:///c:/Users/user/test.ral"
+
+          URIUtil.uri(uri) shouldBe new URI(expected )
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Escape chars
Windows can send uris with some escaped characters, The value from the test represents what I received during my testing on Windows.
```
file:///c%3A/Users/user/test.ral
```

After some research, it seems we need to use `URLDecoder.decode`, I dug `metals` and found that they indeed use it [here](https://github.com/scalameta/metals/blob/main/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala#L145-L189) , I won't paste you the all path to get there, but they call it also at the entry point, e.g on [didOpen](https://github.com/scalameta/metals/blob/main/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala#L339), they use some implicit rich class, that's why they can call `toAbsolutePath` on a string.

## Line separators
Windows is supposed to send `\r\n` for line separator.
But while testing `ralph-lsp` on vscode on Windows, I realized that only `\n` was send to the server.

![image](https://github.com/alephium/ralph-lsp/assets/2979182/473365a0-6146-4931-9e8d-3c6f775f29ca)

So we can't use `System.lineSeparator` as it then shift the positions: 
![image](https://github.com/alephium/ralph-lsp/assets/2979182/e43b49a9-3698-4f4d-a787-ab83b3bc20bf)

and we can't either only use `\n` because we can't exclude that another client uses `\r\n`

With this PR, on Windows, on vscode, on my machine, with aligned planets in the cosmos, it looks fine now: 

![image](https://github.com/alephium/ralph-lsp/assets/2979182/1caf3b26-9227-4fce-95bd-e5f5a73df984)

Other features like go-to, std-interface completion/go-to seems to works fine too