### PR TITLE
Enable in-scope goto definition for others 

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
@@ -31,16 +31,18 @@ private object GoToIdent {
             goToScopeDefinitions(
               identNode = variableNode,
               ident = variable.id,
-              source = sourceCode.tree
-            ).flatMap(GoToLocation(_, sourceCode.parsed))
+              sourceCode = sourceCode,
+              workspace = workspace
+            )
 
           case assignmentNode @ Node(assignment: Ast.AssignmentSimpleTarget[_], _) if assignment.ident == ident =>
             // They selected an assignment. Take 'em there!
             goToScopeDefinitions(
               identNode = assignmentNode,
               ident = assignment.ident,
-              source = sourceCode.tree
-            ).flatMap(GoToLocation(_, sourceCode.parsed))
+              sourceCode = sourceCode,
+              workspace = workspace
+            )
 
           case Node(fieldSelector: Ast.EnumFieldSelector[_], _) if fieldSelector.field == ident =>
             // They selected an enum field. Take 'em there!
@@ -142,61 +144,61 @@ private object GoToIdent {
   /**
    * Navigate to arguments, constants and variables for the given identity ([[Ast.Ident]]).
    *
-   * @param identNode The node representing the identity.
-   * @param ident     The identity data ([[Ast.Ident]]) within the node.
-   * @param source    The source tree to search within.
+   * @param identNode  The node representing the identity.
+   * @param ident      The identity data ([[Ast.Ident]]) within the node.
+   * @param sourceCode The source tree containing the identity node.
+   * @param workspace  The workspace in scope, that may contain other dependant source-code.
    * @return An array sequence of arguments, constants and variables with the input identity.
    */
   private def goToScopeDefinitions(identNode: Node[Ast.Positioned],
                                    ident: Ast.Ident,
-                                   source: Tree.Source): Iterator[Ast.Positioned] = {
-    val arguments =
-      goToArguments(
-        variableNode = identNode,
-        variableId = ident,
-        source = source
+                                   sourceCode: SourceTreeInScope,
+                                   workspace: WorkspaceState.IsSourceAware): Iterator[GoToLocation] = {
+    val argumentsAndConstants =
+      GoTo.inScope(
+        sourceCode = sourceCode,
+        workspace = workspace,
+        searcher = goToConstantsAndTemplateArguments(ident, _)
       )
 
-    val constants =
-      goToConstants(
-        source = source,
+    val functionArguments =
+      goToNearestFunctionArguments(
+        childNode = identNode,
         ident = ident
-      )
+      ).flatMap(GoToLocation(_, sourceCode.parsed))
 
     val localVariables =
       goToInScopeVariables(
         childNode = identNode,
         ident = ident,
-        source = source
-      )
+        source = sourceCode.tree
+      ).flatMap(GoToLocation(_, sourceCode.parsed))
 
-    arguments ++ constants ++ localVariables
+    argumentsAndConstants ++ functionArguments ++ localVariables
   }
 
   /**
-   * Navigate to the argument(s) for the given variable.
+   * Go-to global variable definitions in scope which are constants and template arguments.
    *
-   * @param variableNode The node representing the variable.
-   * @param variableId   The variable to find the argument for.
-   * @param source       The source tree to search within.
-   * @return An array sequence of [[Ast.Argument]]s matching the search result.
-   * */
-  private def goToArguments(variableNode: Node[Ast.Positioned],
-                            variableId: Ast.Ident,
-                            source: Tree.Source): Iterator[Ast.Argument] = {
-    val functionArguments =
-      goToNearestFunctionArguments(
-        childNode = variableNode,
-        ident = variableId
+   * @param ident The identity of the definition to search.
+   * @param tree  The source tree to search the identity within.
+   * @return An iterator over constants and arguments.
+   */
+  private def goToConstantsAndTemplateArguments(ident: Ast.Ident,
+                                                tree: Tree.Source): Iterator[Ast.Positioned] = {
+    val constants =
+      goToConstants(
+        ident = ident,
+        source = tree
       )
 
     val templateArguments =
       goToTemplateArguments(
-        source = source,
-        ident = variableId
+        source = tree,
+        ident = ident
       )
 
-    functionArguments ++ templateArguments
+    constants ++ templateArguments
   }
 
   /**
@@ -206,8 +208,8 @@ private object GoToIdent {
    * @param ident  The constant identification to find.
    * @return The constant definitions.
    */
-  private def goToConstants(source: Tree.Source,
-                            ident: Ast.Ident): Iterator[Ast.ConstantVarDef] =
+  private def goToConstants(ident: Ast.Ident,
+                            source: Tree.Source): Iterator[Ast.ConstantVarDef] =
     source
       .rootNode
       .walkDown

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
@@ -15,8 +15,7 @@ private object GoToIdent {
    *
    * @param identNode  The node representing the identifier in the AST.
    * @param ident      The identifier for which the argument definition is sought.
-   * @param sourceCode The source tree in scope.
-   * @param sourceCode The parsed state of the source-code where the search is executed.
+   * @param sourceCode The source-tree where this search was executed and its parsed source-code state.
    * @return An array sequence of positioned ASTs matching the search result.
    * */
   def goTo(identNode: Node[Ast.Positioned],

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
@@ -178,11 +178,11 @@ private object GoToIdent {
   }
 
   /**
-   * Go-to global variable definitions in scope which are constants and template arguments.
+   * Navigate to constants and template arguments within the source tree.
    *
-   * @param ident The identity of the definition to search.
-   * @param tree  The source tree to search the identity within.
-   * @return An iterator over constants and arguments.
+   * @param ident The identity to search for.
+   * @param tree  The source tree to search within.
+   * @return An iterator over the found constants and arguments.
    */
   private def goToConstantsAndTemplateArguments(ident: Ast.Ident,
                                                 tree: Tree.Source): Iterator[Ast.Positioned] = {

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
@@ -15,7 +15,8 @@ private object GoToIdent {
    *
    * @param identNode  The node representing the identifier in the AST.
    * @param ident      The identifier for which the argument definition is sought.
-   * @param sourceCode The source-tree where this search was executed and its parsed source-code state.
+   * @param sourceCode The source-tree and its parsed source-code state, where this search was executed.
+   * @param workspace  The workspace where this search was executed and where all the source trees exist.
    * @return An array sequence of positioned ASTs matching the search result.
    * */
   def goTo(identNode: Node[Ast.Positioned],

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToSource.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToSource.scala
@@ -46,8 +46,8 @@ private object GoToSource {
             GoToTypeId.goTo(
               identNode = typIdNode,
               typeId = typeId,
-              source = sourceCode.tree,
-              sourceCode = sourceCode.parsed
+              sourceCode = sourceCode,
+              workspace = workspace
             )
 
           case _ =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToSource.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToSource.scala
@@ -6,7 +6,6 @@ import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra._
 import org.alephium.ralph.lsp.pc.search.gotodef.data.GoToLocation
 import org.alephium.ralph.lsp.pc.sourcecode.SourceTreeInScope
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
-import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 
 private object GoToSource {
 
@@ -15,6 +14,7 @@ private object GoToSource {
    *
    * @param cursorIndex The index of the token clicked by the user.
    * @param sourceCode  The parsed state of the source-code where the search is executed.
+   * @param workspace   The workspace where this search was executed and where all the source trees exist.
    * @return An iterator over the target go-to location(s).
    */
   def goTo(cursorIndex: Int,
@@ -37,9 +37,8 @@ private object GoToSource {
             GoToFuncId.goTo(
               funcIdNode = funcIdNode,
               funcId = funcId,
-              source = sourceCode.tree,
-              sourceCode = sourceCode.parsed,
-              dependencyBuiltIn = workspace.build.findDependency(DependencyID.BuiltIn)
+              sourceCode = sourceCode,
+              workspace = workspace
             )
 
           case typIdNode @ Node(typeId: Ast.TypeId, _) =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToTypeId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToTypeId.scala
@@ -43,10 +43,11 @@ private object GoToTypeId {
 
           case Node(emitEvent: Ast.EmitEvent[_], _) if emitEvent.id == typeId =>
             // They selected an event emit. Take 'em there!
-            goToEventDef(
-              emitEvent = emitEvent,
-              source = sourceCode.tree
-            ).flatMap(GoToLocation(_, sourceCode.parsed))
+            GoTo.inScope(
+              sourceCode = sourceCode,
+              workspace = workspace,
+              searcher = goToEventDef(emitEvent, _)
+            )
 
           case Node(eventDef: Ast.EventDef, _) if eventDef.id == typeId =>
             // They selected an event definition. Find event usages.

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArgumentSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArgumentSpec.scala
@@ -94,6 +94,32 @@ class GoToArgumentSpec extends AnyWordSpec with Matchers {
           |""".stripMargin
       )
     }
+
+    "there are duplicate arguments within inheritance" in {
+      goTo(
+        """
+          |Abstract Contract Parent3(>>param: MyParam<<,
+          |                          >>param: MyParam<<) { }
+          |
+          |
+          |Abstract Contract Parent2(>>param: MyParam<<,
+          |                          >>param: MyParam<<) extends Parent3() { }
+          |
+          |Abstract Contract Parent1(>>param: MyParam<<) extends Parent2() {
+          |
+          |  // this function also has `interface` as parameter, but it is not in scope.
+          |  pub fn local_function(param: MyParam) -> () { }
+          |}
+          |
+          |Contract GoToField(>>param: MyParam<<) extends Parent1() {
+          |
+          |  pub fn local_function(>>param: MyParam<<) -> () {
+          |    let result = param@@.function()
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
   }
 
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToAssignmentsInContractSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToAssignmentsInContractSpec.scala
@@ -66,7 +66,18 @@ class GoToAssignmentsInContractSpec extends AnyWordSpec with Matchers {
       "at multiple locations" in {
         goTo(
           """
-            |Contract GoToAssignment(>>mut counter: U256<<) {
+            |Abstract Contract Parent2(>>mut counter: U256<<) { }
+            |
+            |// This is not an Abstract, but Go-To definition should still work as expected.
+            |Contract Parent1(>>mut counter: U256<<,
+            |                 >>mut counter: U256<<) extends Parent2() {
+            |
+            |  // the counter parameter here is not in scope, so it should get added to search result.
+            |  fn function(mut counter: U256) -> () {}
+            |
+            |}
+            |
+            |Contract GoToAssignment(>>mut counter: U256<<) extends Parent1() {
             |
             |  pub fn function(>>mut counter: U256<<) -> () {
             |    >>let mut counter = 0

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToConstantSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToConstantSpec.scala
@@ -25,7 +25,11 @@ class GoToConstantSpec extends AnyWordSpec with Matchers {
     "constant exists" in {
       goTo(
         """
-          |Contract GoToConstant() {
+          |Abstract Contract Parent() {
+          |  >>const MyConstant = 1<<
+          |}
+          |
+          |Contract Child() extends Parent() {
           |
           |  >>const MyConstant = 0<<
           |
@@ -40,7 +44,12 @@ class GoToConstantSpec extends AnyWordSpec with Matchers {
     "duplicate constants exists" in {
       goTo(
         """
-          |Contract GoToConstant() {
+          |Abstract Contract Parent() {
+          |  >>const MyConstant = 2<<
+          |  >>const MyConstant = 3<<
+          |}
+          |
+          |Contract Child() extends Parent() {
           |
           |  >>const MyConstant = 0<<
           |  >>const MyConstant = 1<<
@@ -56,7 +65,13 @@ class GoToConstantSpec extends AnyWordSpec with Matchers {
     "constant and the Contract have the same name" in {
       goTo(
         """
-          |Contract MyConstant() {
+          |Abstract Contract MyConstant() {
+          |
+          |  >>const MyConstant = 2<<
+          |  >>const MyConstant = 3<<
+          |}
+          |
+          |Contract MyConstant() extends MyConstant() {
           |
           |  >>const MyConstant = 0<<
           |  >>const MyConstant = 1<<

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumFieldSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumFieldSpec.scala
@@ -24,7 +24,25 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
     "user selects the first enum field" in {
       goTo(
         """
-          |Contract MyContract() {
+          |// This parent is not inherited
+          |Abstract Contract ParentNotUsed() {
+          |
+          |  enum EnumType {
+          |    Field0 = 0
+          |    Field1 = 1
+          |  }
+          |}
+          |
+          |
+          |Abstract Contract Parent() {
+          |
+          |  enum EnumType {
+          |    >>Field0 = 0<<
+          |    Field1 = 1
+          |  }
+          |}
+          |
+          |Contract MyContract() extends Parent() {
           |
           |  enum EnumType {
           |    >>Field0 = 0<<
@@ -43,7 +61,15 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
     "user selects the second enum field" in {
       goTo(
         """
-          |Contract MyContract() {
+          |Abstract Contract Parent() {
+          |
+          |  enum EnumType {
+          |    >>Field0 = 0<<
+          |    Field1 = 1
+          |  }
+          |}
+          |
+          |Contract MyContract() extends Parent() {
           |
           |  enum EnumType {
           |    Field0 = 0
@@ -63,7 +89,19 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
       "user selects the first enum field" in {
         goTo(
           """
-            |Contract MyContract() {
+            |Abstract Contract Parent() {
+            |  enum EnumType {
+            |    >>Field0 = 0<<
+            |    Field1 = 1
+            |  }
+            |
+            |  enum EnumType {
+            |    >>Field0 = 0<<
+            |    Field1 = 1
+            |  }
+            |}
+            |
+            |Contract MyContract() extends Parent() {
             |
             |  enum EnumType {
             |    >>Field0 = 0<<

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumFieldSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumFieldSpec.scala
@@ -64,8 +64,8 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
           |Abstract Contract Parent() {
           |
           |  enum EnumType {
-          |    >>Field0 = 0<<
-          |    Field1 = 1
+          |    Field0 = 0
+          |    >>Field1 = 1<<
           |  }
           |}
           |

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumTypeSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumTypeSpec.scala
@@ -24,7 +24,15 @@ class GoToEnumTypeSpec extends AnyWordSpec with Matchers {
     "user selects the enum type of the first field" in {
       goTo(
         """
-          |Contract MyContract() {
+          |Abstract Contract Parent() {
+          |
+          |  enum >>EnumType<< {
+          |    Field0 = 0
+          |    Field1 = 1
+          |  }
+          |}
+          |
+          |Contract MyContract() extends Parent() {
           |
           |  enum >>EnumType<< {
           |    Field0 = 0
@@ -43,7 +51,15 @@ class GoToEnumTypeSpec extends AnyWordSpec with Matchers {
     "user selects the enum type of the second field" in {
       goTo(
         """
-          |Contract MyContract() {
+          |Abstract Contract Parent() {
+          |
+          |  enum >>EnumType<< {
+          |    Field0 = 0
+          |    Field1 = 1
+          |  }
+          |}
+          |
+          |Contract MyContract() extends Parent() {
           |
           |  enum >>EnumType<< {
           |    Field0 = 0
@@ -62,7 +78,33 @@ class GoToEnumTypeSpec extends AnyWordSpec with Matchers {
     "there are multiple enum types with duplicate names" in {
       goTo(
         """
-          |Contract MyContract() {
+          |Abstract Contract Parent2() {
+          |
+          |  enum EnumTypeNotUsed {
+          |    Field0 = 0
+          |    Field1 = 1
+          |  }
+          |
+          |  enum >>EnumType<< {
+          |    Field0 = 0
+          |    Field1 = 1
+          |  }
+          |}
+          |
+          |Abstract Contract Parent1() extends Parent2() {
+          |
+          |  enum >>EnumType<< {
+          |    Field0 = 0
+          |    Field1 = 1
+          |  }
+          |
+          |  enum EnumTypeNotUsed {
+          |    Field0 = 0
+          |    Field1 = 1
+          |  }
+          |}
+          |
+          |Contract MyContract() extends Parent1() {
           |
           |  enum >>EnumType<< {
           |    Field0 = 0

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEventSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEventSpec.scala
@@ -26,7 +26,15 @@ class GoToEventSpec extends AnyWordSpec with Matchers {
     "an event exists" in {
       goTo(
         """
-          |Contract Test() {
+          |Abstract Contract Parent() {
+          |
+          |  event TransferNotUsed(to: Address, amount: U256)
+          |
+          |  >>event Transfer(to: Address, amount: U256)<<
+          |
+          |}
+          |
+          |Contract Test() extends Parent() {
           |
           |  >>event Transfer(to: Address, amount: U256)<<
           |
@@ -38,27 +46,19 @@ class GoToEventSpec extends AnyWordSpec with Matchers {
       )
     }
 
-    "multiple events exist" in {
+    "duplicate events exist" in {
       goTo(
         """
-          |Contract Test() {
+          |Abstract Contract Parent() {
           |
-          |  >>event Transfer(to: Address, amount: U256)<<
           |  >>event Transfer(amount: U256)<<
+          |  >>event Transfer(to: Address, amount: U256)<<
+          |  event TransferNotUsed(to: Address, amount: U256)
           |  >>event Transfer(to: Address)<<
           |
-          |  pub fn function() -> () {
-          |    emit Transfe@@r(to, amount)
-          |  }
           |}
-          |""".stripMargin
-      )
-    }
-
-    "events exist with duplicate names" in {
-      goTo(
-        """
-          |Contract Transfer(transfer: Transfer) {
+          |
+          |Contract Test() extends Parent() {
           |
           |  >>event Transfer(to: Address, amount: U256)<<
           |  >>event Transfer(amount: U256)<<

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFunctionSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFunctionSpec.scala
@@ -42,7 +42,17 @@ class GoToFunctionSpec extends AnyWordSpec with Matchers {
     "function and argument have same names" in {
       goTo(
         """
-          |Contract MyContract(interface: MyInterface) {
+          |Abstract Contract Parent2() {
+          |
+          |  pub fn >>function_b<<(boolean: Bool) -> () { }
+          |}
+          |
+          |Abstract Contract Parent1() {
+          |
+          |  pub fn >>function_b<<(boolean: Bool) -> () { }
+          |}
+          |
+          |Contract MyContract(interface: MyInterface) extends Parent1(), Parent2() {
           |
           |  // function_b is also an input parameter, but it should still go to the target function.
           |  pub fn function_a(function_b: Bool) -> () {


### PR DESCRIPTION
- Building on previous PR #168, this enables in-scope go-to searches on other jump definition functions. 
- Towards #105