### PR TITLE
Run GoTo definitions on all code in scope

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/Tree.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/Tree.scala
@@ -62,6 +62,15 @@ object Tree {
 
           case _ =>
         }
+
+    def typeId(): Ast.TypeId =
+      ast match {
+        case Left(contract) =>
+          contract.ident
+
+        case Right(struct) =>
+          struct.id
+      }
   }
 
   sealed trait Literal extends Tree

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/Tree.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/Tree.scala
@@ -45,7 +45,7 @@ object Tree {
      * @note Lazily initialised as it can have concurrent access or no access at all.
      * */
     lazy val rootNode: Node[Ast.Positioned] =
-      NodeBuilder.buildRootNode(ast, index)
+      NodeBuilder.buildRootNode(ast)
 
     /**
      * Solution for issue <a href="https://github.com/alephium/ralph-lsp/issues/135">#135</a>.

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/node/NodeBuilder.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/node/NodeBuilder.scala
@@ -1,8 +1,8 @@
 package org.alephium.ralph.lsp.access.compiler.ast.node
 
 import com.typesafe.scalalogging.StrictLogging
+import org.alephium.ralph.Ast
 import org.alephium.ralph.Ast.Positioned
-import org.alephium.ralph.{Ast, SourceIndex}
 
 /** Functions that build a traversable tree from [[Ast.ContractWithState]], returning the root [[Node]]. */
 object NodeBuilder extends StrictLogging {
@@ -13,8 +13,7 @@ object NodeBuilder extends StrictLogging {
    * @param ast The [[Ast.ContractWithState]] instance
    * @return Root node of the tree.
    */
-  def buildRootNode(ast: Either[Ast.ContractWithState, Ast.Struct],
-                    rootIndex: SourceIndex): Node[Positioned] = {
+  def buildRootNode(ast: Either[Ast.ContractWithState, Ast.Struct]): Node[Positioned] = {
     // TODO: Are all these siblings? If they are not, they need to build a tree structure using source-index.
     val rootSiblings =
       ast match {
@@ -52,7 +51,7 @@ object NodeBuilder extends StrictLogging {
 
     // Root node
     Node(
-      data = RootPosition(rootIndex),
+      data = ast.merge,
       children = sortedRootSiblings
     )
   }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/node/RootPosition.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/node/RootPosition.scala
@@ -1,9 +1,0 @@
-package org.alephium.ralph.lsp.access.compiler.ast.node
-
-import org.alephium.ralph.Ast.Positioned
-import org.alephium.ralph.SourceIndex
-
-/** Default root [[Node]]'s data. */
-case class RootPosition(index: SourceIndex) extends Positioned {
-  super.atSourceIndex(Some(index))
-}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoTo.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoTo.scala
@@ -1,0 +1,38 @@
+package org.alephium.ralph.lsp.pc.search.gotodef
+
+import org.alephium.ralph.Ast
+import org.alephium.ralph.lsp.access.compiler.ast.Tree
+import org.alephium.ralph.lsp.pc.search.gotodef.data.GoToLocation
+import org.alephium.ralph.lsp.pc.sourcecode.SourceTreeInScope
+import org.alephium.ralph.lsp.pc.workspace.{WorkspaceSearcher, WorkspaceState}
+
+/** Common Go-to functions */
+object GoTo {
+
+  /**
+   * Executes the `searcher` function on all source-trees in scope.
+   *
+   * @param sourceCode The source-tree in scope.
+   * @param workspace  The workspace to which this source-tree belongs.
+   * @param searcher   The search function to execute.
+   * @return Go-to definition search results.
+   */
+  def inScope(sourceCode: SourceTreeInScope,
+              workspace: WorkspaceState.IsSourceAware,
+              searcher: Tree.Source => Iterator[Ast.Positioned]): Iterator[GoToLocation] =
+    WorkspaceSearcher
+      .collectInScope(sourceCode, workspace) // collect all source-files/source-trees in scope
+      .iterator
+      .flatMap {
+        treeInScope =>
+          // execute the searcher function on each tree
+          val searchResult =
+            searcher(treeInScope.tree)
+
+          GoToLocation(
+            sourceCode = treeInScope.parsed,
+            asts = searchResult
+          )
+      }
+
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefinitionProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefinitionProvider.scala
@@ -5,7 +5,7 @@ import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra._
 import org.alephium.ralph.lsp.pc.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.lsp.pc.search.CodeProvider
 import org.alephium.ralph.lsp.pc.search.gotodef.data.GoToLocation
-import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
+import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceTreeInScope}
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 
@@ -36,9 +36,8 @@ private[search] object GoToDefinitionProvider extends CodeProvider[GoToLocation]
             // request is for source-code go-to definition
             GoToSource.goTo(
               cursorIndex = cursorIndex,
-              sourceCode = sourceCode,
-              sourceAST = source,
-              dependencyBuiltIn = workspace.build.findDependency(DependencyID.BuiltIn)
+              sourceCode = SourceTreeInScope(source, sourceCode),
+              workspace = workspace
             )
         }
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcher.scala
@@ -73,8 +73,8 @@ object SourceCodeSearcher {
    *
    * @param inheritances   The inheritances to search for.
    * @param allSource      The source code files containing the inheritance implementations.
-   * @param processedTrees Note: This is a mutable collection so this function must be private.
-   *                       A buffer to store processed source trees to avoid duplicate processing.
+   * @param processedTrees A buffer to store processed source trees to avoid duplicate processing.
+   *                       This is a mutable collection so this function must be private.
    * @return All inheritance implementations along with their corresponding source files.
    */
   private def collectParentsInherited(inheritances: Seq[Ast.Inheritance],
@@ -86,6 +86,7 @@ object SourceCodeSearcher {
       allSource flatMap {
         parsed =>
           parsed.ast.statements flatMap {
+            // collect the trees that belong to one of the inheritances and the ones that are not already processed
             case source: Tree.Source if inheritances.exists(_.parentId == source.typeId()) && !processedTrees.contains(source) =>
               processedTrees addOne source
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcher.scala
@@ -1,5 +1,7 @@
 package org.alephium.ralph.lsp.pc.sourcecode
 
+import org.alephium.ralph.lsp.access.compiler.ast.Tree
+
 import scala.collection.immutable.ArraySeq
 
 /**
@@ -24,5 +26,22 @@ object SourceCodeSearcher {
       case errored: SourceCodeState.ErrorCompilation =>
         errored.parsed
     }
+
+  /**
+   * Collect all unique import statements from source code.
+   *
+   * @param sourceCode Source code to search import statements within.
+   * @return All import statements.
+   */
+  def collectImportStatements(sourceCode: ArraySeq[SourceCodeState.Parsed]): ArraySeq[Tree.Import] =
+    sourceCode
+      .flatMap {
+        parsed =>
+          parsed.ast.statements.collect {
+            case imported: Tree.Import =>
+              imported
+          }
+      }
+      .distinctBy(_.string.value)
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcher.scala
@@ -1,0 +1,28 @@
+package org.alephium.ralph.lsp.pc.sourcecode
+
+import scala.collection.immutable.ArraySeq
+
+/**
+ * Search functions related to [[SourceCodeState]]
+ * */
+object SourceCodeSearcher {
+
+  /**
+   * Collects all source files with valid parsed syntax.
+   *
+   * @param sourceCode The source files to filter.
+   * @return An array sequence containing parsed source code files.
+   */
+  def collectParsed(sourceCode: ArraySeq[SourceCodeState]): ArraySeq[SourceCodeState.Parsed] =
+    sourceCode collect {
+      case parsed: SourceCodeState.Parsed =>
+        parsed
+
+      case compiled: SourceCodeState.Compiled =>
+        compiled.parsed
+
+      case errored: SourceCodeState.ErrorCompilation =>
+        errored.parsed
+    }
+
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceTreeInScope.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceTreeInScope.scala
@@ -1,0 +1,13 @@
+package org.alephium.ralph.lsp.pc.sourcecode
+
+import org.alephium.ralph.lsp.access.compiler.ast.Tree
+
+/**
+ * Represents a single source tree ([[Tree.Source]]) within a source file ([[SourceCodeState.Parsed]]),
+ * which can contain multiple source trees such as contracts, scripts etc.
+ *
+ * @param tree   The source tree within the parsed source file.
+ * @param parsed The source file containing the source tree.
+ */
+case class SourceTreeInScope(tree: Tree.Source,
+                             parsed: SourceCodeState.Parsed)

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
@@ -1,0 +1,73 @@
+package org.alephium.ralph.lsp.pc.workspace
+
+import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeSearcher, SourceCodeState, SourceTreeInScope}
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
+
+import scala.collection.immutable.ArraySeq
+
+/** Implements search functions that run on [[WorkspaceState.IsSourceAware]] */
+object WorkspaceSearcher {
+
+  /**
+   * Collects all source trees within the scope of the provided source code.
+   *
+   * @param sourceCode The source code for which in-scope files are being searched.
+   * @param workspace  The workspace that may contain files within the scope.
+   * @return The source trees within the scope.
+   */
+  def collectInScope(sourceCode: SourceTreeInScope,
+                     workspace: WorkspaceState.IsSourceAware): Seq[SourceTreeInScope] = {
+    val allInScopeCode =
+      collectParsedInScope(workspace)
+
+    val inheritancesInScope =
+      SourceCodeSearcher.collectInheritanceInScope(
+        source = sourceCode.tree,
+        allSource = allInScopeCode
+      )
+
+    inheritancesInScope :+ sourceCode
+  }
+
+  /**
+   * Collects all parsed source files, excluding `std` dependency source files
+   * that are not imported.
+   *
+   * @param workspace The workspace with dependencies.
+   * @return Parsed source files in scope.
+   */
+  private def collectParsedInScope(workspace: WorkspaceState.IsSourceAware): ArraySeq[SourceCodeState.Parsed] = {
+    // fetch the `std` dependency
+    val stdSourceParsedCode =
+      workspace
+        .build
+        .findDependency(DependencyID.Std)
+        .toSeq
+        .flatMap(_.sourceCode.map(_.parsed))
+
+    // collect all parsed source-files
+    val workspaceCode =
+      SourceCodeSearcher.collectParsed(workspace.sourceCode)
+
+    // collect all import statements
+    val importStatements =
+      SourceCodeSearcher
+        .collectImportStatements(workspaceCode)
+        .map(_.string.value)
+
+    // filter out std files that are not imported
+    val importedCode =
+      stdSourceParsedCode filter {
+        stdCode =>
+          stdCode
+            .importIdentifier
+            .exists {
+              stdImportIdentifier =>
+                importStatements contains stdImportIdentifier.string.value
+            }
+      }
+
+    workspaceCode ++ importedCode
+  }
+
+}

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/TestFile.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/TestFile.scala
@@ -114,6 +114,9 @@ object TestFile {
   def delete(uri: URI): Unit =
     Files.delete(Paths.get(uri))
 
+  def deleteIfExists(uri: URI): Boolean =
+    Files.deleteIfExists(Paths.get(uri))
+
   /** Recursive delete all files in this folder */
   def deleteAll(uri: URI): Boolean =
     deleteAll(new File(uri))

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumFieldSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumFieldSpec.scala
@@ -162,7 +162,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
         )
       }
 
-      "an enum field is selected in an parent" in {
+      "an enum field is selected that's implemented within a parent" in {
         goTo(
           """
             |Abstract Contract Parent2() {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumFieldSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumFieldSpec.scala
@@ -161,6 +161,38 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
             |""".stripMargin
         )
       }
+
+      "an enum field is selected in an parent" in {
+        goTo(
+          """
+            |Abstract Contract Parent2() {
+            |  enum EnumType {
+            |    >>Field0 = 00<<
+            |    Field3 = 3
+            |  }
+            |}
+            |
+            |Abstract Contract Parent1() extends Parent2() {
+            |  enum EnumType {
+            |    >>Field0 = 00<<
+            |    Field3 = 3
+            |  }
+            |}
+            |
+            |Contract MyContract() extends Parent1() {
+            |
+            |  enum EnumType {
+            |    >>Field0 = 0<<
+            |    Field1 = 1
+            |  }
+            |
+            |  pub fn function() -> () {
+            |    let field0 = EnumType.Field0@@
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
     }
   }
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeCompileSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeCompileSpec.scala
@@ -69,7 +69,7 @@ class SourceCodeCompileSpec extends AnyWordSpec with Matchers with ScalaCheckDri
             TestCode.genInterface("MyInterface"), // An Interface
             TestCode.genScript("MyScript") // A Script
           )
-            .map(TestSourceCode.genParsed(_))
+            .map(TestSourceCode.genParsedOK(_))
             .map(_.sample.get)
 
         // Expected that all source files have a SourceCodeState.Compiled entry

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectImportStatementsSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectImportStatementsSpec.scala
@@ -1,0 +1,91 @@
+package org.alephium.ralph.lsp.pc.sourcecode
+
+import org.alephium.ralph.lsp.access.compiler.CompilerAccess
+import org.alephium.ralph.lsp.access.file.FileAccess
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.collection.immutable.ArraySeq
+
+class SourceCodeSearcherCollectImportStatementsSpec extends AnyWordSpec with Matchers {
+
+  implicit val file: FileAccess = FileAccess.disk
+  implicit val compiler: CompilerAccess = CompilerAccess.ralphc
+
+  "collectParsed" should {
+    "return empty" when {
+      "input is empty" in {
+        SourceCodeSearcher.collectImportStatements(ArraySeq.empty) shouldBe empty
+      }
+    }
+
+    "collect distinct import statements" in {
+      val goodCodeParsed =
+        TestSourceCode.genParsed(
+          """
+            |import "blah/blah"
+            |import "blah/blah"
+            |import "std/fungible_token_interface"
+            |import "std/fungible_token_interface"
+            |
+            |Contract MyContract() {
+            |  fn function1() -> () {}
+            |}
+            |""".stripMargin
+        ).sample.get.asInstanceOf[SourceCodeState.Parsed]
+
+      val goodCodeCompiled =
+        TestSourceCode.genCompiled(
+          """
+            |import "std/nft_collection_interface"
+            |import "std/nft_collection_interface"
+            |import "std/fungible_token_interface"
+            |import "std/fungible_token_unimplemented"
+            |
+            |Abstract Contract AbstractContract() { }
+            |
+            |Contract MyContract() extends AbstractContract() {
+            |  fn function1() -> () {}
+            |}
+            |""".stripMargin
+        ).sample.get.asInstanceOf[SourceCodeState.Compiled].parsed
+
+      val errorCompilation =
+        TestSourceCode
+          .genCompiled(
+            """
+              |import "std/nft_collection_with_royalty_interface"
+              |import "std/nft_collection_with_royalty_interface"
+              |import "std/nft_collection_interface"
+              |import "std/nft_collection_interface"
+              |
+              |Contract MyContract() extends DoesNotExist() {
+              |  fn function1() -> () {}
+              |}
+              |""".stripMargin
+          ).sample.get.asInstanceOf[SourceCodeState.ErrorCompilation].parsed
+
+      val sourceCode =
+        ArraySeq(goodCodeParsed, goodCodeCompiled, errorCompilation)
+
+      val actual =
+        SourceCodeSearcher
+          .collectImportStatements(sourceCode)
+          .map(_.string.value)
+
+      val expected =
+        Array(
+          "\"blah/blah\"",
+          "\"std/fungible_token_interface\"",
+          "\"std/fungible_token_unimplemented\"",
+          "\"std/nft_collection_interface\"",
+          "\"std/nft_collection_with_royalty_interface\""
+        )
+
+      actual should contain theSameElementsAs expected
+
+      TestSourceCode deleteAllIfExists sourceCode
+    }
+  }
+
+}

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectInheritanceInScopeSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectInheritanceInScopeSpec.scala
@@ -1,0 +1,208 @@
+package org.alephium.ralph.lsp.pc.sourcecode
+
+import org.alephium.ralph.lsp.access.compiler.CompilerAccess
+import org.alephium.ralph.lsp.access.compiler.ast.Tree
+import org.alephium.ralph.lsp.access.file.FileAccess
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.EitherValues._
+
+import scala.collection.immutable.ArraySeq
+
+class SourceCodeSearcherCollectInheritanceInScopeSpec extends AnyWordSpec with Matchers {
+
+  implicit val file: FileAccess = FileAccess.disk
+  implicit val compiler: CompilerAccess = CompilerAccess.ralphc
+
+  "return empty" when {
+    "input source-code is empty" in {
+      val parsed =
+        TestSourceCode.genParsed(
+          """
+            |Contract MyContract() {
+            |  fn function1() -> () {}
+            |}
+            |""".stripMargin
+        ).sample.get.asInstanceOf[SourceCodeState.Parsed]
+
+      val tree =
+        parsed.ast.statements.head.asInstanceOf[Tree.Source]
+
+      SourceCodeSearcher.collectInheritanceInScope(
+        source = tree,
+        allSource = ArraySeq.empty
+      ) shouldBe empty
+
+      TestSourceCode deleteIfExists parsed
+    }
+  }
+
+  "collect single parent implementations" when {
+    def doTest(code: String) = {
+      val parsed =
+        TestSourceCode
+          .genParsed(code)
+          .sample
+          .get
+          .asInstanceOf[SourceCodeState.Parsed]
+
+      // first statement is Parent()
+      val parent = parsed.ast.statements.head.asInstanceOf[Tree.Source]
+      parent.ast.merge.name shouldBe "Parent"
+
+      // second statement is Child()
+      val child = parsed.ast.statements.last.asInstanceOf[Tree.Source]
+      child.ast.merge.name shouldBe "Child"
+
+      // expect parent to be returned
+      val expected =
+        SourceTreeInScope(
+          tree = parent,
+          parsed = parsed
+        )
+
+      val actual =
+        SourceCodeSearcher.collectInheritanceInScope(
+          source = child,
+          allSource = ArraySeq(parsed)
+        )
+
+      actual should contain only expected
+
+      TestSourceCode deleteIfExists parsed
+    }
+
+    "parent is an Abstract Contract" in {
+      doTest {
+        """
+          |Abstract Contract Parent() { }
+          |
+          |Contract Child() extends Parent() {
+          |  fn function1() -> () {}
+          |}
+          |""".stripMargin
+      }
+    }
+
+    "parent is an Interface" in {
+      doTest {
+        """
+          |Interface Parent {
+          |  pub fn parent() -> U256
+          |}
+          |
+          |Contract Child() implements Parent {
+          |  pub fn parent() -> U256 {
+          |    return 1
+          |  }
+          |}
+          |""".stripMargin
+      }
+    }
+  }
+
+  "collect deep inheritance" when {
+    "it also contains cyclic and duplicate inheritance" in {
+      // file1 contains the Child() contract for which the parents are collected.
+      val file1 =
+        TestSourceCode
+          .genParsed(
+            """
+              |Abstract Contract Parent2() extends Parent4(), Parent6() implements Parent1 { }
+              |
+              |// Interface is implemented
+              |Interface Parent1 {
+              |  pub fn parent() -> U256
+              |}
+              |
+              |// Parent3 is not extends by Child(), it should not be in the result
+              |Abstract Contract Parent3() extends Parent4(), Parent4() { }
+              |
+              |// The child parents to collect
+              |Contract Child() extends Parent2(), Child() implements Parent1 {
+              |  pub fn parent() -> U256 {
+              |    return 1
+              |  }
+              |}
+              |""".stripMargin
+          )
+          .sample
+          .get
+          .asInstanceOf[SourceCodeState.Parsed]
+
+      // file2 contains all other abstract contracts
+      val file2 =
+        TestSourceCode
+          .genParsed(
+            """
+              |Abstract Contract Parent6() extends Parent4() { }
+              |
+              |Abstract Contract Parent5() extends Parent4(), Parent5() { }
+              |
+              |Abstract Contract Parent4() extends Parent5(), Parent6(), Parent4() { }
+              |""".stripMargin
+          )
+          .sample
+          .get
+          .asInstanceOf[SourceCodeState.Parsed]
+
+      // collect all tree from file1
+      val treesFromFile1 =
+        file1.ast.statements.map(_.asInstanceOf[Tree.Source])
+
+      // collect all tree from file2
+      val treesFromFile2 =
+        file2.ast.statements.map(_.asInstanceOf[Tree.Source])
+
+      // the last statement in file1 is Child()
+      val child = treesFromFile1.last
+      child.ast.merge.name shouldBe "Child"
+
+      // expect parents to be returned excluding Parent3() and Child()
+      val expectedTreesFromFile1 =
+        treesFromFile1
+          .filterNot {
+            tree =>
+              tree.ast.merge.name == "Parent3" || tree.ast.merge.name == "Child"
+          }
+          .map {
+            parent =>
+              SourceTreeInScope(
+                tree = parent,
+                parsed = file1 // file1 is in scope
+              )
+          }
+
+      val expectedTreesFromFile2 =
+        treesFromFile2
+          .map {
+            parent =>
+              SourceTreeInScope(
+                tree = parent,
+                parsed = file2 // file2 is in scope
+              )
+          }
+
+      // collect all parent trees to expect
+      val expectedTrees =
+        expectedTreesFromFile1 ++ expectedTreesFromFile2
+
+      // actual trees returned
+      val actual =
+        SourceCodeSearcher.collectInheritanceInScope(
+          source = child,
+          allSource = ArraySeq(file1, file2)
+        )
+
+      actual should contain theSameElementsAs expectedTrees
+
+      // Double check: Also assert the names of the parents.
+      val parentNames = actual.map(_.tree.ast.left.value.name)
+      // Note: Parent3 and Child are not included.
+      parentNames should contain only("Parent1", "Parent2", "Parent4", "Parent5", "Parent6")
+
+      TestSourceCode deleteAllIfExists Array(file1, file2)
+    }
+  }
+
+}

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectParsedSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectParsedSpec.scala
@@ -1,0 +1,78 @@
+package org.alephium.ralph.lsp.pc.sourcecode
+
+import org.alephium.ralph.lsp.access.compiler.CompilerAccess
+import org.alephium.ralph.lsp.access.file.FileAccess
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.collection.immutable.ArraySeq
+
+class SourceCodeSearcherCollectParsedSpec extends AnyWordSpec with Matchers {
+
+  implicit val file: FileAccess = FileAccess.disk
+  implicit val compiler: CompilerAccess = CompilerAccess.ralphc
+
+  "collectParsed" should {
+    "return empty" when {
+      "input is empty" in {
+        SourceCodeSearcher.collectParsed(ArraySeq.empty) shouldBe empty
+      }
+    }
+
+    "collect parsed source code even if it contains compiler errors" in {
+      val onDisk =
+        TestSourceCode.genOnDisk().sample.get
+
+      val unCompiled =
+        TestSourceCode.genUnCompiled().sample.get
+
+      val errorParser =
+        TestSourceCode.genParsed(
+          """
+            |Contract MyContract() {
+            |  blah
+            |}
+            |""".stripMargin
+        ).sample.get.asInstanceOf[SourceCodeState.ErrorParser]
+
+      val goodCodeParsed =
+        TestSourceCode.genParsed(
+          """
+            |Contract MyContract() {
+            |  fn function1() -> () {}
+            |}
+            |""".stripMargin
+        ).sample.get.asInstanceOf[SourceCodeState.Parsed]
+
+      val goodCodeCompiled =
+        TestSourceCode.genCompiled(
+          """
+            |Abstract Contract AbstractContract() { }
+            |
+            |Contract MyContract() extends AbstractContract() {
+            |  fn function1() -> () {}
+            |}
+            |""".stripMargin
+        ).sample.get.asInstanceOf[SourceCodeState.Compiled]
+
+      val errorCompilation =
+        TestSourceCode
+          .genCompiled(
+            """
+              |Contract MyContract() extends DoesNotExist() {
+              |  fn function1() -> () {}
+              |}
+              |""".stripMargin
+          ).sample.get.asInstanceOf[SourceCodeState.ErrorCompilation]
+
+      val sourceCode =
+        ArraySeq(onDisk, unCompiled, errorParser, goodCodeParsed, goodCodeCompiled, errorCompilation)
+
+      val result =
+        SourceCodeSearcher.collectParsed(sourceCode)
+
+      result should contain only(goodCodeParsed, goodCodeCompiled.parsed, errorCompilation.parsed)
+    }
+  }
+
+}

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectParsedSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectParsedSpec.scala
@@ -65,13 +65,15 @@ class SourceCodeSearcherCollectParsedSpec extends AnyWordSpec with Matchers {
               |""".stripMargin
           ).sample.get.asInstanceOf[SourceCodeState.ErrorCompilation]
 
-      val sourceCode =
+      val allCode =
         ArraySeq(onDisk, unCompiled, errorParser, goodCodeParsed, goodCodeCompiled, errorCompilation)
 
       val result =
-        SourceCodeSearcher.collectParsed(sourceCode)
+        SourceCodeSearcher.collectParsed(allCode)
 
       result should contain only(goodCodeParsed, goodCodeCompiled.parsed, errorCompilation.parsed)
+
+      TestSourceCode deleteAllIfExists allCode
     }
   }
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
@@ -139,6 +139,14 @@ object TestSourceCode {
                                                              compiler: CompilerAccess): Gen[SourceCodeState] =
     unCompiled map SourceCode.parse
 
+  def genCompiledOK(code: Gen[String] = TestCode.genGoodCode(),
+                    fileURI: Gen[URI] = genFileURI())(implicit file: FileAccess,
+                                                      compiler: CompilerAccess): Gen[SourceCodeState.Compiled] =
+    genCompiled(
+      code = code,
+      fileURI = fileURI
+    ).map(_.asInstanceOf[SourceCodeState.Compiled])
+
   def genCompiled(code: Gen[String] = TestCode.genGoodCode(),
                   fileURI: Gen[URI] = genFileURI())(implicit file: FileAccess,
                                                     compiler: CompilerAccess): Gen[SourceCodeState.IsParsed] = {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
@@ -6,6 +6,7 @@ import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.compiler.message.error.TestError
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.util.URIUtil
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.TestDependency
 import org.alephium.ralph.lsp.pc.workspace.build.{BuildState, TestBuild}
 import org.alephium.ralph.lsp.{TestCode, TestFile}
 import org.scalacheck.Gen
@@ -157,7 +158,7 @@ object TestSourceCode {
     val result =
       SourceCode.compile(
         sourceCode = ArraySeq(parsed),
-        dependency = ArraySeq.empty,
+        dependency = TestDependency.buildStd().dependencies.flatMap(_.sourceCode),
         compilerOptions = CompilerOptions.Default,
         workspaceErrorURI = parsed.fileURI
       )
@@ -187,6 +188,12 @@ object TestSourceCode {
   def delete(sourceCode: SourceCodeState): Unit =
     TestFile.delete(sourceCode.fileURI)
 
+  def deleteIfExists(sourceCode: SourceCodeState): Boolean =
+    TestFile.deleteIfExists(sourceCode.fileURI)
+
   def deleteAll(sourceCode: Iterable[SourceCodeState]): Unit =
     sourceCode foreach delete
+
+  def deleteAllIfExists(sourceCode: Iterable[SourceCodeState]): Unit =
+    sourceCode foreach deleteIfExists
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
@@ -114,9 +114,17 @@ object TestSourceCode {
       genUnCompiled(code, fileURI)
     )
 
+  def genParsedOK(code: Gen[String] = TestCode.genGoodCode(),
+                  fileURI: Gen[URI] = genFileURI())(implicit file: FileAccess,
+                                                    compiler: CompilerAccess): Gen[SourceCodeState.Parsed] =
+    genParsed(
+      code = code,
+      fileURI = fileURI
+    ).map(_.asInstanceOf[SourceCodeState.Parsed])
+
   def genParsed(code: Gen[String] = TestCode.genGoodCode(),
                 fileURI: Gen[URI] = genFileURI())(implicit file: FileAccess,
-                                                  compiler: CompilerAccess): Gen[SourceCodeState.Parsed] = {
+                                                  compiler: CompilerAccess): Gen[SourceCodeState] = {
     val unCompiled =
       genUnCompiled(
         code = code,
@@ -127,16 +135,14 @@ object TestSourceCode {
   }
 
   def genParsed(unCompiled: Gen[SourceCodeState.UnCompiled])(implicit file: FileAccess,
-                                                             compiler: CompilerAccess): Gen[SourceCodeState.Parsed] =
-    unCompiled
-      .map(SourceCode.parse)
-      .map(_.asInstanceOf[SourceCodeState.Parsed])
+                                                             compiler: CompilerAccess): Gen[SourceCodeState] =
+    unCompiled map SourceCode.parse
 
   def genCompiled(code: Gen[String] = TestCode.genGoodCode(),
                   fileURI: Gen[URI] = genFileURI())(implicit file: FileAccess,
                                                     compiler: CompilerAccess): Gen[SourceCodeState.IsParsed] = {
     val parsed =
-      genParsed(
+      genParsedOK(
         code = code,
         fileURI = fileURI
       )

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/ImporterSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/ImporterSpec.scala
@@ -28,7 +28,7 @@ class ImporterSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenProper
 
         val parsed =
           TestSourceCode
-            .genParsed(
+            .genParsedOK(
               """
                 |Contract MyContract(id:U256){
                 |  pub fn getId() -> U256 {
@@ -92,7 +92,7 @@ class ImporterSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenProper
         // parse myCode with the above dependant code imported
         val myCode =
           TestSourceCode
-            .genParsed(
+            .genParsedOK(
               s"""
                  |// import the above code
                  |import "my_package/my_file"
@@ -130,7 +130,7 @@ class ImporterSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenProper
 
         val myCode =
           TestSourceCode
-            .genParsed(
+            .genParsedOK(
               s"""
                  |// this import does not exist
                  |import "my_package/my_file"

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcherCollectInScopeSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcherCollectInScopeSpec.scala
@@ -1,0 +1,150 @@
+package org.alephium.ralph.lsp.pc.workspace
+
+import org.alephium.ralph.lsp.access.compiler.CompilerAccess
+import org.alephium.ralph.lsp.access.compiler.ast.Tree
+import org.alephium.ralph.lsp.access.file.FileAccess
+import org.alephium.ralph.lsp.pc.client.TestClientLogger
+import org.alephium.ralph.lsp.pc.log.ClientLogger
+import org.alephium.ralph.lsp.pc.sourcecode.{SourceTreeInScope, TestSourceCode}
+import org.alephium.ralph.lsp.pc.workspace.build.TestBuild
+import org.scalatest.OptionValues._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.collection.immutable.ArraySeq
+
+class WorkspaceSearcherCollectInScopeSpec extends AnyWordSpec with Matchers {
+
+  implicit val file: FileAccess = FileAccess.disk
+  implicit val compiler: CompilerAccess = CompilerAccess.ralphc
+  implicit val logger: ClientLogger = TestClientLogger
+
+  "contain all source-code in scope" in {
+    // Generate a build file
+    val build =
+      TestBuild.genCompiledOK().sample.value
+
+    // Generate a source file which contains the contract Child1
+    val sourceFile1 =
+      TestSourceCode.genParsedOK(
+        code =
+          """
+            |import "std/nft_interface"
+            |import "std/nft_collection_interface"
+            |
+            |// Note: INFT interface is implemented
+            |Abstract Contract Parent1() extends Parent2() implements INFT { }
+            |
+            |Contract Child() extends Parent1() {
+            |  fn function() -> () {}
+            |}
+            |""".stripMargin,
+        fileURI =
+          build.contractURI.resolve("file1.ral")
+      ).sample.value
+
+    TestSourceCode persist sourceFile1
+
+    // Generate a source file which contains some of the parent inheritances
+    val sourceFile2 =
+      TestSourceCode.genParsedOK(
+        code =
+          """
+            |import "std/nft_collection_with_royalty_interface"
+            |
+            |// Note: INFTCollectionWithRoyalty is implemented
+            |Abstract Contract Parent2() implements INFTCollectionWithRoyalty { }
+            |""".stripMargin,
+        fileURI =
+          build.contractURI.resolve("file2.ral")
+      ).sample.value
+
+    TestSourceCode persist sourceFile2
+
+    // create a workspace for the two source files above
+    val workspace = {
+      val unCompiled =
+        WorkspaceState.UnCompiled(
+          build = build,
+          sourceCode = ArraySeq(sourceFile1, sourceFile2)
+        )
+
+      // it is successfully parsed
+      val workspace =
+        Workspace
+          .parse(unCompiled)
+          .asInstanceOf[WorkspaceState.Parsed]
+
+      // it contains the 2 source files
+      workspace.sourceCode should have size 2
+
+      workspace
+    }
+
+    // collect all trees from file1
+    val file1Trees =
+      sourceFile1.ast.statements.collect {
+        case source: Tree.Source =>
+          SourceTreeInScope(source, sourceFile1)
+      }
+
+    // We need to test to find in-scope inheritance for the Child contract.
+    val childTree =
+      file1Trees.find(_.tree.ast.merge.name == "Child").value
+
+    // collect all trees from file2
+    val file2Trees =
+      sourceFile2.ast.statements.collect {
+        case source: Tree.Source =>
+          SourceTreeInScope(source, sourceFile2)
+      }
+
+    // std interfaces with the following import identifiers should get included.
+    val expectedImports =
+      Array(
+        "\"std/nft_interface\"",
+        "\"std/nft_collection_interface\"",
+        "\"std/nft_collection_with_royalty_interface\"",
+      )
+
+    // find the source files with the above imports
+    val dependencyTrees =
+      build
+        .dependencies
+        .flatMap(_.sourceCode)
+        .collect {
+          case source if expectedImports.contains(source.importIdentifier.value.string.value) =>
+            source.parsed.ast.statements.collect {
+              case tree: Tree.Source =>
+                SourceTreeInScope(
+                  tree = tree,
+                  parsed = source.parsed
+                )
+            }
+        }
+        .flatten
+
+    dependencyTrees should have size 3
+
+    // all expected source files in-scope
+    val expected =
+      file1Trees ++ file2Trees ++ dependencyTrees
+
+    // execute the function
+    val actual =
+      WorkspaceSearcher.collectInScope(
+        sourceCode =
+          SourceTreeInScope(
+            tree = childTree.tree,
+            parsed = sourceFile1
+          ),
+        workspace = workspace
+      )
+
+    // it should contain all expected source-trees.
+    actual should contain theSameElementsAs expected
+
+    TestBuild delete build
+  }
+
+}


### PR DESCRIPTION
Currently, all go-to definitions run on a single tree. This PR allows them to run for all trees in scope. See [test](https://github.com/alephium/ralph-lsp/blob/15f6fd4caad98342600fb9dc97ba48715089e68d/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumFieldSpec.scala#L165).

For example: Selecting `EnumType` in `Child()` contract will jump to the definition in `Parent()` contract.

```rust
Abstract Contract Parent() {
  enum EnumName {
    EnumType = 1
  }
}

Contract Child() extends Parent() {
  fn function() -> () {
    let _ = EnumName.EnumType
  }
}
```

At the moment this only works for enum fields, all the others can be implemented just as easily by invoking [this function](https://github.com/alephium/ralph-lsp/blob/15f6fd4caad98342600fb9dc97ba48715089e68d/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoTo.scala#L20), they will be implemented in following PRs with their required test-cases.

Towards #105.