### PR TITLE
GoTo built-in function & support multiple dependencies

### DIFF
--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
@@ -7,6 +7,7 @@ import org.alephium.ralph.lsp.pc.search.CodeProvider
 import org.alephium.ralph.lsp.pc.search.completion.Suggestion
 import org.alephium.ralph.lsp.pc.search.gotodef.data.GoToLocation
 import org.alephium.ralph.lsp.pc.state.{PCState, PCStateDiagnostics}
+import org.alephium.ralph.lsp.pc.util.CollectionUtil
 import org.alephium.ralph.lsp.pc.util.URIUtil.uri
 import org.alephium.ralph.lsp.pc.workspace._
 import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorUnknownFileType
@@ -327,11 +328,11 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
                 case Some(Left(error)) =>
                   // Completion failed: Log the error message
                   logger.error("Code completion failed: " + error.message)
-                  ArraySeq.empty[Suggestion]
+                  Iterator.empty[Suggestion]
 
                 case None =>
                   // Not a ralph file or it does not belong to the workspace's contract-uri directory.
-                  ArraySeq.empty[Suggestion]
+                  Iterator.empty[Suggestion]
               }
 
             val completionList =
@@ -374,21 +375,21 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
               goToResult match {
                 case Some(Right(goToLocations)) =>
                   // successful
-                  goToLocations map GoToConverter.toLocation
+                  GoToConverter.toLocations(goToLocations)
 
                 case Some(Left(error)) =>
                   // Go-to definition failed: Log the error message
                   logger.error("Go-to definition failed: " + error.message)
-                  ArraySeq.empty[Location]
+                  Iterator.empty[Location]
 
                 case None =>
                   // Not a ralph file or it does not belong to the workspace's contract-uri directory.
-                  ArraySeq.empty[Location]
+                  Iterator.empty[Location]
               }
 
             cancelChecker.checkCanceled()
 
-            messages.Either.forLeft(util.Arrays.asList(locations: _*))
+            messages.Either.forLeft(CollectionUtil.toJavaList(locations))
 
           case _: WorkspaceState.Created =>
             // Workspace must be compiled at least once to enable GoTo definition.

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/converter/CompletionConverter.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/converter/CompletionConverter.scala
@@ -4,13 +4,12 @@ import org.alephium.ralph.lsp.pc.search.completion.Suggestion
 import org.eclipse.lsp4j._
 
 import java.util
-import scala.collection.immutable.ArraySeq
 
 /** Implements functions that transform internal code-completion types to LSP4J */
 object CompletionConverter {
 
   /** Convert a sequence of code completion result to LSP4J type. */
-  def toCompletionList(suggestions: ArraySeq[Suggestion]): CompletionList = {
+  def toCompletionList(suggestions: Iterator[Suggestion]): CompletionList = {
     val items = new util.ArrayList[CompletionItem]()
 
     suggestions foreach {

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/converter/GoToConverter.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/converter/GoToConverter.scala
@@ -7,6 +7,10 @@ import org.eclipse.lsp4j
 /** Converts Go-to definition types to LSP4J types */
 object GoToConverter {
 
+  /** Convert [[GoToLocation]]s to LSP4J types [[lsp4j.Location]] */
+  def toLocations(goTos: Iterator[GoToLocation]): Iterator[lsp4j.Location] =
+    goTos map toLocation
+
   /** Convert [[GoToLocation]] to LSP4J type [[lsp4j.Location]] */
   def toLocation(goTo: GoToLocation): lsp4j.Location =
     new lsp4j.Location(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/CodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/CodeProvider.scala
@@ -10,7 +10,6 @@ import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
 import org.alephium.ralph.lsp.pc.workspace.{Workspace, WorkspaceState}
 
 import java.net.URI
-import scala.collection.immutable.ArraySeq
 
 /**
  * A trait representing a code provider, which performs search operations
@@ -30,7 +29,7 @@ trait CodeProvider[A] {
    */
   def search(cursorIndex: Int,
              sourceCode: SourceCodeState.Parsed,
-             workspace: WorkspaceState.IsSourceAware)(implicit logger: ClientLogger): ArraySeq[A]
+             workspace: WorkspaceState.IsSourceAware)(implicit logger: ClientLogger): Iterator[A]
 }
 
 object CodeProvider {
@@ -56,7 +55,7 @@ object CodeProvider {
                 character: Int,
                 fileURI: URI,
                 workspace: WorkspaceState.IsSourceAware)(implicit provider: CodeProvider[A],
-                                                         logger: ClientLogger): Option[Either[CompilerMessage.Error, ArraySeq[A]]] =
+                                                         logger: ClientLogger): Option[Either[CompilerMessage.Error, Iterator[A]]] =
     Workspace.findParsed( // find the parsed file where this search was executed.
       fileURI = fileURI,
       workspace = workspace

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/CodeCompletionProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/CodeCompletionProvider.scala
@@ -6,6 +6,7 @@ import org.alephium.ralph.lsp.pc.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.lsp.pc.search.CodeProvider
 import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 
 /**
  * Implements [[CodeProvider]] that provides code completion results of type [[Suggestion]].
@@ -25,7 +26,7 @@ private[search] object CodeCompletionProvider extends CodeProvider[Suggestion] w
             // request is for import statement completion
             ImportCompleter.complete(
               cursorIndex = cursorIndex,
-              dependency = workspace.build.dependency,
+              dependency = workspace.build.findDependency(DependencyID.Std),
               imported = importStatement
             ).iterator
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/CodeCompletionProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/CodeCompletionProvider.scala
@@ -7,8 +7,6 @@ import org.alephium.ralph.lsp.pc.search.CodeProvider
 import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 
-import scala.collection.immutable.ArraySeq
-
 /**
  * Implements [[CodeProvider]] that provides code completion results of type [[Suggestion]].
  *
@@ -18,7 +16,7 @@ private[search] object CodeCompletionProvider extends CodeProvider[Suggestion] w
 
   override def search(cursorIndex: Int,
                       sourceCode: SourceCodeState.Parsed,
-                      workspace: WorkspaceState.IsSourceAware)(implicit logger: ClientLogger): ArraySeq[Suggestion] =
+                      workspace: WorkspaceState.IsSourceAware)(implicit logger: ClientLogger): Iterator[Suggestion] =
     // find the statement where this cursorIndex sits.
     sourceCode.ast.statements.find(_.index contains cursorIndex) match {
       case Some(statement) =>
@@ -29,14 +27,14 @@ private[search] object CodeCompletionProvider extends CodeProvider[Suggestion] w
               cursorIndex = cursorIndex,
               dependency = workspace.build.dependency,
               imported = importStatement
-            )
+            ).iterator
 
           case _: Tree.Source =>
-            ArraySeq.empty // TODO: Provide source level completion.
+            Iterator.empty // TODO: Provide source level completion.
         }
 
       case None =>
         // TODO: Provide top level completion.
-        ArraySeq.empty
+        Iterator.empty
     }
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/CodeCompletionProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/CodeCompletionProvider.scala
@@ -15,6 +15,7 @@ import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
  */
 private[search] object CodeCompletionProvider extends CodeProvider[Suggestion] with StrictImplicitLogging {
 
+  /** @inheritdoc */
   override def search(cursorIndex: Int,
                       sourceCode: SourceCodeState.Parsed,
                       workspace: WorkspaceState.IsSourceAware)(implicit logger: ClientLogger): Iterator[Suggestion] =

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefinitionProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefinitionProvider.scala
@@ -8,8 +8,6 @@ import org.alephium.ralph.lsp.pc.search.gotodef.data.GoToLocation
 import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 
-import scala.collection.immutable.ArraySeq
-
 /**
  * Implements [[CodeProvider]] that provides go-to definition results of type [[GoToLocation]].
  *
@@ -19,7 +17,7 @@ private[search] object GoToDefinitionProvider extends CodeProvider[GoToLocation]
 
   override def search(cursorIndex: Int,
                       sourceCode: SourceCodeState.Parsed,
-                      workspace: WorkspaceState.IsSourceAware)(implicit logger: ClientLogger): ArraySeq[GoToLocation] =
+                      workspace: WorkspaceState.IsSourceAware)(implicit logger: ClientLogger): Iterator[GoToLocation] =
     // find the statement where this cursorIndex sits.
     sourceCode.ast.statements.find(_.index contains cursorIndex) match {
       case Some(statement) =>
@@ -30,7 +28,7 @@ private[search] object GoToDefinitionProvider extends CodeProvider[GoToLocation]
               cursorIndex = cursorIndex,
               dependency = workspace.build.dependency,
               importStatement = importStatement
-            )
+            ).iterator
 
           case source: Tree.Source =>
             // request is for source-code go-to definition
@@ -42,6 +40,6 @@ private[search] object GoToDefinitionProvider extends CodeProvider[GoToLocation]
         }
 
       case None =>
-        ArraySeq.empty
+        Iterator.empty
     }
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefinitionProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefinitionProvider.scala
@@ -7,6 +7,7 @@ import org.alephium.ralph.lsp.pc.search.CodeProvider
 import org.alephium.ralph.lsp.pc.search.gotodef.data.GoToLocation
 import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 
 /**
  * Implements [[CodeProvider]] that provides go-to definition results of type [[GoToLocation]].
@@ -26,7 +27,7 @@ private[search] object GoToDefinitionProvider extends CodeProvider[GoToLocation]
             // request is for import go-to definition
             GoToImport.goTo(
               cursorIndex = cursorIndex,
-              dependency = workspace.build.dependency,
+              dependency = workspace.build.findDependency(DependencyID.Std),
               importStatement = importStatement
             ).iterator
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefinitionProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefinitionProvider.scala
@@ -37,7 +37,8 @@ private[search] object GoToDefinitionProvider extends CodeProvider[GoToLocation]
             GoToSource.goTo(
               cursorIndex = cursorIndex,
               sourceCode = sourceCode,
-              sourceAST = source
+              sourceAST = source,
+              dependencyBuiltIn = workspace.build.findDependency(DependencyID.BuiltIn)
             )
         }
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefinitionProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefinitionProvider.scala
@@ -16,6 +16,7 @@ import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
  */
 private[search] object GoToDefinitionProvider extends CodeProvider[GoToLocation] with StrictImplicitLogging {
 
+  /** @inheritdoc */
   override def search(cursorIndex: Int,
                       sourceCode: SourceCodeState.Parsed,
                       workspace: WorkspaceState.IsSourceAware)(implicit logger: ClientLogger): Iterator[GoToLocation] =

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
@@ -59,7 +59,7 @@ private object GoToFuncId {
    * @return An array sequence containing all the local function definitions.
    * */
   private def goToLocalFunction(funcId: Ast.FuncId,
-                                source: Tree.Source): Iterator[Ast.FuncId] =
+                                source: Tree.Source): Iterator[Ast.Positioned] =
     // TODO: Improve selection by checking function argument count and types.
     source.ast match {
       case Left(ast) =>
@@ -67,7 +67,16 @@ private object GoToFuncId {
           .funcs
           .iterator
           .filter(_.id == funcId)
-          .map(_.id)
+          .map {
+            funcDef =>
+              if (funcDef.bodyOpt.isEmpty)
+                funcDef // we show the entire function definition to display the function signature.
+              else
+                // The function contains a body so return just the function id.
+                // FIXME: There is still a need to display just the function signature.
+                //        At the moment there is no AST type that provides just the function signature.
+                funcDef.id
+          }
 
       case Right(_) =>
         Iterator.empty

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
@@ -4,6 +4,9 @@ import org.alephium.ralph.Ast
 import org.alephium.ralph.Ast.Positioned
 import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.ast.node.Node
+import org.alephium.ralph.lsp.pc.search.gotodef.data.GoToLocation
+import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
+import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 
 private object GoToFuncId {
 
@@ -17,28 +20,34 @@ private object GoToFuncId {
    * */
   def goTo(funcIdNode: Node[Positioned],
            funcId: Ast.FuncId,
-           source: Tree.Source): Iterator[Ast.Positioned] =
+           source: Tree.Source,
+           sourceCode: SourceCodeState.Parsed,
+           dependencyBuiltIn: Option[WorkspaceState.Compiled]): Iterator[GoToLocation] =
     funcIdNode.parent match { // take one step up to check the type of function call.
       case Some(parent) =>
         parent match {
           case Node(callExpr: Ast.CallExpr[_], _) if callExpr.id == funcId =>
             // The user clicked on a local function. Take 'em there!
-            goToLocalFunction(
-              funcId = funcId,
-              source = source
+            goToFunction(
+              funcId = callExpr.id,
+              source = source,
+              sourceCode = sourceCode,
+              dependencyBuiltIn = dependencyBuiltIn
             )
 
           case Node(funcCall: Ast.FuncCall[_], _) if funcCall.id == funcId =>
-            goToLocalFunction(
+            goToFunction(
               funcId = funcCall.id,
-              source = source
+              source = source,
+              sourceCode = sourceCode,
+              dependencyBuiltIn = dependencyBuiltIn
             )
 
           case Node(funcDef: Ast.FuncDef[_], _) if funcDef.id == funcId =>
-            goToFunctionCalls(
+            goToFunctionUsage(
               funcId = funcDef.id,
               source = source
-            )
+            ).flatMap(GoToLocation(_, sourceCode))
 
           case Node(callExpr: Ast.ContractCallExpr, _) if callExpr.callId == funcId =>
             // TODO: The user clicked on a external function call. Take 'em there!
@@ -47,9 +56,34 @@ private object GoToFuncId {
           case _ =>
             Iterator.empty
         }
+
       case None =>
         Iterator.empty
     }
+
+  /**
+   * Navigate to local or built-in functions within the source code for the specified [[Ast.FuncId]].
+   *
+   * @param funcId            The [[Ast.FuncId]] of the function to locate.
+   * @param source            The source tree to search within.
+   * @param sourceCode        The source code corresponding to the source tree.
+   * @param dependencyBuiltIn The dependency workspace containing built-in functions.
+   * @return An iterator over all searched function definitions.
+   */
+  private def goToFunction(funcId: Ast.FuncId,
+                           source: Tree.Source,
+                           sourceCode: SourceCodeState.Parsed,
+                           dependencyBuiltIn: Option[WorkspaceState.Compiled]): Iterator[GoToLocation] =
+    if (funcId.isBuiltIn)
+      goToBuiltInFunction(
+        funcId = funcId,
+        dependencyBuiltIn = dependencyBuiltIn
+      )
+    else
+      goToLocalFunction(
+        funcId = funcId,
+        source = source
+      ).flatMap(GoToLocation(_, sourceCode))
 
   /**
    * Navigate to the local function within the source code for the given [[Ast.FuncId]].
@@ -83,14 +117,70 @@ private object GoToFuncId {
     }
 
   /**
-   * Navigate to all local function calls where the given function definition [[Ast.FuncDef]]
+   * Navigate to built-in functions identified by the given [[Ast.FuncId]] within a the dependant workspace.
+   *
+   * @param funcId            The build-in function id to search.
+   * @param dependencyBuiltIn Dependant workspace containing built-in function source files.
+   * @return A iterator over locations of the built-in functions within the compiled workspace.
+   */
+  private def goToBuiltInFunction(funcId: Ast.FuncId,
+                                  dependencyBuiltIn: Option[WorkspaceState.Compiled]): Iterator[GoToLocation] =
+    dependencyBuiltIn match {
+      case Some(buildInWorkspace) =>
+        buildInWorkspace
+          .sourceCode
+          .iterator // iterator over dependant source-code files
+          .flatMap {
+            compiled =>
+              goToBuiltInFunction(
+                funcId = funcId,
+                builtInFunctions = compiled
+              )
+          }
+
+      case None =>
+        Iterator.empty
+    }
+
+  /**
+   * Navigate to built-in functions identified by the given [[Ast.FuncId]] within a source file.
+   *
+   * @param funcId           The build-in function id to search.
+   * @param builtInFunctions Compiled source file containing built-in functions.
+   * @return A iterator over locations of the built-in functions within the compiled source file.
+   */
+  private def goToBuiltInFunction(funcId: Ast.FuncId,
+                                  builtInFunctions: SourceCodeState.Compiled): Iterator[GoToLocation] =
+    builtInFunctions
+      .parsed
+      .ast
+      .statements
+      .iterator
+      .collect {
+        case source: Tree.Source =>
+          // search for the matching functionIds within the built-in source file.
+          val builtInFunctionIDs =
+            goToLocalFunction(
+              funcId = funcId,
+              source = source
+            )
+
+          GoToLocation(
+            sourceCode = builtInFunctions.parsed,
+            asts = builtInFunctionIDs
+          )
+      }
+      .flatten
+
+  /**
+   * Navigate to all local function usage where the given function definition [[Ast.FuncDef]]
    * is invoked.
    *
    * @param funcId The [[Ast.FuncId]] of the [[Ast.FuncDef]] to locate calls for.
    * @param source The source tree to search within.
    * @return An iterator containing all the local function calls.
    * */
-  private def goToFunctionCalls(funcId: Ast.FuncId,
+  private def goToFunctionUsage(funcId: Ast.FuncId,
                                 source: Tree.Source): Iterator[Ast.Positioned] =
     source
       .rootNode

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
@@ -103,6 +103,9 @@ private object GoToIdent {
               fromNodeIdent = argument.ident,
               source = source
             )
+
+          case _ =>
+            Iterator.empty
         }
 
       case None =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToSource.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToSource.scala
@@ -3,9 +3,10 @@ package org.alephium.ralph.lsp.pc.search.gotodef
 import org.alephium.ralph.Ast
 import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.ast.node.Node
-import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.SourceIndexExtension
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra._
 import org.alephium.ralph.lsp.pc.search.gotodef.data.GoToLocation
 import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
+import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 
 private object GoToSource {
 
@@ -13,36 +14,15 @@ private object GoToSource {
    * Navigates to the definition of a token in the source code.
    *
    * @param cursorIndex The index of the token clicked by the user.
-   * @param sourceCode  The requested source file.
-   * @param sourceAST   Parsed AST of the requested source file's code.
-   * @return An array sequence containing the target go-to location(s).
+   * @param sourceCode  The parsed state of the source-code where the search is executed.
+   * @param sourceAST   Parsed AST of the searched source file.
+   * @return An iterator over the target go-to location(s).
    */
   def goTo(cursorIndex: Int,
            sourceCode: SourceCodeState.Parsed,
-           sourceAST: Tree.Source): Iterator[GoToLocation] = {
-    val goToResult =
-      goTo(
-        cursorIndex = cursorIndex,
-        source = sourceAST
-      )
-
-    // covert go-to node to GoToLocation
-    GoToLocation(
-      sourceCode = sourceCode,
-      asts = goToResult
-    )
-  }
-
-  /**
-   * Navigates to the definition of a token in the source code.
-   *
-   * @param cursorIndex The index of the token clicked by the user.
-   * @param source      The source tree to navigate within.
-   * @return An iterator over the positioned AST elements found.
-   */
-  private def goTo(cursorIndex: Int,
-                   source: Tree.Source): Iterator[Ast.Positioned] =
-    source.rootNode.findLast(_.sourceIndex.exists(_ contains cursorIndex)) match { // find the node closest to this source-index
+           sourceAST: Tree.Source,
+           dependencyBuiltIn: Option[WorkspaceState.Compiled]): Iterator[GoToLocation] =
+    sourceAST.rootNode.findLast(_.sourceIndex.exists(_ contains cursorIndex)) match { // find the node closest to this source-index
       case Some(closest) =>
         closest match {
           case identNode @ Node(ident: Ast.Ident, _) =>
@@ -50,7 +30,8 @@ private object GoToSource {
             GoToIdent.goTo(
               identNode = identNode,
               ident = ident,
-              source = source
+              sourceAST = sourceAST,
+              sourceCode = sourceCode
             )
 
           case funcIdNode @ Node(funcId: Ast.FuncId, _) =>
@@ -58,7 +39,9 @@ private object GoToSource {
             GoToFuncId.goTo(
               funcIdNode = funcIdNode,
               funcId = funcId,
-              source = source
+              source = sourceAST,
+              sourceCode = sourceCode,
+              dependencyBuiltIn = dependencyBuiltIn
             )
 
           case typIdNode @ Node(typeId: Ast.TypeId, _) =>
@@ -66,7 +49,8 @@ private object GoToSource {
             GoToTypeId.goTo(
               identNode = typIdNode,
               typeId = typeId,
-              source = source
+              source = sourceAST,
+              sourceCode = sourceCode
             )
 
           case _ =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToSource.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToSource.scala
@@ -7,8 +7,6 @@ import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.SourceInd
 import org.alephium.ralph.lsp.pc.search.gotodef.data.GoToLocation
 import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
 
-import scala.collection.immutable.ArraySeq
-
 private object GoToSource {
 
   /**
@@ -21,7 +19,7 @@ private object GoToSource {
    */
   def goTo(cursorIndex: Int,
            sourceCode: SourceCodeState.Parsed,
-           sourceAST: Tree.Source): ArraySeq[GoToLocation] = {
+           sourceAST: Tree.Source): Iterator[GoToLocation] = {
     val goToResult =
       goTo(
         cursorIndex = cursorIndex,
@@ -31,7 +29,7 @@ private object GoToSource {
     // covert go-to node to GoToLocation
     GoToLocation(
       sourceCode = sourceCode,
-      ast = goToResult.to(ArraySeq)
+      asts = goToResult
     )
   }
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToSource.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToSource.scala
@@ -31,7 +31,7 @@ private object GoToSource {
     // covert go-to node to GoToLocation
     GoToLocation(
       sourceCode = sourceCode,
-      ast = goToResult
+      ast = goToResult.to(ArraySeq)
     )
   }
 
@@ -40,39 +40,43 @@ private object GoToSource {
    *
    * @param cursorIndex The index of the token clicked by the user.
    * @param source      The source tree to navigate within.
-   * @return An option containing the positioned AST element if found, otherwise None.
+   * @return An iterator over the positioned AST elements found.
    */
   private def goTo(cursorIndex: Int,
-                   source: Tree.Source): ArraySeq[Ast.Positioned] =
-    source
-      .rootNode
-      .findLast(_.sourceIndex.exists(_ contains cursorIndex)) // find the node closest to this source-index
-      .to(ArraySeq)
-      .collect {
-        case identNode @ Node(ident: Ast.Ident, _) =>
-          // the clicked/closest node is an ident
-          GoToIdent.goTo(
-            identNode = identNode,
-            ident = ident,
-            source = source
-          )
+                   source: Tree.Source): Iterator[Ast.Positioned] =
+    source.rootNode.findLast(_.sourceIndex.exists(_ contains cursorIndex)) match { // find the node closest to this source-index
+      case Some(closest) =>
+        closest match {
+          case identNode @ Node(ident: Ast.Ident, _) =>
+            // the clicked/closest node is an ident
+            GoToIdent.goTo(
+              identNode = identNode,
+              ident = ident,
+              source = source
+            )
 
-        case funcIdNode @ Node(funcId: Ast.FuncId, _) =>
-          // the clicked/closest node is functionId
-          GoToFuncId.goTo(
-            funcIdNode = funcIdNode,
-            funcId = funcId,
-            source = source
-          )
+          case funcIdNode @ Node(funcId: Ast.FuncId, _) =>
+            // the clicked/closest node is functionId
+            GoToFuncId.goTo(
+              funcIdNode = funcIdNode,
+              funcId = funcId,
+              source = source
+            )
 
-        case typIdNode @ Node(typeId: Ast.TypeId, _) =>
-          // the clicked/closest node is TypeId
-          GoToTypeId.goTo(
-            identNode = typIdNode,
-            typeId = typeId,
-            source = source
-          )
-      }
-      .flatten
+          case typIdNode @ Node(typeId: Ast.TypeId, _) =>
+            // the clicked/closest node is TypeId
+            GoToTypeId.goTo(
+              identNode = typIdNode,
+              typeId = typeId,
+              source = source
+            )
+
+          case _ =>
+            Iterator.empty
+        }
+
+      case None =>
+        Iterator.empty
+    }
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/data/GoToLocation.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/data/GoToLocation.scala
@@ -6,7 +6,6 @@ import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.SourceInd
 import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
 
 import java.net.URI
-import scala.collection.immutable.ArraySeq
 
 object GoToLocation {
 
@@ -14,12 +13,12 @@ object GoToLocation {
    * Converts the given data to a [[GoToLocation]].
    *
    * @param sourceCode The source file to navigate to.
-   * @param ast        The positions within the source file to navigate to.
-   * @return A list of [[GoToLocation]]s representing the navigation destinations.
+   * @param asts       The positions within the source file to navigate to.
+   * @return A Iterator over [[GoToLocation]]s representing the navigation destinations.
    */
   def apply(sourceCode: SourceCodeState.Parsed,
-            ast: ArraySeq[Ast.Positioned]): ArraySeq[GoToLocation] =
-    ast.flatMap(GoToLocation(_, sourceCode))
+            asts: Iterator[Ast.Positioned]): Iterator[GoToLocation] =
+    asts.flatMap(GoToLocation(_, sourceCode))
 
   /**
    * Converts the given data to a [[GoToLocation]].

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
@@ -212,7 +212,7 @@ private[pc] object SourceCode {
    * @return Workspace-level error if an error occurred without a target source-file, or else next state for each source-code.
    */
   def compile(sourceCode: ArraySeq[SourceCodeState.Parsed],
-              dependency: Option[ArraySeq[SourceCodeState.Compiled]],
+              dependency: ArraySeq[SourceCodeState.Compiled],
               compilerOptions: CompilerOptions,
               workspaceErrorURI: URI)(implicit compiler: CompilerAccess): Either[CompilerMessage.AnyError, ArraySeq[SourceCodeState.IsParsed]] =
     Importer.typeCheck(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
@@ -17,7 +17,9 @@ sealed trait SourceCodeState {
    *
    * Can be concurrently accessed or not accessed at all.
    *
-   * @see [[URIUtil.importIdentifier]] */
+   * @return An AST representing this source file's import string literal.
+   * @see [[URIUtil.importIdentifier]]
+   */
   lazy val importIdentifier: Option[Tree.Import] =
     URIUtil
       .importIdentifier(fileURI)

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/Importer.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/Importer.scala
@@ -17,17 +17,14 @@ object Importer {
    *         - Right: The imported code.
    */
   def typeCheck(sourceCode: ArraySeq[SourceCodeState.Parsed],
-                dependency: Option[ArraySeq[SourceCodeState.Compiled]]): Either[ArraySeq[SourceCodeState.ErrorCompilation], ArraySeq[SourceCodeState.Compiled]] = {
-    val dependencyOrEmpty =
-      dependency getOrElse ArraySeq.empty
-
+                dependency: ArraySeq[SourceCodeState.Compiled]): Either[ArraySeq[SourceCodeState.ErrorCompilation], ArraySeq[SourceCodeState.Compiled]] = {
     // run import type check on every source file
     val imported =
       sourceCode map {
         sourceCode =>
           typeCheck(
             sourceCode = sourceCode,
-            dependency = dependencyOrEmpty
+            dependency = dependency
           )
       }
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/util/CollectionUtil.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/util/CollectionUtil.scala
@@ -1,8 +1,22 @@
 package org.alephium.ralph.lsp.pc.util
 
+import java.util
 import scala.collection.immutable.ArraySeq
 
 object CollectionUtil {
+
+  /**
+   * Converts an iterator to a Java ArrayList.
+   *
+   * @param iterator The iterator to convert.
+   * @tparam A The type of elements.
+   * @return A Java ArrayList containing the elements from the iterator.
+   */
+  def toJavaList[A](iterator: Iterator[A]): util.ArrayList[A] = {
+    val javaList = new util.ArrayList[A]()
+    iterator.foreach(javaList.add)
+    javaList
+  }
 
   implicit class CollectionUtilImplicits[+A](val collection: ArraySeq[A]) extends AnyVal {
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/Build.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/Build.scala
@@ -36,9 +36,9 @@ object Build {
       case Left(error) =>
         BuildErrored(
           buildURI = buildURI,
-          code = Some(json),
+          codeOption = Some(json),
           errors = ArraySeq(error),
-          dependency = None,
+          dependencies = ArraySeq.empty,
           activateWorkspace = None
         )
 
@@ -56,9 +56,9 @@ object Build {
       case Left(error) =>
         BuildErrored(
           buildURI = buildURI,
-          code = None,
+          codeOption = None,
           errors = ArraySeq(error),
-          dependency = None,
+          dependencies = ArraySeq.empty,
           activateWorkspace = None
         )
 
@@ -80,7 +80,7 @@ object Build {
         currentBuild match {
           case Some(currentBuild) =>
             // carry the dependency for existing build forward.
-            errored.copy(dependency = currentBuild.dependency)
+            errored.copy(dependencies = currentBuild.dependencies)
 
           case None =>
             errored
@@ -114,9 +114,9 @@ object Build {
       case Left(error) =>
         BuildErrored(
           buildURI = buildURI,
-          code = None,
+          codeOption = None,
           errors = ArraySeq(error),
-          dependency = currentBuild.flatMap(_.dependency),
+          dependencies = currentBuild.to(ArraySeq).flatMap(_.dependencies),
           activateWorkspace = None
         )
 
@@ -129,9 +129,9 @@ object Build {
         else
           BuildErrored(
             buildURI = buildURI,
-            code = None,
+            codeOption = None,
             errors = ArraySeq(ErrorBuildFileNotFound(buildURI)),
-            dependency = currentBuild.flatMap(_.dependency),
+            dependencies = currentBuild.to(ArraySeq).flatMap(_.dependencies),
             activateWorkspace = None
           )
     }
@@ -192,9 +192,9 @@ object Build {
         val buildError =
           BuildState.BuildErrored(
             buildURI = buildURI,
-            code = code,
+            codeOption = code,
             errors = ArraySeq(error),
-            dependency = currentBuild.dependency,
+            dependencies = currentBuild.dependencies,
             activateWorkspace = None
           )
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/Build.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/Build.scala
@@ -87,7 +87,7 @@ object Build {
         }
 
       case parsed: BuildParsed =>
-        def compileDependency() =
+        def compileDependencies() =
           Dependency.compile(
             parsed = parsed,
             currentBuild = currentBuild
@@ -97,7 +97,7 @@ object Build {
         val compilationResult =
           BuildValidator
             .validate(parsed)
-            .getOrElse(compileDependency())
+            .getOrElse(compileDependencies())
 
         DependencyDB.persist(
           parentBuild = compilationResult,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildState.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildState.scala
@@ -1,14 +1,18 @@
 package org.alephium.ralph.lsp.pc.workspace.build
 
 import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
+import org.alephium.ralph.lsp.pc.util.URIUtil
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.pc.workspace.build.RalphcConfig.{RalphcCompiledConfig, RalphcParsedConfig}
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 
 import java.net.URI
 import java.nio.file.{Path, Paths}
 import scala.collection.immutable.ArraySeq
 
 sealed trait BuildState {
+  def codeOption: Option[String]
+
   def buildURI: URI
 
   def workspaceURI: URI =
@@ -22,18 +26,24 @@ object BuildState {
 
   /** Compiled states */
   sealed trait IsCompiled extends BuildState {
-    def dependency: Option[WorkspaceState.IsParsedAndCompiled]
+    def dependencies: ArraySeq[WorkspaceState.IsParsedAndCompiled]
+
+    def findDependency(id: DependencyID): Option[WorkspaceState.IsParsedAndCompiled] =
+      BuildState.findDependency(dependencies, id)
   }
 
   /** Build is successfully parsed */
   case class BuildParsed(buildURI: URI,
                          code: String,
-                         config: RalphcParsedConfig) extends BuildState.IsParsed
+                         config: RalphcParsedConfig) extends BuildState.IsParsed {
+    override def codeOption: Option[String] =
+      Some(code)
+  }
 
   /** Build is successfully compiled */
   case class BuildCompiled(buildURI: URI,
                            code: String,
-                           dependency: Option[WorkspaceState.Compiled],
+                           dependencies: ArraySeq[WorkspaceState.Compiled],
                            dependencyPath: Path,
                            config: RalphcCompiledConfig) extends BuildState.IsCompiled {
     def contractURI: URI =
@@ -41,13 +51,19 @@ object BuildState {
 
     def artifactURI: URI =
       config.artifactPath.toUri
+
+    override def findDependency(id: DependencyID): Option[WorkspaceState.Compiled] =
+      BuildState.findDependency(dependencies, id)
+
+    override def codeOption: Option[String] =
+      Some(code)
   }
 
   /**
    * Represents: A build error occurred.
    *
    * @param buildURI          Build's location
-   * @param code              Build's text content
+   * @param codeOption        Build's text content
    * @param errors            Errors to report for the build
    * @param activateWorkspace Workspace to activate as a result of this error.
    *                          This parameter is crucial because even for an invalid build file, the client
@@ -58,9 +74,23 @@ object BuildState {
    *                          - Some [[WorkspaceState.IsSourceAware]] to replace existing workspace.
    */
   case class BuildErrored(buildURI: URI,
-                          code: Option[String],
+                          codeOption: Option[String],
                           errors: ArraySeq[CompilerMessage.AnyError],
-                          dependency: Option[WorkspaceState.IsParsedAndCompiled],
+                          dependencies: ArraySeq[WorkspaceState.IsParsedAndCompiled],
                           activateWorkspace: Option[WorkspaceState.IsSourceAware]) extends BuildState.IsParsed with BuildState.IsCompiled
+
+  /**
+   * Finds a dependency with the specified ID in the given array of dependencies.
+   *
+   * @param dependencies The array of dependencies to search within.
+   * @param id           The ID of the dependency to find.
+   * @return An option containing the found dependency, or None if not found.
+   */
+  @inline private def findDependency[T <: WorkspaceState.IsParsedAndCompiled](dependencies: ArraySeq[T],
+                                                                              id: DependencyID): Option[T] =
+    dependencies find {
+      dependency =>
+        URIUtil.getFileName(dependency.workspaceURI) == id.dirName
+    }
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildValidator.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildValidator.scala
@@ -82,9 +82,9 @@ object BuildValidator {
       Some(
         BuildErrored( // report errors
           buildURI = parsed.buildURI,
-          code = Some(parsed.code),
+          codeOption = Some(parsed.code),
           errors = ArraySeq.from(errors),
-          dependency = None,
+          dependencies = ArraySeq.empty,
           activateWorkspace = None
         )
       )
@@ -146,9 +146,9 @@ object BuildValidator {
           val errorState =
             BuildErrored( // report errors
               buildURI = parsed.buildURI,
-              code = Some(parsed.code),
+              codeOption = Some(parsed.code),
               errors = ArraySeq.from(errors),
-              dependency = None,
+              dependencies = ArraySeq.empty,
               activateWorkspace = None
             )
 
@@ -160,9 +160,9 @@ object BuildValidator {
         val errors =
           BuildErrored(
             buildURI = parsed.buildURI,
-            code = Some(parsed.code),
+            codeOption = Some(parsed.code),
             errors = ArraySeq(error),
-            dependency = None,
+            dependencies = ArraySeq.empty,
             activateWorkspace = None
           )
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/Dependency.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/Dependency.scala
@@ -5,6 +5,7 @@ import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.log.ClientLogger
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader.DependencyDownloader
 import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorDefaultDependencyDirectoryDoesNotExists
 import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState}
 import org.alephium.ralph.lsp.pc.workspace.{Workspace, WorkspaceState}
@@ -38,20 +39,22 @@ object Dependency {
 
     absoluteDependenciesPath match {
       case Some(absoluteDependenciesPath) =>
-        currentBuild.flatMap(_.dependency) match {
-          case Some(dependency) if absoluteDependenciesPath == dependency.build.dependencyPath =>
-            // Existing build already has compiled dependency and dependencyPath is unchanged. Re-use the dependency.
+        currentBuild match {
+          // Check: Does the existing build already has a compiled dependency and is the dependencyPath is unchanged.
+          case Some(currentBuild: BuildState.BuildCompiled) if currentBuild.dependencyPath == absoluteDependenciesPath =>
+            // Check passed: Re-use the dependency.
             toBuildState(
               parentWorkspaceBuild = parsed,
-              dependencyResult = dependency,
-              absoluteDependenciesPath = absoluteDependenciesPath
+              dependencyResult = currentBuild.dependencies,
+              absoluteDependencyPath = absoluteDependenciesPath
             )
 
           case _ =>
-            // Existing code requires a dependency build.
-            downloadAndCompileStd(
+            // Check failed: Existing code requires a fresh dependency build.
+            downloadAndCompileDependencies(
               parsed = parsed,
-              absoluteDependenciesPath = absoluteDependenciesPath
+              absoluteDependencyPath = absoluteDependenciesPath,
+              dependencyDownloaders = DependencyDownloader.all()
             )
         }
 
@@ -68,52 +71,59 @@ object Dependency {
 
         BuildState.BuildErrored(
           buildURI = parsed.buildURI,
-          code = Some(parsed.code),
+          codeOption = Some(parsed.code),
           errors = ArraySeq(error),
-          dependency = None,
+          dependencies = ArraySeq.empty,
           activateWorkspace = None
         )
     }
   }
 
   /**
-   * Download and compile standard/std dependency for a parsed Build [[BuildState.BuildParsed]].
+   * Download and compile dependencies for a parsed Build [[BuildState.BuildParsed]].
    *
-   * @param parsed Build of the parent workspace compiling this standard/std dependency.
+   * @param parsed Build of the parent workspace compiling the dependencies.
    * @return Compilation result contains in the [[BuildState.IsCompiled]] state for
    *         the parent workspace. If there are errors, they will be in
-   *         the field [[BuildState.BuildErrored.dependency]] as a regular workspace errors.
+   *         the field [[BuildState.BuildErrored.dependencies]] as a regular workspace errors.
    */
-  private def downloadAndCompileStd(parsed: BuildState.BuildParsed,
-                                    absoluteDependenciesPath: Path)(implicit file: FileAccess,
-                                                                    compiler: CompilerAccess,
-                                                                    logger: ClientLogger): BuildState.IsCompiled =
-    DependencyDownloader.downloadStd(
-      dependencyPath = absoluteDependenciesPath,
-      errorIndex = SourceIndexExtra.zero(parsed.buildURI)
-    ) match { // download std
-      case Left(errors) =>
-        // report all download errors at build file level.
-        BuildState.BuildErrored(
-          buildURI = parsed.buildURI,
-          code = Some(parsed.code),
-          errors = errors,
-          dependency = None,
-          activateWorkspace = None
-        )
+  private def downloadAndCompileDependencies(parsed: BuildState.BuildParsed,
+                                             absoluteDependencyPath: Path,
+                                             dependencyDownloaders: ArraySeq[DependencyDownloader])(implicit file: FileAccess,
+                                                                                                    compiler: CompilerAccess,
+                                                                                                    logger: ClientLogger): BuildState.IsCompiled = {
+    val (errors, downloaded) =
+      dependencyDownloaders
+        .map {
+          downloader =>
+            downloader.download(
+              dependencyPath = absoluteDependencyPath,
+              errorIndex = SourceIndexExtra.zero(parsed.buildURI)
+            )
+        }
+        .partitionMap(identity)
 
-      case Right(dependencyStd) =>
-        // Compile std. A dependency is just a regular workspace with a `ralph.json` file.
-        val dependencyStdCompiled =
-          Workspace.parseAndCompile(dependencyStd)
+    if (errors.nonEmpty) {
+      // report all download errors at build file level.
+      BuildState.BuildErrored(
+        buildURI = parsed.buildURI,
+        codeOption = Some(parsed.code),
+        errors = errors.flatten,
+        dependencies = ArraySeq.empty,
+        activateWorkspace = None
+      )
+    } else {
+      // Compile dependency. A dependency is just a regular workspace with a `ralph.json` file.
+      val compiled = downloaded map Workspace.parseAndCompile
 
-        // store it within a compiled build-state
-        toBuildState(
-          parentWorkspaceBuild = parsed,
-          dependencyResult = dependencyStdCompiled,
-          absoluteDependenciesPath = absoluteDependenciesPath
-        )
+      // store it within a compiled build-state
+      toBuildState(
+        parentWorkspaceBuild = parsed,
+        dependencyResult = compiled,
+        absoluteDependencyPath = absoluteDependencyPath
+      )
     }
+  }
 
   /**
    * Convert the dependency compilation result to  a compiled build-state.
@@ -123,37 +133,41 @@ object Dependency {
    * @return A compiled result.
    */
   private def toBuildState(parentWorkspaceBuild: BuildState.BuildParsed,
-                           dependencyResult: WorkspaceState.IsParsedAndCompiled,
-                           absoluteDependenciesPath: Path): BuildState.IsCompiled =
-    dependencyResult match {
-      case compiledStd: WorkspaceState.Compiled => // Dependency compiled OK. Convert the build state to compiled.
-        val (absoluteContractPath, absoluteArtifactPath) =
-          Build.getAbsoluteContractArtifactPaths(parentWorkspaceBuild)
+                           dependencyResult: ArraySeq[WorkspaceState.IsParsedAndCompiled],
+                           absoluteDependencyPath: Path): BuildState.IsCompiled = {
+    val compiledResults =
+      dependencyResult collect {
+        case compiledDependency: WorkspaceState.Compiled =>
+          compiledDependency
+      }
 
-        val config =
-          Config(
-            compilerOptions = parentWorkspaceBuild.config.compilerOptions,
-            contractPath = absoluteContractPath,
-            artifactPath = absoluteArtifactPath
-          )
+    if (compiledResults.length == dependencyResult.length) {
+      val (absoluteContractPath, absoluteArtifactPath) =
+        Build.getAbsoluteContractArtifactPaths(parentWorkspaceBuild)
 
-        // Build OK. Promote build to compiled state.
-        BuildState.BuildCompiled(
-          buildURI = parentWorkspaceBuild.buildURI,
-          code = parentWorkspaceBuild.code,
-          dependency = Some(compiledStd), // store the compiled dependency in the build.
-          dependencyPath = absoluteDependenciesPath,
-          config = config
+      val config =
+        Config(
+          compilerOptions = parentWorkspaceBuild.config.compilerOptions,
+          contractPath = absoluteContractPath,
+          artifactPath = absoluteArtifactPath
         )
 
-      case state @ (_: WorkspaceState.Errored | _: WorkspaceState.UnCompiled) =>
-        // Dependency code has errors. Return error build state and store the errored workspace.
-        BuildState.BuildErrored(
-          buildURI = parentWorkspaceBuild.buildURI,
-          code = Some(parentWorkspaceBuild.code),
-          errors = ArraySeq.empty,
-          dependency = Some(state), // dependency workspace with error.
-          activateWorkspace = None
-        )
+      // Build OK. Promote build to compiled state.
+      BuildState.BuildCompiled(
+        buildURI = parentWorkspaceBuild.buildURI,
+        code = parentWorkspaceBuild.code,
+        dependencies = compiledResults, // store the compiled dependency in the build.
+        dependencyPath = absoluteDependencyPath,
+        config = config
+      )
+    } else {
+      BuildState.BuildErrored(
+        buildURI = parentWorkspaceBuild.buildURI,
+        codeOption = Some(parentWorkspaceBuild.code),
+        errors = ArraySeq.empty,
+        dependencies = dependencyResult, // dependency workspace with error.
+        activateWorkspace = None
+      )
     }
+  }
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/DependencyDownloader.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/DependencyDownloader.scala
@@ -2,8 +2,8 @@ package org.alephium.ralph.lsp.pc.workspace.build.dependency
 
 import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.pc.log.{ClientLogger, StrictImplicitLogging}
-import org.alephium.ralph.lsp.pc.sourcecode.imports.StdInterface
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader.StdInterfaceDownloader
 import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState, RalphcConfig}
 import org.alephium.ralph.{CompilerOptions, SourceIndex}
 
@@ -19,7 +19,7 @@ object DependencyDownloader extends StrictImplicitLogging {
    */
   def downloadStd(dependencyPath: Path,
                   errorIndex: SourceIndex)(implicit logger: ClientLogger): Either[ArraySeq[CompilerMessage.AnyError], WorkspaceState.UnCompiled] =
-    StdInterface.stdInterfaces(
+    StdInterfaceDownloader.stdInterfaces(
       dependencyPath = dependencyPath,
       errorIndex = errorIndex
     ) match {
@@ -46,7 +46,7 @@ object DependencyDownloader extends StrictImplicitLogging {
    */
   private def defaultBuildForStd(dependencyPath: Path): BuildState.BuildCompiled = {
     val workspaceDir =
-      dependencyPath resolve StdInterface.stdFolder
+      dependencyPath resolve StdInterfaceDownloader.stdFolder
 
     val buildDir =
       workspaceDir resolve Build.BUILD_FILE_NAME

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/DependencyID.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/DependencyID.scala
@@ -13,7 +13,7 @@ object DependencyID {
   }
 
   case object BuiltIn extends DependencyID {
-    override def dirName: String = "built_in"
+    override def dirName: String = "builtin"
   }
 
   def all(): ArraySeq[DependencyID] =

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/DependencyID.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/DependencyID.scala
@@ -1,0 +1,25 @@
+package org.alephium.ralph.lsp.pc.workspace.build.dependency
+
+import scala.collection.immutable.ArraySeq
+
+sealed trait DependencyID {
+  def dirName: String
+}
+
+object DependencyID {
+
+  case object Std extends DependencyID {
+    override def dirName: String = "std"
+  }
+
+  case object BuiltIn extends DependencyID {
+    override def dirName: String = "built_in"
+  }
+
+  def all(): ArraySeq[DependencyID] =
+    ArraySeq(
+      DependencyID.Std,
+      DependencyID.BuiltIn
+    )
+
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/BuiltInFunctionDownloader.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/BuiltInFunctionDownloader.scala
@@ -1,0 +1,128 @@
+package org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader
+
+import org.alephium.ralph.lsp.access.compiler.CompilerAccess
+import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
+import org.alephium.ralph.lsp.pc.log.ClientLogger
+import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
+import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
+import org.alephium.ralph.{BuiltIn, SourceIndex}
+
+import java.nio.file.Path
+import scala.collection.immutable.ArraySeq
+
+private object BuiltInFunctionDownloader extends DependencyDownloader {
+
+  /**
+   * Downloads built-in function source files.
+   *
+   * @param dependencyPath The directory where dependencies are located.
+   * @return An iterable over the downloaded built-in source files.
+   */
+  protected def _download(dependencyPath: Path,
+                          errorIndex: SourceIndex)(implicit logger: ClientLogger): Either[ArraySeq[CompilerMessage.AnyError], WorkspaceState.UnCompiled] = {
+    val workspaceDir =
+      dependencyPath resolve DependencyID.BuiltIn.dirName
+
+    val sourceCode =
+      toSourceCodeState(
+        workspacePath = workspaceDir,
+        functions = BuiltInFunctionInfo.build()
+      )
+
+    // a default build file.
+    val build =
+      DependencyDownloader.defaultBuild(workspaceDir)
+
+    val workspace =
+      WorkspaceState.UnCompiled(
+        build = build,
+        sourceCode = sourceCode.to(ArraySeq)
+      )
+
+    Right(workspace)
+  }
+
+  /**
+   * Converts [[BuiltInFunctionInfo]] to [[SourceCodeState.UnCompiled]].
+   *
+   * @param workspacePath The directory where dependencies are located.
+   * @param functions     The built-in function information.
+   * @return An iterable over the converted [[SourceCodeState.UnCompiled]] objects.
+   */
+  private def toSourceCodeState(workspacePath: Path,
+                                functions: Seq[BuiltInFunctionInfo]): Iterable[SourceCodeState.UnCompiled] =
+    functions
+      .groupBy(_.category)
+      .map {
+        case (category, functions) =>
+          val interface =
+            toInterface(
+              category = category,
+              functions = functions
+            )
+
+          val filePath =
+            workspacePath.resolve(s"${category.toString().toLowerCase}_functions.${CompilerAccess.RALPH_FILE_EXTENSION}")
+
+          SourceCodeState.UnCompiled(
+            fileURI = filePath.toUri,
+            code = interface
+          )
+      }
+
+  /**
+   * Converts built-in function information to a Ralph Interface which is parseable and compilable.
+   *
+   * @param category  The category of built-in functions.
+   * @param functions The built-in function information.
+   * @return A string representing the generated interface.
+   */
+  private def toInterface(category: BuiltIn.Category,
+                          functions: Seq[BuiltInFunctionInfo]): String = {
+    val functionsCode =
+      functions
+        .sorted
+        .map {
+          function =>
+            val params =
+              if (function.params.nonEmpty)
+                function
+                  .params
+                  .map(param => s"  // $param")
+                  .mkString("\n", "\n", "")
+              else
+                ""
+
+            s"""  // ${function.doc}$params
+               |  // ${function.returns}
+               |  ${function.signature}
+               |""".stripMargin
+        }
+        .mkString("\n")
+
+    val interface =
+      s"""Interface ${category}Functions {
+         |
+         |$functionsCode
+         |}
+         |""".stripMargin
+
+    // replace the non-compilable code with compilable code.
+    replaceNonStandardCode(interface)
+  }
+
+  /**
+   * Replaces non-standard code elements.
+   *
+   * @param code The code string to be processed.
+   * @return The code string with non-standard elements replaced.
+   */
+  private def replaceNonStandardCode(code: String): String =
+    code
+      .replaceAll("\\?:", ":")
+      .replaceAll("<Contract>", "TheContract")
+      .replaceAll("Bool\\|I256\\|U256\\|Address", "From")
+      .replaceAll("\\.\\.\\.any", "any: Sequence")
+
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/BuiltInFunctionInfo.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/BuiltInFunctionInfo.scala
@@ -1,0 +1,66 @@
+package org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader
+
+import org.alephium.ralph.BuiltIn
+import org.alephium.ralph.BuiltIn.Category
+
+object BuiltInFunctionInfo {
+
+  /**
+   * This code is borrowed from `alephium-tools` project.
+   *
+   * @see <a href="https://github.com/alephium/alephium/blob/master/tools/src/main/scala/org/alephium/tools/BuiltInFunctions.scala">BuiltInFunctions.scala</a>
+   */
+  implicit val ordering: Ordering[BuiltInFunctionInfo] = {
+    val orders =
+      Seq[BuiltIn.Category](
+        Category.Contract,
+        Category.SubContract,
+        Category.Asset,
+        Category.Utils,
+        Category.Chain,
+        Category.Conversion,
+        Category.ByteVec,
+        Category.Cryptography
+      )
+
+    Ordering.by {
+      functionInfo =>
+        orders.indexOf(functionInfo.category)
+    }
+  }
+
+  /**
+   * Builds a sequence of [[BuiltInFunctionInfo]] instances representing built-in functions supported by Ralph.
+   */
+  def build(): Seq[BuiltInFunctionInfo] =
+    BuiltIn
+      .statefulFuncsSeq
+      .map {
+        case (_, function) =>
+          BuiltInFunctionInfo(
+            name = function.name,
+            category = function.category,
+            signature = function.signature,
+            doc = function.doc,
+            params = function.params,
+            returns = function.returns
+          )
+      }
+}
+
+/**
+ * Represents information about a built-in function.
+ *
+ * @param name      The name of the built-in function.
+ * @param category  The category of the built-in function.
+ * @param signature The signature of the built-in function.
+ * @param doc       The documentation of the built-in function.
+ * @param params    The parameters of the built-in function.
+ * @param returns   The return type of the built-in function.
+ */
+final case class BuiltInFunctionInfo(name: String,
+                                     category: Category,
+                                     signature: String,
+                                     doc: String,
+                                     params: Seq[String],
+                                     returns: String)

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/DependencyDownloader.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/DependencyDownloader.scala
@@ -1,9 +1,8 @@
-package org.alephium.ralph.lsp.pc.workspace.build.dependency
+package org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader
 
 import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.pc.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
-import org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader.StdInterfaceDownloader
 import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState, RalphcConfig}
 import org.alephium.ralph.{CompilerOptions, SourceIndex}
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/StdInterfaceDownloader.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/StdInterfaceDownloader.scala
@@ -1,4 +1,4 @@
-package org.alephium.ralph.lsp.pc.sourcecode.imports
+package org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader
 
 import org.alephium.ralph.SourceIndex
 import org.alephium.ralph.lsp.pc.log.{ClientLogger, StrictImplicitLogging}
@@ -11,7 +11,7 @@ import scala.io.Source
 import scala.jdk.CollectionConverters.{IteratorHasAsScala, MapHasAsJava}
 import scala.util.{Failure, Success, Using}
 
-object StdInterface extends StrictImplicitLogging {
+object StdInterfaceDownloader extends StrictImplicitLogging {
 
   val stdFolder = "std"
 
@@ -59,7 +59,7 @@ object StdInterface extends StrictImplicitLogging {
       case Failure(throwable) =>
         val error =
           ErrorDownloadingDependency(
-            dependencyID = StdInterface.stdFolder,
+            dependencyID = StdInterfaceDownloader.stdFolder,
             throwable = throwable,
             index = errorIndex
           )

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/error/ErrorEmptyErrorsOnDownload.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/error/ErrorEmptyErrorsOnDownload.scala
@@ -1,0 +1,11 @@
+package org.alephium.ralph.lsp.pc.workspace.build.error
+
+import org.alephium.ralph.SourceIndex
+import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader.DependencyDownloader
+
+case class ErrorEmptyErrorsOnDownload(downloader: DependencyDownloader,
+                                      index: SourceIndex) extends CompilerMessage.Error {
+  override def message: String =
+    s"Downloader '${downloader.getClass.getSimpleName}' resulted in empty errors."
+}

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
@@ -7,6 +7,7 @@ import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.access.util.TestCodeUtil
 import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.alephium.ralph.lsp.pc.log.ClientLogger
+import org.alephium.ralph.lsp.pc.search.completion.Suggestion
 import org.alephium.ralph.lsp.pc.search.gotodef.data.GoToLocation
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, TestSourceCode}
 import org.alephium.ralph.lsp.pc.workspace.build.TestBuild
@@ -80,6 +81,17 @@ object TestCodeProvider {
     searchResult should contain theSameElementsAs expectedGoToLocations
     ()
   }
+
+  /**
+   * Runs code completion where `@@` is positioned.
+   *
+   * @param code The code to run code completion on.
+   * @return A list of code completion suggestions.
+   */
+  def suggest(code: String): List[Suggestion] =
+    TestCodeProvider[Suggestion](code)
+      ._1
+      .toList
 
   /**
    * Run test completion.

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
@@ -9,11 +9,12 @@ import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.search.completion.Suggestion
 import org.alephium.ralph.lsp.pc.search.gotodef.data.GoToLocation
-import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, TestSourceCode}
+import org.alephium.ralph.lsp.pc.sourcecode.{TestSourceCode, SourceCodeState}
 import org.alephium.ralph.lsp.pc.workspace.build.TestBuild
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
-import org.alephium.ralph.lsp.pc.workspace.{TestWorkspace, Workspace, WorkspaceState}
+import org.alephium.ralph.lsp.pc.workspace.{WorkspaceState, TestWorkspace, Workspace}
 import org.scalacheck.Gen
+import org.scalatest.Assertion
 import org.scalatest.EitherValues._
 import org.scalatest.OptionValues._
 import org.scalatest.matchers.should.Matchers._
@@ -60,7 +61,7 @@ object TestCodeProvider {
    *
    * @param code The containing `@@` and `>>...<<` symbols.
    */
-  def goTo(code: String): Unit = {
+  def goTo(code: String): Assertion = {
     val (expectedLineRanges, codeWithoutGoToSymbols, _, _) =
         TestCodeUtil.lineRanges(code)
 
@@ -80,7 +81,6 @@ object TestCodeProvider {
 
     // assert that the go-to definition jumps to all text between the go-to symbols << and >>
     searchResult.toList should contain theSameElementsAs expectedGoToLocations
-    ()
   }
 
   /**
@@ -91,7 +91,7 @@ object TestCodeProvider {
    * @param expected Expected resulting built-in function.
    */
   def goToBuiltIn(code: String,
-                  expected: Option[String]): Unit = {
+                  expected: Option[String]): Assertion = {
     val (_, codeWithoutGoToSymbols, _, _) =
       TestCodeUtil.lineRanges(code)
 
@@ -131,11 +131,9 @@ object TestCodeProvider {
 
         // assert that the go-to definition jumps to all text between the go-to symbols << and >>
         searchResult.toList should contain theSameElementsAs expectedResults
-        ()
 
       case None =>
         searchResult shouldBe empty
-        ()
     }
   }
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
@@ -30,7 +30,7 @@ object TestCodeProvider {
    *   TestCompleter(""" import "@@" """)
    * }}}
    */
-  def apply[A](code: String)(implicit provider: CodeProvider[A]): (ArraySeq[A], SourceCodeState.IsCodeAware) = {
+  def apply[A](code: String)(implicit provider: CodeProvider[A]): (Iterator[A], SourceCodeState.IsCodeAware) = {
     val (linePosition,_ , codeWithoutAtSymbol) = TestCodeUtil.indicatorPosition(code)
 
     // run completion at that line and character
@@ -78,7 +78,7 @@ object TestCodeProvider {
       }
 
     // assert that the go-to definition jumps to all text between the go-to symbols << and >>
-    searchResult should contain theSameElementsAs expectedGoToLocations
+    searchResult.toList should contain theSameElementsAs expectedGoToLocations
     ()
   }
 
@@ -103,7 +103,7 @@ object TestCodeProvider {
    */
   private def apply[A](line: Int,
                        character: Int,
-                       code: Gen[String])(implicit provider: CodeProvider[A]): (Either[CompilerMessage.Error, ArraySeq[A]], WorkspaceState.IsParsedAndCompiled) = {
+                       code: Gen[String])(implicit provider: CodeProvider[A]): (Either[CompilerMessage.Error, Iterator[A]], WorkspaceState.IsParsedAndCompiled) = {
     implicit val clientLogger: ClientLogger = TestClientLogger
     implicit val file: FileAccess = FileAccess.disk
     implicit val compiler: CompilerAccess = CompilerAccess.ralphc

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/completion/ImportCompleterSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/completion/ImportCompleterSpec.scala
@@ -4,7 +4,7 @@ import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.alephium.ralph.lsp.pc.log.ClientLogger
-import org.alephium.ralph.lsp.pc.search.TestCodeProvider
+import org.alephium.ralph.lsp.pc.search.TestCodeProvider.suggest
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -16,18 +16,18 @@ class ImportCompleterSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "cursor is before the quotes" in {
-      TestCodeProvider[Suggestion]("""import @@"std" """)._1 shouldBe empty
-      TestCodeProvider[Suggestion]("""import @@"std/" """)._1 shouldBe empty
+      suggest("""import @@"std" """) shouldBe empty
+      suggest("""import @@"std/" """) shouldBe empty
     }
 
     "cursor is after the quotes" in {
-      TestCodeProvider[Suggestion]("""import "std"@@ """)._1 shouldBe empty
-      TestCodeProvider[Suggestion]("""import "std/"@@ """)._1 shouldBe empty
+      suggest("""import "std"@@ """) shouldBe empty
+      suggest("""import "std/"@@ """) shouldBe empty
     }
 
     "cursor is right after the import statement" in {
-      TestCodeProvider[Suggestion]("""import@@ "std" """)._1 shouldBe empty
-      TestCodeProvider[Suggestion]("""import@@ "std/" """)._1 shouldBe empty
+      suggest("""import@@ "std" """) shouldBe empty
+      suggest("""import@@ "std/" """) shouldBe empty
     }
   }
 
@@ -50,17 +50,17 @@ class ImportCompleterSpec extends AnyWordSpec with Matchers {
       }
 
     "cursor is between the quotes" in {
-      TestCodeProvider[Suggestion]("""import "@@" """)._1 should contain theSameElementsAs expected
-      TestCodeProvider[Suggestion]("""import "s@@" """)._1 should contain theSameElementsAs expected
-      TestCodeProvider[Suggestion]("""import "st@@" """)._1 should contain theSameElementsAs expected
-      TestCodeProvider[Suggestion]("""import "std@@" """)._1 should contain theSameElementsAs expected
+      suggest("""import "@@" """) should contain theSameElementsAs expected
+      suggest("""import "s@@" """) should contain theSameElementsAs expected
+      suggest("""import "st@@" """) should contain theSameElementsAs expected
+      suggest("""import "std@@" """) should contain theSameElementsAs expected
     }
 
     "cursor is before the forward slash" in {
-      TestCodeProvider[Suggestion]("""import "@@std/" """)._1 should contain theSameElementsAs expected
-      TestCodeProvider[Suggestion]("""import "s@@td/" """)._1 should contain theSameElementsAs expected
-      TestCodeProvider[Suggestion]("""import "st@@d/" """)._1 should contain theSameElementsAs expected
-      TestCodeProvider[Suggestion]("""import "std@@/" """)._1 should contain theSameElementsAs expected
+      suggest("""import "@@std/" """) should contain theSameElementsAs expected
+      suggest("""import "s@@td/" """) should contain theSameElementsAs expected
+      suggest("""import "st@@d/" """) should contain theSameElementsAs expected
+      suggest("""import "std@@/" """) should contain theSameElementsAs expected
     }
   }
 
@@ -83,11 +83,11 @@ class ImportCompleterSpec extends AnyWordSpec with Matchers {
       }
 
     "cursor is after the forward slash" in {
-      TestCodeProvider[Suggestion]("""import "std/@@" """)._1 should contain theSameElementsAs expected
-      TestCodeProvider[Suggestion]("""import "std/fungible@@" """)._1 should contain theSameElementsAs expected
-      TestCodeProvider[Suggestion]("""import "std/fungible_@@" """)._1 should contain theSameElementsAs expected
-      TestCodeProvider[Suggestion]("""import "std/nft@@" """)._1 should contain theSameElementsAs expected
-      TestCodeProvider[Suggestion]("""import "std/nft_@@" """)._1 should contain theSameElementsAs expected
+      suggest("""import "std/@@" """) should contain theSameElementsAs expected
+      suggest("""import "std/fungible@@" """) should contain theSameElementsAs expected
+      suggest("""import "std/fungible_@@" """) should contain theSameElementsAs expected
+      suggest("""import "std/nft@@" """) should contain theSameElementsAs expected
+      suggest("""import "std/nft_@@" """) should contain theSameElementsAs expected
     }
   }
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToBuiltInFunctionsSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToBuiltInFunctionsSpec.scala
@@ -1,0 +1,85 @@
+package org.alephium.ralph.lsp.pc.search.gotodef
+
+import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class GoToBuiltInFunctionsSpec extends AnyWordSpec with Matchers {
+
+  "return empty" when {
+    "built-in does not exists" in {
+      goToBuiltIn(
+        code =
+          """
+            |Contract Test() {
+            |  pub fn function() -> () {
+            |    bla@@h!()
+            |  }
+            |}
+            |""".stripMargin,
+
+        expected =
+          None
+      )
+    }
+  }
+
+  "return non-empty" when {
+    "assert!" in {
+      goToBuiltIn(
+        code =
+          """
+            |Contract Test() {
+            |  pub fn function() -> () {
+            |    @@assert!()
+            |  }
+            |}
+            |""".stripMargin,
+
+        expected =
+          Some("""fn assert!(condition:Bool, errorCode:U256) -> ()""")
+      )
+    }
+
+    "verifyAbsoluteLocktime!" in {
+      goToBuiltIn(
+        code =
+          """
+            |Contract Test() {
+            |  pub fn function() -> () {
+            |    for (let mut index = 0; index <= 4; index = index + 1) {
+            |      @@verifyAbsoluteLocktime!()
+            |    }
+            |  }
+            |}
+            |""".stripMargin,
+
+        expected =
+          Some("""fn verifyAbsoluteLocktime!(lockUntil:U256) -> ()""")
+      )
+    }
+
+    "there are duplicate local and built-in function names" in {
+      goToBuiltIn(
+        code =
+          """
+            |Contract Test() {
+            |
+            |  // this function should not get selected.
+            |  fn assert() -> () {
+            |
+            |  }
+            |
+            |  pub fn function() -> () {
+            |    @@assert!()
+            |  }
+            |}
+            |""".stripMargin,
+
+        expected =
+          Some("""fn assert!(condition:Bool, errorCode:U256) -> ()""")
+      )
+    }
+  }
+
+}

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToConstantUsagesSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToConstantUsagesSpec.scala
@@ -1,6 +1,7 @@
 package org.alephium.ralph.lsp.pc.search.gotodef
 
 import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
+import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -25,7 +26,7 @@ class GoToConstantUsagesSpec extends AnyWordSpec with Matchers {
 
   "return non-empty" when {
     "constant has multiple usages" when {
-      def doTest(contractName: String): Unit =
+      def doTest(contractName: String): Assertion =
         goTo(
           s"""
              |Contract $contractName() {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFunctionSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFunctionSpec.scala
@@ -57,5 +57,31 @@ class GoToFunctionSpec extends AnyWordSpec with Matchers {
           |""".stripMargin
       )
     }
+
+    "function is an interface function" should {
+      "highlight the entire function signature" in {
+        goTo(
+          """
+            |Abstract Contract Test() {
+            |
+            |  >>fn function() -> ()<<
+            |
+            |  >>fn function(address: Address) -> ()<<
+            |
+            |  // this function has a body so only the function ID is highlighted.
+            |  fn >>function<<() -> () {
+            |     assert!()
+            |  }
+            |
+            |  fn main() -> () {
+            |    function@@()
+            |  }
+            |
+            |}
+            |""".stripMargin
+        )
+
+      }
+    }
   }
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFunctionUsageSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFunctionUsageSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 /** Test for go to function */
-class GoToFunctionCallsSpec extends AnyWordSpec with Matchers {
+class GoToFunctionUsageSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "function calls do not exist" in {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeCompileSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeCompileSpec.scala
@@ -2,7 +2,7 @@ package org.alephium.ralph.lsp.pc.sourcecode
 
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.file.FileAccess
-import org.alephium.ralph.lsp.pc.workspace.build.dependency.TestDependency
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.{DependencyID, TestDependency}
 import org.alephium.ralph.lsp.{TestCode, TestFile}
 import org.alephium.ralph.{CompiledContract, CompiledScript, CompilerOptions}
 import org.scalatest.EitherValues._
@@ -25,7 +25,7 @@ class SourceCodeCompileSpec extends AnyWordSpec with Matchers with ScalaCheckDri
         val result =
           SourceCode.compile(
             sourceCode = ArraySeq.empty,
-            dependency = None,
+            dependency = ArraySeq.empty,
             compilerOptions = CompilerOptions.Default,
             workspaceErrorURI = TestFile.genFolderURI().sample.value
           ).value
@@ -43,7 +43,7 @@ class SourceCodeCompileSpec extends AnyWordSpec with Matchers with ScalaCheckDri
         val result =
           SourceCode.compile(
             sourceCode = ArraySeq.empty,
-            dependency = dependencyBuild.dependency.map(_.sourceCode),
+            dependency = dependencyBuild.findDependency(DependencyID.Std).value.sourceCode,
             compilerOptions = CompilerOptions.Default,
             workspaceErrorURI = TestFile.genFolderURI().sample.value
           ).value
@@ -77,7 +77,7 @@ class SourceCodeCompileSpec extends AnyWordSpec with Matchers with ScalaCheckDri
           SourceCode
             .compile(
               sourceCode = source,
-              dependency = None,
+              dependency = ArraySeq.empty,
               compilerOptions = CompilerOptions.Default,
               workspaceErrorURI = Paths.get(source.head.fileURI).getParent.toUri // workspace URI
             )

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeParseSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeParseSpec.scala
@@ -77,7 +77,7 @@ class SourceCodeParseSpec extends AnyWordSpec with Matchers with ScalaCheckDrive
               SourceCode
                 .compile(
                   sourceCode = ArraySeq(parsed),
-                  dependency = None,
+                  dependency = ArraySeq.empty,
                   compilerOptions = compilerOptions,
                   workspaceErrorURI = parsed.fileURI
                 )

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
@@ -151,7 +151,7 @@ object TestSourceCode {
     val result =
       SourceCode.compile(
         sourceCode = ArraySeq(parsed),
-        dependency = None,
+        dependency = ArraySeq.empty,
         compilerOptions = CompilerOptions.Default,
         workspaceErrorURI = parsed.fileURI
       )

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/ImporterSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/ImporterSpec.scala
@@ -43,7 +43,7 @@ class ImporterSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenProper
         val importedCode =
           Importer.typeCheck(
             sourceCode = ArraySeq(parsed),
-            dependency = None
+            dependency = ArraySeq.empty
           )
 
         // there are no imports
@@ -111,7 +111,7 @@ class ImporterSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenProper
         val importedCode =
           Importer.typeCheck(
             sourceCode = ArraySeq(myCode),
-            dependency = Some(ArraySeq(dependency))
+            dependency = ArraySeq(dependency)
           ).value
 
         // type check returns the dependency.
@@ -149,7 +149,7 @@ class ImporterSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenProper
         val actualError =
           Importer.typeCheck(
             sourceCode = ArraySeq(myCode),
-            dependency = None
+            dependency = ArraySeq.empty
           ).left.value
 
         // The error must report the import's AST as UnknownImport

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuild1Spec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuild1Spec.scala
@@ -48,9 +48,9 @@ class WorkspaceBuild1Spec extends AnyWordSpec with Matchers with ScalaCheckDrive
               result shouldBe
                 BuildState.BuildErrored(
                   buildURI = workspace.buildURI,
-                  code = None,
+                  codeOption = None,
                   errors = ArraySeq(ErrorBuildFileNotFound(workspace.buildURI)),
-                  dependency = None,
+                  dependencies = ArraySeq.empty,
                   activateWorkspace = None
                 )
           }
@@ -74,9 +74,9 @@ class WorkspaceBuild1Spec extends AnyWordSpec with Matchers with ScalaCheckDrive
               result shouldBe
                 BuildState.BuildErrored(
                   buildURI = workspace.buildURI,
-                  code = None,
+                  codeOption = None,
                   errors = ArraySeq(ErrorBuildFileNotFound(workspace.buildURI)),
-                  dependency = None,
+                  dependencies = ArraySeq.empty,
                   activateWorkspace = None
                 )
 
@@ -114,7 +114,7 @@ class WorkspaceBuild1Spec extends AnyWordSpec with Matchers with ScalaCheckDrive
               result shouldBe
                 BuildState.BuildErrored(
                   buildURI = workspace.buildURI,
-                  code = Some(buildCode),
+                  codeOption = Some(buildCode),
                   errors =
                     ArraySeq(
                       ErrorInvalidBuildSyntax(
@@ -123,7 +123,7 @@ class WorkspaceBuild1Spec extends AnyWordSpec with Matchers with ScalaCheckDrive
                         message = """expected json value got "b""""
                       )
                     ),
-                  dependency = None,
+                  dependencies = ArraySeq.empty,
                   activateWorkspace = None
                 )
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuild3Spec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuild3Spec.scala
@@ -58,7 +58,7 @@ class WorkspaceBuild3Spec extends AnyWordSpec with Matchers with ScalaCheckDrive
         val expectedBuildError =
           BuildState.BuildErrored(
             buildURI = buildCompiled.buildURI,
-            code = Some("blah"), // the invalid build code is carried forward
+            codeOption = Some("blah"), // the invalid build code is carried forward
             errors =
               ArraySeq(
                 ErrorInvalidBuildSyntax( /// the syntax error
@@ -67,7 +67,7 @@ class WorkspaceBuild3Spec extends AnyWordSpec with Matchers with ScalaCheckDrive
                   message = """expected json value got "b""""
                 )
               ),
-            dependency = buildCompiled.dependency, // dependency is carried forward
+            dependencies = buildCompiled.dependencies, // dependency is carried forward
             activateWorkspace = // new workspace is activated with input source-code
               Some(
                 WorkspaceState.UnCompiled(

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceDeleteOrCreateSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceDeleteOrCreateSpec.scala
@@ -66,9 +66,9 @@ class WorkspaceDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCh
                   Some(
                     BuildState.BuildErrored(
                       buildURI = build.buildURI,
-                      code = None, // because workspace is in created state
+                      codeOption = None, // because workspace is in created state
                       errors = ArraySeq(ErrorBuildFileNotFound(build.buildURI)), // the error is reported
-                      dependency = None, // because workspace is in created state
+                      dependencies = ArraySeq.empty, // because workspace is in created state
                       activateWorkspace = None
                     )
                   )
@@ -131,9 +131,9 @@ class WorkspaceDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCh
                   Some(
                     BuildState.BuildErrored(
                       buildURI = build.buildURI,
-                      code = None, // no code is stored because the build is deleted
+                      codeOption = None, // no code is stored because the build is deleted
                       errors = ArraySeq(ErrorBuildFileNotFound(build.buildURI)), // the error is reported
-                      dependency = build.dependency, // dependency from previous build is carried
+                      dependencies = build.dependencies, // dependency from previous build is carried
                       activateWorkspace = Some(workspace) // the same workspace with inside-code and outside-code is stored.
                     )
                   )

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceInitialiseSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceInitialiseSpec.scala
@@ -68,11 +68,11 @@ class WorkspaceInitialiseSpec extends AnyWordSpec with Matchers with ScalaCheckD
               // randomly set dependency to None or Some
               val dependencyRandom =
                 Gen
-                  .oneOf(None, compiled.dependency)
+                  .oneOf(ArraySeq.empty, compiled.dependencies)
                   .sample
                   .get
 
-              compiled.copy(dependency = dependencyRandom)
+              compiled.copy(dependencies = dependencyRandom)
           }
 
       forAll(generator) {
@@ -96,9 +96,9 @@ class WorkspaceInitialiseSpec extends AnyWordSpec with Matchers with ScalaCheckD
           val expectedError =
             BuildState.BuildErrored(
               buildURI = initialBuild.buildURI,
-              code = Some(initialBuild.code),
+              codeOption = Some(initialBuild.code),
               errors = ArraySeq(errorIO), // the error is reported
-              dependency = initialBuild.dependency, // dependency is carried forward
+              dependencies = initialBuild.dependencies, // dependency is carried forward
               activateWorkspace = None // continue with existing workspace
             )
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildSpec.scala
@@ -69,9 +69,9 @@ class BuildSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyC
             val expectedWorkspace =
               BuildState.BuildErrored(
                 buildURI = outsideBuild.buildURI, // must not be expected build-file location.
-                code = buildCode,
+                codeOption = buildCode,
                 errors = ArraySeq(expectedError),
-                dependency = insideBuild.dependency, // compiled dependency is carried to next compilation
+                dependencies = insideBuild.dependencies, // compiled dependency is carried to next compilation
                 activateWorkspace = None
               )
 
@@ -139,9 +139,9 @@ class BuildSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyC
             val expectedWorkspace =
               BuildState.BuildErrored(
                 buildURI = build.buildURI,
-                code = buildCode,
+                codeOption = buildCode,
                 errors = ArraySeq(expectedError),
-                dependency = currentBuild.dependency, // compiled dependency is carried to next compilation
+                dependencies = currentBuild.dependencies, // compiled dependency is carried to next compilation
                 activateWorkspace = None
               )
 
@@ -176,9 +176,9 @@ class BuildSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyC
           val expected =
             BuildState.BuildErrored(
               buildURI = buildURI,
-              code = None,
+              codeOption = None,
               errors = ArraySeq(ErrorBuildFileNotFound(buildURI)),
-              dependency = None,
+              dependencies = ArraySeq.empty,
               activateWorkspace = None
             )
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/RalphcConfigSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/RalphcConfigSpec.scala
@@ -127,7 +127,7 @@ class RalphcConfigSpec extends AnyWordSpec with Matchers {
             currentBuild = None
           ).asInstanceOf[BuildState.BuildCompiled]
 
-      compiledStd.dependency shouldBe defined
+      compiledStd.dependencies should have size 2
 
       val expectedDependenciesPath =
         config.dependencyPath match {
@@ -142,7 +142,7 @@ class RalphcConfigSpec extends AnyWordSpec with Matchers {
         BuildState.BuildCompiled(
           buildURI = expectedBuildPath.toUri,
           code = expectedCode,
-          dependency = compiledStd.dependency,
+          dependencies = compiledStd.dependencies,
           dependencyPath = expectedDependenciesPath,
           config = expectedCompiledConfig
         )

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/TestDependency.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/TestDependency.scala
@@ -38,7 +38,7 @@ object TestDependency {
       ).asInstanceOf[BuildState.BuildCompiled]
 
     // dependency should exists in the build
-    dependencyBuild.dependency shouldBe defined
+    dependencyBuild.dependencies should have size 2
 
     // return the build (the build contains the std workspace)
     dependencyBuild

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/StdInterfaceDownloaderSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/StdInterfaceDownloaderSpec.scala
@@ -3,6 +3,7 @@ package org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader
 import org.alephium.ralph.lsp.TestFile
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra
 import org.alephium.ralph.lsp.pc.client.TestClientLogger
+import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
 import org.scalatest.EitherValues._
 import org.scalatest.OptionValues._
 import org.scalatest.matchers.should.Matchers
@@ -17,10 +18,10 @@ class StdInterfaceDownloaderSpec extends AnyWordSpec with Matchers {
 
   "stdInterfaces" should {
     val stdInterfaces =
-      StdInterfaceDownloader.stdInterfaces(
+      StdInterfaceDownloader.download(
         dependencyPath = Paths.get("my_workspace"),
         errorIndex = SourceIndexExtra.zero(TestFile.genFolderURI().sample.value)
-      ).value
+      ).value.sourceCode.map(_.asInstanceOf[SourceCodeState.UnCompiled])
 
     "be defined" in {
       //Will fail if web3 wasn't download correctly

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/StdInterfaceDownloaderSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/StdInterfaceDownloaderSpec.scala
@@ -1,4 +1,4 @@
-package org.alephium.ralph.lsp.pc.sourcecode.imports
+package org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader
 
 import org.alephium.ralph.lsp.TestFile
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra
@@ -10,14 +10,14 @@ import org.scalatest.wordspec.AnyWordSpec
 
 import java.nio.file.Paths
 
-class StdInterfaceSpec extends AnyWordSpec with Matchers {
+class StdInterfaceDownloaderSpec extends AnyWordSpec with Matchers {
 
   implicit val logger: TestClientLogger.type =
     TestClientLogger
 
   "stdInterfaces" should {
     val stdInterfaces =
-      StdInterface.stdInterfaces(
+      StdInterfaceDownloader.stdInterfaces(
         dependencyPath = Paths.get("my_workspace"),
         errorIndex = SourceIndexExtra.zero(TestFile.genFolderURI().sample.value)
       ).value


### PR DESCRIPTION
- GoTo built-in functions
  - Built-in functions are stored as `Interfaces` and as a regular dependency, similar to `std`. These built-in `Interfaces` are not accessible outside go-to definition. They are parsed and compiled so a valid AST is available for them, to be used by go-to definitions.
     ![image](https://github.com/alephium/ralph-lsp/assets/1773953/5cb49431-f432-4b1a-b05a-f2bf03d56f62)
  - The documentation for built-in functions provided by node generates non-standard code, such as `issueTo?:Address`,  `contract:<Contract>` etc., these get replaced [here](https://github.com/alephium/ralph-lsp/compare/goto_built_in?expand=1#diff-9d8996b7faa853cec8567461bf9d9be8f19f2a642812bced90048fe17d3978e8R121). 
- Support for multiple dependencies. See `trait DependencyDownloader`.
- Towards #105 