### PR TITLE
Include tuple fields from `Ast` types

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/node/NodeBuilder.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/node/NodeBuilder.scala
@@ -81,9 +81,19 @@ object NodeBuilder extends StrictLogging {
       val children = buildOne(positioned)
       List(Node(positioned, children))
 
+    case (left: Positioned, right: Positioned) =>
+      val leftChildren = buildOne(left)
+      val rightChildren = buildOne(right)
+      List(
+        Node(left, leftChildren),
+        Node(right, rightChildren)
+      )
+
     case Some(positioned: Positioned) =>
-      val children = buildOne(positioned)
-      List(Node(positioned, children))
+      positionedProducts(positioned)
+
+    case Some(tuple @ (_: Positioned, _: Positioned)) =>
+      positionedProducts(tuple)
 
     case positions: Seq[_] =>
       buildMany(positions)

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToLocalVariableSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToLocalVariableSpec.scala
@@ -71,6 +71,21 @@ class GoToLocalVariableSpec extends AnyWordSpec with Matchers {
           |""".stripMargin
       )
     }
+
+    "variable is in an ApproveAsset expression" in {
+      goTo(
+        """
+          |Contract GoToTest() {
+          |
+          |  pub fn function() -> () {
+          |    >>let varA = 123
+          |    <<obj.fun{builtIn!() -> ALPH: varA@@}(somethingElse)
+          |  }
+          |
+          |}
+          |""".stripMargin
+      )
+    }
   }
 
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToLocalVariableUsageSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToLocalVariableUsageSpec.scala
@@ -48,6 +48,7 @@ class GoToLocalVariableUsageSpec extends AnyWordSpec with Matchers {
           |    let varA = >>varB<<
           |    let varB@@ = varA
           |    let varC = >>varB<<
+          |    obj.fun{builtIn!() -> ALPH: >>varB<<}(somethingElse)
           |  }
           |
           |}
@@ -67,6 +68,7 @@ class GoToLocalVariableUsageSpec extends AnyWordSpec with Matchers {
           |         index <= 4;
           |         index = >>varB<< + 1) {
           |       function(>>varB<<)
+          |       obj.fun{builtIn!() -> ALPH: >>varB<<}(somethingElse)
           |    }
           |  }
           |}


### PR DESCRIPTION
Enables the AST `Tree/Node` generated by `NodeBuilder` to include tuple fields from the node's `Ast` types. This is so that variables like `varA` in the following snippet are recognised for go-to definitions.

```rust
obj.fun{builtIn!() -> ALPH: varA}()
```