### PR TITLE
Native packager

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: lsp-server/target/universal/ralph-lsp-0.1.0-SNAPSHOT.zip
+          asset_path: target/universal/ralph-lsp-0.1.0-SNAPSHOT.zip
           asset_name: ralph-lsp-${{ steps.get_version.outputs.VERSION }}.zip
 
       - name: Upload Release Asset (VSCode Extension)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           version=$(echo ${GITHUB_REF/refs\/tags\//} | cut -c 2-)
           echo "VERSION=$version" >> $GITHUB_OUTPUT
         shell: bash
-      - run: sbt "compile; lsp-server/assembly"
+      - run: sbt "compile; lsp-server/assembly; universal:packageBin"
 
       - name: Install jq
         run: sudo apt-get install jq
@@ -54,7 +54,7 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Upload Release Asset
+      - name: Upload Release Asset (Jar)
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -63,6 +63,15 @@ jobs:
           asset_path: lsp-server/target/scala-2.13/ralph-lsp.jar
           asset_name: ralph-lsp-${{ steps.get_version.outputs.VERSION }}.jar
           asset_content_type: application/java-archive
+
+      - name: Upload Release Asset (Universal zip)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: lsp-server/target/universal/ralph-lsp-0.1.0-SNAPSHOT.zip
+          asset_name: ralph-lsp-${{ steps.get_version.outputs.VERSION }}.zip
 
       - name: Upload Release Asset (VSCode Extension)
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 17
-      - run: sbt "compile;test;doc"
+      - run: sbt "compile;test;doc;stage"
 
   test-windows:
     runs-on: windows-latest
@@ -24,4 +24,4 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 17
-      - run: sbt "compile;test;doc"
+      - run: sbt "compile;test;doc;stage"

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -9,16 +9,10 @@ on:
 
 jobs:
   test-ubuntu:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 17
-      - run: sbt "compile;test;doc;stage"
-
-  test-windows:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 17
-      - run: sbt "compile;test"
+      - run: sbt "compile;test;doc"
 
   test-windows:
     runs-on: windows-latest
@@ -24,4 +24,4 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 17
-      - run: sbt "compile;test"
+      - run: sbt "compile;test;doc"

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -8,7 +8,7 @@ on:
       - '**'
 
 jobs:
-  test-ubuntu:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,10 @@ val commonSettings =
         "-Ywarn-unused:patvars",
         "-Ywarn-unused:privates",
         "-Ywarn-value-discard"
-      ) ++ inliningOptions
+      ) ++ inliningOptions,
+      Compile / doc / scalacOptions ++= Seq(
+        "-no-link-warnings"
+      )
   )
 
 lazy val `compiler-access` =

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,9 @@
 val JAR_NAME =
   "ralph-lsp.jar"
 
+val MAIN_CLASS =
+  "org.alephium.ralph.lsp.Main"
+
 val inliningOptions =
   Seq(
     "-opt-warnings",
@@ -94,10 +97,9 @@ lazy val copyJARToVSCode =
 lazy val `lsp-server` =
   project
     .settings(
-      name := "ralph-lsp",
       commonSettings,
       scalacOptions += "-Xmixin-force-forwarders:false", // duplicate RPC method initialized.
-      assembly / mainClass := Some("org.alephium.ralph.lsp.Main"),
+      assembly / mainClass := Some(MAIN_CLASS),
       assembly / assemblyJarName := JAR_NAME,
       assemblyMergeStrategy := {
         case PathList("module-info.class") => MergeStrategy.discard
@@ -120,6 +122,14 @@ lazy val `lsp-server` =
           Dependencies.scalaLogging
         )
     ).dependsOn(`presentation-compiler`)
+
+lazy val `ralph-lsp` =
+  (project in file("."))
+    .settings(
+     commonSettings,
+     Compile / mainClass := Some(MAIN_CLASS),
+    ).dependsOn(`lsp-server`)
+    .aggregate(`compiler-access`, `presentation-compiler`, `lsp-server`)
     .enablePlugins(JavaAppPackaging)
 
 lazy val downloadWeb3AndInstallStd = taskKey[Unit]("Download alephium-web3 source code and copy std interface to the correct resource folder")

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ val inliningOptions =
   Seq(
     "-opt-warnings",
     "-opt:l:inline",
-    "-opt-inline-from:org.alephium.explorer.**"
+    "-opt-inline-from:org.alephium.ralph.lsp.**"
     // Uncomment to debug inlining
     /*
     "-Yopt-log-inline",

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,6 @@ val inliningOptions =
 
 val commonSettings =
   Seq(
-    name := "ralph-lsp",
     organization := "org.alephium",
     scalaVersion := Version.scala213,
     scalacOptions ++=
@@ -95,6 +94,7 @@ lazy val copyJARToVSCode =
 lazy val `lsp-server` =
   project
     .settings(
+      name := "ralph-lsp",
       commonSettings,
       scalacOptions += "-Xmixin-force-forwarders:false", // duplicate RPC method initialized.
       assembly / mainClass := Some("org.alephium.ralph.lsp.Main"),
@@ -120,6 +120,7 @@ lazy val `lsp-server` =
           Dependencies.scalaLogging
         )
     ).dependsOn(`presentation-compiler`)
+    .enablePlugins(JavaAppPackaging)
 
 lazy val downloadWeb3AndInstallStd = taskKey[Unit]("Download alephium-web3 source code and copy std interface to the correct resource folder")
 

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
@@ -143,7 +143,6 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
       thisServer.state = state.copy(listener = Some(listener()))
     }
 
-  /** @inheritdoc */
   override def initialize(params: InitializeParams): CompletableFuture[InitializeResult] =
     runAsync {
       cancelChecker =>
@@ -171,7 +170,6 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
         new InitializeResult(serverCapabilities())
     }
 
-  /** @inheritdoc */
   override def initialized(params: InitializedParams): Unit =
     runSync {
       logger.debug("Client initialized")
@@ -199,7 +197,6 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
       logger.debug("Client doesn't support dynamic registration for watched files")
     }
 
-  /** @inheritdoc */
   override def didOpen(params: DidOpenTextDocumentParams): Unit =
     runSync {
       val fileURI = uri(params.getTextDocument.getUri)
@@ -213,7 +210,6 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
       )
     }
 
-  /** @inheritdoc */
   override def didChange(params: DidChangeTextDocumentParams): Unit =
     runSync {
       val fileURI = uri(params.getTextDocument.getUri)
@@ -227,7 +223,6 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
       )
     }
 
-  /** @inheritdoc */
   override def didClose(params: DidCloseTextDocumentParams): Unit =
     runSync {
       val fileURI = uri(params.getTextDocument.getUri)
@@ -240,7 +235,6 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
       )
     }
 
-  /** @inheritdoc */
   override def didSave(params: DidSaveTextDocumentParams): Unit =
     runSync {
       val fileURI = uri(params.getTextDocument.getUri)
@@ -254,7 +248,6 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
       )
     }
 
-  /** @inheritdoc */
   override def didChangeWatchedFiles(params: DidChangeWatchedFilesParams): Unit =
     runSync {
       val changes =
@@ -296,7 +289,6 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
       }
     }
 
-  /** @inheritdoc */
   override def completion(params: CompletionParams): CompletableFuture[messages.Either[util.List[CompletionItem], CompletionList]] =
     runAsync {
       cancelChecker =>
@@ -347,7 +339,6 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
         }
     }
 
-  /** @inheritdoc */
   override def definition(params: DefinitionParams): CompletableFuture[messages.Either[util.List[_ <: Location], util.List[_ <: LocationLink]]] =
     runAsync {
       cancelChecker =>
@@ -589,7 +580,6 @@ class RalphLangServer private(@volatile private var state: ServerState)(implicit
             logger.error("Async request failed", error)
       }
 
-  /** @inheritdoc */
   override def setTrace(params: SetTraceParams): Unit =
     setTraceSetting(params.getValue)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
 addSbtPlugin("org.jetbrains" % "sbt-idea-plugin" % "3.20.1")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")


### PR DESCRIPTION
Resolves: https://github.com/alephium/ralph-lsp/issues/165 

This PR introduce [sbt-native-packager](https://github.com/sbt/sbt-native-packager) which allows to : 

Build native packages for different systems
  * Universal `zip`,`tar.gz`, `xz` archives
  * `deb` and `rpm` packages for Debian/RHEL based systems
  * `dmg` for macOS
  * `msi` for Windows
  * `docker` images
  * `graalvm` native images

I started with the `zip` archive, but we could later choose to add some others. In the archive, you have two folders: `bin` and `lib`,

in `bin` you have the `ralph-lsp` executable for Linux and MacOs, as well a `ralph-lsp.bat` for Windows.

Using the `sbt stage` command allows to create the `bin/lib` folders locally at `lsp-server/target/universal/stage` and is convenient for local development.
Adding `lsp-server/target/universal/stage/bin/` to your `PATH` gives you then `ralph-lsp` executable from anywhere and we don't need to run `java -jar ralph-lsp.jar`

`scaladoc` was failing in multiple places, see #172 