### PR TITLE
Moved `PCState` function out from `Workspace` to `PC` 

### DIFF
--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
@@ -6,11 +6,11 @@ import org.alephium.ralph.lsp.pc.log.StrictImplicitLogging
 import org.alephium.ralph.lsp.pc.search.CodeProvider
 import org.alephium.ralph.lsp.pc.search.completion.Suggestion
 import org.alephium.ralph.lsp.pc.search.gotodef.data.GoToLocation
-import org.alephium.ralph.lsp.pc.state.{PCState, PCStateDiagnostics}
 import org.alephium.ralph.lsp.pc.util.CollectionUtil
 import org.alephium.ralph.lsp.pc.util.URIUtil.uri
 import org.alephium.ralph.lsp.pc.workspace._
 import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorUnknownFileType
+import org.alephium.ralph.lsp.pc.{PCState, PCStateDiagnostics}
 import org.alephium.ralph.lsp.server
 import org.alephium.ralph.lsp.server.MessageMethods.{WORKSPACE_WATCHED_FILES, WORKSPACE_WATCHED_FILES_ID}
 import org.alephium.ralph.lsp.server.RalphLangServer._

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
@@ -10,7 +10,7 @@ import org.alephium.ralph.lsp.pc.util.CollectionUtil
 import org.alephium.ralph.lsp.pc.util.URIUtil.uri
 import org.alephium.ralph.lsp.pc.workspace._
 import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorUnknownFileType
-import org.alephium.ralph.lsp.pc.{PCState, PCStateDiagnostics}
+import org.alephium.ralph.lsp.pc.{PC, PCState, PCStateDiagnostics}
 import org.alephium.ralph.lsp.server
 import org.alephium.ralph.lsp.server.MessageMethods.{WORKSPACE_WATCHED_FILES, WORKSPACE_WATCHED_FILES_ID}
 import org.alephium.ralph.lsp.server.RalphLangServer._
@@ -283,7 +283,7 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
 
         // Build OK! process delete or create
         val newPCState =
-          Workspace.deleteOrCreate(
+          PC.deleteOrCreate(
             events = events,
             pcState = currentPCState
           )
@@ -440,7 +440,7 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
         getPCState()
 
       val newPCState =
-        Workspace.changed(
+        PC.changed(
           fileURI = fileURI,
           code = code,
           pcState = currentPCState

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
@@ -156,10 +156,7 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
           rootURI getOrElse notifyAndThrow(ResponseError.WorkspaceFolderNotSupplied)
 
         val pcState =
-          PCState(
-            workspace = Workspace.create(workspaceURI),
-            buildErrors = None
-          )
+          PC.initialise(workspaceURI)
 
         setPCState(pcState)
 

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/state/ServerState.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/state/ServerState.scala
@@ -1,6 +1,6 @@
 package org.alephium.ralph.lsp.server.state
 
-import org.alephium.ralph.lsp.pc.state.PCState
+import org.alephium.ralph.lsp.pc.PCState
 import org.alephium.ralph.lsp.server.RalphLangClient
 
 import java.util.concurrent.{Future => JFuture}

--- a/lsp-server/src/test/scala/org/alephium/ralph/lsp/server/RalphLangServerSpec.scala
+++ b/lsp-server/src/test/scala/org/alephium/ralph/lsp/server/RalphLangServerSpec.scala
@@ -2,7 +2,7 @@ package org.alephium.ralph.lsp.server
 
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.file.FileAccess
-import org.alephium.ralph.lsp.pc.state.PCState
+import org.alephium.ralph.lsp.pc.PCState
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.server.state.{ServerState, Trace}
 import org.eclipse.lsp4j._

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PC.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PC.scala
@@ -13,6 +13,18 @@ import scala.collection.immutable.ArraySeq
 
 object PC {
 
+  /**
+   * Initialises a new presentation compiler.
+   *
+   * @param workspaceURI The [[URI]] of the directory where the workspace is initialised.
+   * @return A new [[PCState]] instance representing the compiler state with no compilation.
+   */
+  def initialise(workspaceURI: URI): PCState =
+    PCState(
+      workspace = Workspace.create(workspaceURI),
+      buildErrors = None
+    )
+
   /** Process source or build file change for a workspace that may or may not be source-aware ([[WorkspaceState.IsSourceAware]]) */
   def changed(fileURI: URI,
               code: Option[String],

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PC.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PC.scala
@@ -1,13 +1,152 @@
 package org.alephium.ralph.lsp.pc
 
-import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
-import org.alephium.ralph.lsp.pc.workspace.build.BuildState
+import org.alephium.ralph.lsp.access.compiler.CompilerAccess
+import org.alephium.ralph.lsp.access.file.FileAccess
+import org.alephium.ralph.lsp.pc.log.ClientLogger
+import org.alephium.ralph.lsp.pc.util.URIUtil
+import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorUnknownFileType
+import org.alephium.ralph.lsp.pc.workspace.{Workspace, WorkspaceFile, WorkspaceFileEvent, WorkspaceState}
+import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState}
+
+import java.net.URI
+import scala.collection.immutable.ArraySeq
 
 object PC {
 
+  /** Process source or build file change for a workspace that may or may not be source-aware ([[WorkspaceState.IsSourceAware]]) */
+  def changed(fileURI: URI,
+              code: Option[String],
+              pcState: PCState)(implicit file: FileAccess,
+                                compiler: CompilerAccess,
+                                logger: ClientLogger): Either[ErrorUnknownFileType, Option[PCState]] =
+    Workspace.build(
+      code = Some(WorkspaceFile(fileURI, code)),
+      workspace = pcState.workspace
+    ) match {
+      case error @ Left(_) =>
+        val newPCState =
+          buildChanged(
+            buildChangeResult = error,
+            pcState = pcState
+          )
+
+        Right(Some(newPCState))
+
+      case Right(aware) =>
+        val fileExtension =
+          URIUtil.getFileExtension(fileURI)
+
+        if (fileExtension == Build.BUILD_FILE_EXTENSION) {
+          // process build change
+          val buildResult =
+            Workspace.buildChanged(
+              buildURI = fileURI,
+              code = code,
+              workspace = aware
+            )
+
+          val newPCState =
+            buildResult map {
+              buildResult =>
+                buildChanged(
+                  buildChangeResult = buildResult,
+                  pcState = pcState
+                )
+            }
+
+          Right(newPCState)
+
+        } else if (fileExtension == CompilerAccess.RALPH_FILE_EXTENSION) {
+          // process source code change
+          val sourceResult =
+            Workspace.sourceCodeChanged(
+              fileURI = fileURI,
+              updatedCode = code,
+              workspace = aware
+            )
+
+          val newPCState =
+            sourceCodeChanged(
+              sourceChangeResult = sourceResult,
+              pcState = pcState
+            )
+
+          Right(Some(newPCState))
+        } else {
+          Left(ErrorUnknownFileType(fileURI))
+        }
+    }
+
+  /**
+   * Delete or create a file within the workspace that may or may not be source-aware ([[WorkspaceState.IsSourceAware]])
+   *
+   * @param events  Events to process
+   * @param pcState Current workspace and build state
+   * @return Workspace change result
+   * */
+  def deleteOrCreate(events: ArraySeq[WorkspaceFileEvent],
+                     pcState: PCState)(implicit file: FileAccess,
+                                       compiler: CompilerAccess,
+                                       logger: ClientLogger): PCState =
+    Workspace.build(
+      code = None,
+      workspace = pcState.workspace
+    ) match {
+      case Left(error) =>
+        buildChanged(
+          buildChangeResult = Left(error),
+          pcState = pcState
+        )
+
+      case Right(workspace) =>
+        // collect events that belong to this workspace
+        val workspaceEvents =
+          events filter {
+            event =>
+              URIUtil.contains(workspace.workspaceURI, event.uri)
+          }
+
+        // is the build deleted?
+        val isBuildDeleted =
+          workspaceEvents contains WorkspaceFileEvent.Deleted(workspace.buildURI)
+
+        val buildCode =
+          if (isBuildDeleted) // if build is deleted, compile from disk
+            None
+          else // build exists, process from memory
+            pcState.buildErrors match {
+              case Some(errored) =>
+                // use the code from the previous build's compilation run
+                errored.codeOption
+
+              case None =>
+                // previous build was good, use the compiled build code
+                Some(workspace.build.code)
+            }
+
+        // apply events to the workspace
+        val newSourceCode =
+          Workspace.applyEvents(
+            events = workspaceEvents,
+            workspace = workspace
+          )
+
+        val result =
+          Workspace.compile(
+            buildCode = buildCode,
+            sourceCode = newSourceCode,
+            currentBuild = workspace.build
+          )
+
+        buildChanged(
+          buildChangeResult = result,
+          pcState = pcState
+        )
+    }
+
   /** Apply build change to the [[PCState]] */
-  def buildChanged(buildChangeResult: Either[BuildState.BuildErrored, WorkspaceState],
-                   pcState: PCState): PCState =
+  private def buildChanged(buildChangeResult: Either[BuildState.BuildErrored, WorkspaceState],
+                           pcState: PCState): PCState =
     buildChangeResult match {
       case Left(buildError) =>
         // fetch the activateWorkspace to replace existing workspace
@@ -29,8 +168,8 @@ object PC {
     }
 
   /** Apply source-code change to the [[PCState]] */
-  def sourceCodeChanged(sourceChangeResult: Either[BuildState.BuildErrored, WorkspaceState],
-                        pcState: PCState): PCState =
+  private def sourceCodeChanged(sourceChangeResult: Either[BuildState.BuildErrored, WorkspaceState],
+                                pcState: PCState): PCState =
     sourceChangeResult match {
       case Left(buildError) =>
         pcState.copy(buildErrors = Some(buildError))

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PC.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PC.scala
@@ -1,9 +1,9 @@
-package org.alephium.ralph.lsp.pc.state
+package org.alephium.ralph.lsp.pc
 
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.pc.workspace.build.BuildState
 
-object PCStateUpdater {
+object PC {
 
   /** Apply build change to the [[PCState]] */
   def buildChanged(buildChangeResult: Either[BuildState.BuildErrored, WorkspaceState],

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PC.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PC.scala
@@ -5,16 +5,23 @@ import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.util.URIUtil
 import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorUnknownFileType
-import org.alephium.ralph.lsp.pc.workspace.{Workspace, WorkspaceFile, WorkspaceFileEvent, WorkspaceState}
 import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState}
+import org.alephium.ralph.lsp.pc.workspace.{Workspace, WorkspaceFile, WorkspaceFileEvent, WorkspaceState}
 
 import java.net.URI
 import scala.collection.immutable.ArraySeq
 
+/**
+ * Implements public presentation compiler APIs.
+ *
+ * To invoke a compilation, there are only two ways:
+ *  - When a file is changed, use [[PC.changed]]
+ *  - When a file is deleted or created, use [[PC.deleteOrCreate]]
+ */
 object PC {
 
   /**
-   * Initialises a new presentation compiler.
+   * Initialises a new presentation compiler state.
    *
    * @param workspaceURI The [[URI]] of the directory where the workspace is initialised.
    * @return A new [[PCState]] instance representing the compiler state with no compilation.
@@ -25,7 +32,16 @@ object PC {
       buildErrors = None
     )
 
-  /** Process source or build file change for a workspace that may or may not be source-aware ([[WorkspaceState.IsSourceAware]]) */
+  /**
+   * Processes a change in source or build file for a workspace that may or may not be source-aware ([[WorkspaceState.IsSourceAware]]).
+   *
+   * @param fileURI The URI of the changed file.
+   * @param code    An optional string containing the code of the changed file.
+   *                If this is [[None]], the file's content will fetched from disk.
+   * @param pcState The current state of the presentation compiler.
+   * @return Either an [[ErrorUnknownFileType]] if the file type is unknown,
+   *         or an optional new [[PCState]] instance representing the updated compiler state.
+   */
   def changed(fileURI: URI,
               code: Option[String],
               pcState: PCState)(implicit file: FileAccess,
@@ -90,12 +106,12 @@ object PC {
     }
 
   /**
-   * Delete or create a file within the workspace that may or may not be source-aware ([[WorkspaceState.IsSourceAware]])
+   * Deletes or creates a file within the workspace, which may or may not be source-aware ([[WorkspaceState.IsSourceAware]]).
    *
-   * @param events  Events to process
-   * @param pcState Current workspace and build state
-   * @return Workspace change result
-   * */
+   * @param events  Events to process.
+   * @param pcState Current presentation compiler state.
+   * @return The updated presentation compiler state containing the compilation result.
+   */
   def deleteOrCreate(events: ArraySeq[WorkspaceFileEvent],
                      pcState: PCState)(implicit file: FileAccess,
                                        compiler: CompilerAccess,
@@ -156,7 +172,13 @@ object PC {
         )
     }
 
-  /** Apply build change to the [[PCState]] */
+  /**
+   * Applies a build change to the [[PCState]].
+   *
+   * @param buildChangeResult The result of the build change operation.
+   * @param pcState           The current presentation compiler state.
+   * @return The updated presentation compiler state.
+   */
   private def buildChanged(buildChangeResult: Either[BuildState.BuildErrored, WorkspaceState],
                            pcState: PCState): PCState =
     buildChangeResult match {
@@ -179,7 +201,13 @@ object PC {
         )
     }
 
-  /** Apply source-code change to the [[PCState]] */
+  /**
+   * Applies a source code change to the [[PCState]].
+   *
+   * @param sourceChangeResult The result of the source code change operation.
+   * @param pcState            The current presentation compiler state.
+   * @return The updated presentation compiler state.
+   */
   private def sourceCodeChanged(sourceChangeResult: Either[BuildState.BuildErrored, WorkspaceState],
                                 pcState: PCState): PCState =
     sourceChangeResult match {

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PCState.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PCState.scala
@@ -1,4 +1,4 @@
-package org.alephium.ralph.lsp.pc.state
+package org.alephium.ralph.lsp.pc
 
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.pc.workspace.build.BuildState

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PCStateDiagnostics.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PCStateDiagnostics.scala
@@ -1,4 +1,4 @@
-package org.alephium.ralph.lsp.pc.state
+package org.alephium.ralph.lsp.pc
 
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra._
 import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, LineRange}
@@ -99,7 +99,6 @@ object PCStateDiagnostics {
                   newWorkspace = newBuild.findDependency(dependencyID)
                 )
             }
-
 
         dependencyDiagnostics ++ Iterable(buildDiagnostics)
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PCStateDiagnostics.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PCStateDiagnostics.scala
@@ -15,9 +15,11 @@ object PCStateDiagnostics {
 
   /**
    * Given the current [[PCState]] and the next [[PCState]],
-   * return new diagnostics to publish.
+   * returns new diagnostics to publish.
    *
-   * @return Diagnostics clearing resolved diagnostics dispatched in previous state.
+   * @param currentState The current presentation compiler state.
+   * @param newState     The next presentation compiler state.
+   * @return An iterator over resolved diagnostics dispatched in the previous state and new diagnostics.
    */
   def toFileDiagnostics(currentState: PCState,
                         newState: PCState): Iterable[FileDiagnostic] = {

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/Workspace.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/Workspace.scala
@@ -26,7 +26,7 @@ import scala.collection.immutable.ArraySeq
  *  - [[Workspace.parse]] - Parses an initialised workspace.
  *  - [[Workspace.compile]] - Compiles a parsed workspace.
  */
-object Workspace extends StrictImplicitLogging {
+private[pc] object Workspace extends StrictImplicitLogging {
 
   /** First stage of a workspace where just the root workspace folder is known */
   def create(workspaceURI: URI): WorkspaceState.Created =

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/Workspace.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/Workspace.scala
@@ -5,13 +5,13 @@ import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceCode, SourceCodeState}
-import org.alephium.ralph.lsp.pc.state.{PCState, PCStateUpdater}
 import org.alephium.ralph.lsp.pc.util.CollectionUtil._
 import org.alephium.ralph.lsp.pc.util.URIUtil
 import org.alephium.ralph.lsp.pc.workspace.build.BuildState.BuildCompiled
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorUnknownFileType
 import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState}
+import org.alephium.ralph.lsp.pc.{PC, PCState}
 
 import java.net.URI
 import scala.collection.immutable.ArraySeq
@@ -315,7 +315,7 @@ object Workspace extends StrictImplicitLogging {
       workspace = pcState.workspace
     ) match {
       case Left(error) =>
-        PCStateUpdater.buildChanged(
+        PC.buildChanged(
           buildChangeResult = Left(error),
           pcState = pcState
         )
@@ -360,7 +360,7 @@ object Workspace extends StrictImplicitLogging {
             currentBuild = workspace.build
           )
 
-        PCStateUpdater.buildChanged(
+        PC.buildChanged(
           buildChangeResult = result,
           pcState = pcState
         )
@@ -410,7 +410,7 @@ object Workspace extends StrictImplicitLogging {
     ) match {
       case error @ Left(_) =>
         val newPCState =
-          PCStateUpdater.buildChanged(
+          PC.buildChanged(
             buildChangeResult = error,
             pcState = pcState
           )
@@ -433,7 +433,7 @@ object Workspace extends StrictImplicitLogging {
           val newPCState =
             buildResult map {
               buildResult =>
-                PCStateUpdater.buildChanged(
+                PC.buildChanged(
                   buildChangeResult = buildResult,
                   pcState = pcState
                 )
@@ -451,7 +451,7 @@ object Workspace extends StrictImplicitLogging {
             )
 
           val newPCState =
-            PCStateUpdater.sourceCodeChanged(
+            PC.sourceCodeChanged(
               sourceChangeResult = sourceResult,
               pcState = pcState
             )

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/PCDeleteOrCreateSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/PCDeleteOrCreateSpec.scala
@@ -1,13 +1,13 @@
-package org.alephium.ralph.lsp.pc.workspace
+package org.alephium.ralph.lsp.pc
 
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.file.FileAccess
-import org.alephium.ralph.lsp.pc.PCState
 import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, TestSourceCode}
 import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorBuildFileNotFound
 import org.alephium.ralph.lsp.pc.workspace.build.{BuildState, TestBuild}
+import org.alephium.ralph.lsp.pc.workspace.{TestWorkspace, WorkspaceFileEvent, WorkspaceState}
 import org.scalacheck.Gen
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
@@ -18,9 +18,9 @@ import scala.collection.immutable.ArraySeq
 import scala.util.Random
 
 /**
- * Test cases for [[Workspace.deleteOrCreate]] function.
+ * Test cases for [[PC.deleteOrCreate]] function.
  */
-class WorkspaceDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks with MockFactory {
+class PCDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks with MockFactory {
 
   implicit val clientLogger: ClientLogger =
     TestClientLogger
@@ -54,7 +54,7 @@ class WorkspaceDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCh
 
             // invoke delete
             val actualPCState =
-              Workspace.deleteOrCreate(
+              PC.deleteOrCreate(
                 events = ArraySeq(event),
                 pcState = currentPCState
               )
@@ -118,7 +118,7 @@ class WorkspaceDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCh
 
             // invoke build event
             val actualPCState =
-              Workspace.deleteOrCreate(
+              PC.deleteOrCreate(
                 events = ArraySeq(event),
                 pcState = currentPCState
               )
@@ -150,7 +150,7 @@ class WorkspaceDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCh
 
             // invoke the same event
             val actualPCStateOK =
-              Workspace.deleteOrCreate(
+              PC.deleteOrCreate(
                 events = ArraySeq(event),
                 pcState = currentPCState
               )
@@ -209,7 +209,7 @@ class WorkspaceDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCh
 
           // invoke the event
           val actualPCState =
-            Workspace.deleteOrCreate(
+            PC.deleteOrCreate(
               events = ArraySeq(event),
               pcState = currentPCState
             )
@@ -254,7 +254,7 @@ class WorkspaceDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCh
 
           // Add the all code to the workspace
           val compiledPCState =
-            Workspace.deleteOrCreate(
+            PC.deleteOrCreate(
               events = allCode.to(ArraySeq).map { code =>
                 WorkspaceFileEvent.Created(code.fileURI)
               },
@@ -269,7 +269,7 @@ class WorkspaceDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCh
           // Delete the abstract contract
           TestSourceCode delete extension
           val erroredState =
-            Workspace.deleteOrCreate(
+            PC.deleteOrCreate(
               events = ArraySeq(WorkspaceFileEvent.Deleted(extension.fileURI)),
               pcState = compiledPCState
             )
@@ -282,7 +282,7 @@ class WorkspaceDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCh
 
           // The error is in the contract file, as the abstract contract is missing
           erroredWorkspace.sourceCode.size shouldBe 1
-          val sourceState  = erroredWorkspace.sourceCode.head.asInstanceOf[SourceCodeState.ErrorCompilation]
+          val sourceState = erroredWorkspace.sourceCode.head.asInstanceOf[SourceCodeState.ErrorCompilation]
           sourceState.fileURI shouldBe contract.fileURI
           val messages = sourceState.errors.map(_.message)
           messages.size shouldBe 1
@@ -292,7 +292,7 @@ class WorkspaceDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCh
           TestSourceCode persist (extension, code = Gen.const(extensionCode))
 
           val recompiledPCState =
-            Workspace.deleteOrCreate(
+            PC.deleteOrCreate(
               events = ArraySeq(
                 WorkspaceFileEvent.Created(extension.fileURI),
               ),

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceDeleteOrCreateSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceDeleteOrCreateSpec.scala
@@ -2,10 +2,10 @@ package org.alephium.ralph.lsp.pc.workspace
 
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.file.FileAccess
+import org.alephium.ralph.lsp.pc.PCState
 import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, TestSourceCode}
-import org.alephium.ralph.lsp.pc.state.PCState
 import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorBuildFileNotFound
 import org.alephium.ralph.lsp.pc.workspace.build.{BuildState, TestBuild}
 import org.scalacheck.Gen


### PR DESCRIPTION
- Minor refactoring. 
- Moved `PCState` related functions `changed` and `deleteOrCreate` out from `Workspace` to `PC`.
- `PC` contains just the public functions from the `presentation-compiler` module used by the LSP server.