### PR TITLE
Check format in CI on Ubuntu only

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -19,3 +19,12 @@ jobs:
         with:
           java-version: 17
       - run: sbt "compile;test;doc;stage"
+
+  styling:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      - run: sbt "scalafmtCheckAll; scalafmtSbtCheck"


### PR DESCRIPTION
From [this comment](https://github.com/alephium/ralph-lsp/pull/174#issuecomment-2048953763) I tried to debug with my Windows.
I installed sbt on it....but `scalafmtCheck` was passing, I then noticed that our CI was not using the same java distribution as me:

Me: Temurin
CI: Azul system

I tried in both way, to use azul on my machine and temurin on CI, but always the same result: Works on my machine, not on CI.

I'm a bit clueless why it doesn't work, but I think we could take the same approach as in the node:

[Tests are run on every OS](https://github.com/alephium/alephium/blob/multi-inputs-one-pay-gas/.github/workflows/test.yml)
[Styling check is only run on Ubuntu](https://github.com/alephium/alephium/blob/multi-inputs-one-pay-gas/.github/workflows/styling.yml)

We thus have now 4 actions: 
![image](https://github.com/alephium/ralph-lsp/assets/2979182/7a74d454-8951-4702-87e8-a33c017451bf)

Checking format on every OS doesn't make much sense anyway IMO

We can also keep the branch for later if we prefer not to check format on CI yet