### PR TITLE
Implemented `goToCode`

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToTypeId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToTypeId.scala
@@ -6,7 +6,7 @@ import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.ast.node.Node
 import org.alephium.ralph.lsp.pc.search.gotodef.data.GoToLocation
 import org.alephium.ralph.lsp.pc.sourcecode.SourceTreeInScope
-import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
+import org.alephium.ralph.lsp.pc.workspace.{WorkspaceState, WorkspaceSearcher}
 
 private object GoToTypeId {
 
@@ -58,7 +58,11 @@ private object GoToTypeId {
             ).flatMap(GoToLocation(_, sourceCode.parsed))
 
           case _ =>
-            Iterator.empty
+            // For everything else find Contracts, Interfaces, or TxScripts with the given type ID.
+            goToCodeId(
+              typeId = typeId,
+              workspace = workspace
+            )
         }
 
       case None =>
@@ -139,6 +143,35 @@ private object GoToTypeId {
       .collect {
         case Node(emitEvent: Ast.EmitEvent[_], _) if emitEvent.id == eventDef.id =>
           emitEvent.id
+      }
+
+  /**
+   * Navigate to Contracts, Interfaces, or TxScripts by their type ID.
+   *
+   * @param typeId    The type ID to locate.
+   * @param workspace The Workspace where the implementation of the type ID may exist.
+   * @return An iterator over search result locations.
+   */
+  private def goToCodeId(
+      typeId: Ast.TypeId,
+      workspace: WorkspaceState.IsSourceAware): Iterator[GoToLocation] =
+    WorkspaceSearcher
+      .collectParsedInScope(workspace)
+      .iterator
+      .flatMap {
+        parsed =>
+          parsed
+            .ast
+            .statements
+            .iterator
+            .collect {
+              case source: Tree.Source if source.typeId() == typeId =>
+                GoToLocation(
+                  ast = source.typeId(),
+                  sourceCode = parsed
+                )
+            }
+            .flatten
       }
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
@@ -66,7 +66,7 @@ object WorkspaceSearcher {
    * @param workspace The workspace with dependencies.
    * @return Parsed source files in scope.
    */
-  private def collectParsedInScope(workspace: WorkspaceState.IsSourceAware): ArraySeq[SourceCodeState.Parsed] = {
+  def collectParsedInScope(workspace: WorkspaceState.IsSourceAware): ArraySeq[SourceCodeState.Parsed] = {
     // fetch the `std` dependency
     val stdSourceParsedCode =
       workspace

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToCodeSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToCodeSpec.scala
@@ -1,0 +1,99 @@
+package org.alephium.ralph.lsp.pc.search.gotodef
+
+import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class GoToCodeSpec extends AnyWordSpec with Matchers {
+
+  "return empty" when {
+    "typeId does not exist" in {
+      goTo(
+        """
+          |Contract GoToConstant() {
+          |
+          |  pub fn function(input: MyAbstrac@@t) -> () {
+          |
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
+  }
+
+  "return non-empty" when {
+    val types =
+      """
+        |TxScript >>Parent<<() {
+        |  assert!()
+        |}
+        |
+        |Abstract Contract >>Parent<<() { }
+        |
+        |Abstract Contract NotThis() { }
+        |
+        |Interface >>Parent<< {
+        |  fn function() -> ()
+        |}
+        |
+        |Interface NotThisEither {
+        |  fn function() -> ()
+        |}
+        |
+        |Contract >>Parent<<() {
+        |  fn function() -> () { }
+        |}
+        |""".stripMargin
+
+    "type is an inheritance" in {
+      goTo(
+        s"""
+          |$types
+          |
+          |Contract Child() extends Paren@@t() {
+          |  pub fn function() -> () { }
+          |}
+          |""".stripMargin
+      )
+    }
+
+    "type is a function parameter" in {
+      goTo(
+        s"""
+           |$types
+           |
+           |Contract Child() {
+           |  pub fn function(parent: Parent@@) -> () { }
+           |}
+           |""".stripMargin
+      )
+    }
+
+    "type is a template parameter" in {
+      goTo(
+        s"""
+           |$types
+           |
+           |Contract Child(parent: Parent@@) {
+           |  pub fn function() -> () { }
+           |}
+           |""".stripMargin
+      )
+    }
+
+    "type is a constructor" in {
+      goTo(
+        s"""
+           |$types
+           |
+           |Contract Child() {
+           |  pub fn function() -> () {
+           |    let parent = Parent@@(blah)
+           |  }
+           |}
+           |""".stripMargin
+      )
+    }
+  }
+
+}


### PR DESCRIPTION
- Go-to to `Contracts`, `Interfaces`, or `TxScripts` by their type ID.
- Towards #105 