### PR TITLE
Implements `GoTo.implementingChildren`

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoTo.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoTo.scala
@@ -33,12 +33,12 @@ object GoTo {
    * @param searcher   The search function to execute.
    * @return Go-to definition search results.
    */
-  def inScope(
+  def inheritedParents(
       sourceCode: SourceTreeInScope,
       workspace: WorkspaceState.IsSourceAware,
       searcher: Tree.Source => Iterator[Ast.Positioned]): Iterator[GoToLocation] =
     WorkspaceSearcher
-      .collectInScope(sourceCode, workspace) // collect all source-files/source-trees in scope
+      .collectInheritedParents(sourceCode, workspace) // collect all source-files/source-trees in scope
       .iterator
       .flatMap {
         treeInScope =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
@@ -95,7 +95,7 @@ private object GoToFuncId {
         dependencyBuiltIn = workspace.build.findDependency(DependencyID.BuiltIn)
       )
     else
-      GoTo.inScope(
+      GoTo.inheritedParents(
         sourceCode = sourceCode,
         workspace = workspace,
         searcher = goToLocalFunction(funcId, _)

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
@@ -63,7 +63,7 @@ private object GoToIdent {
 
           case Node(fieldSelector: Ast.EnumFieldSelector[_], _) if fieldSelector.field == ident =>
             // They selected an enum field. Take 'em there!
-            GoTo.inScope(
+            GoTo.inheritedParents(
               sourceCode = sourceCode,
               workspace = workspace,
               searcher = goToEnumField(fieldSelector, _)
@@ -174,7 +174,7 @@ private object GoToIdent {
       sourceCode: SourceTreeInScope,
       workspace: WorkspaceState.IsSourceAware): Iterator[GoToLocation] = {
     val argumentsAndConstants =
-      GoTo.inScope(
+      GoTo.inheritedParents(
         sourceCode = sourceCode,
         workspace = workspace,
         searcher = goToConstantsAndTemplateArguments(ident, _)

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToTypeId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToTypeId.scala
@@ -53,10 +53,11 @@ private object GoToTypeId {
 
           case Node(enumDef: Ast.EnumDef, _) if enumDef.id == typeId =>
             // They selected an enum definition. Find enum usages.
-            goToEnumTypeUsage(
-              enumDef = enumDef,
-              source = sourceCode.tree
-            ).flatMap(GoToLocation(_, sourceCode.parsed))
+            GoTo.implementingChildren(
+              sourceCode = sourceCode,
+              workspace = workspace,
+              searcher = goToEnumTypeUsage(enumDef, _)
+            )
 
           case Node(emitEvent: Ast.EmitEvent[_], _) if emitEvent.id == typeId =>
             // They selected an event emit. Take 'em there!

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToTypeId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToTypeId.scala
@@ -45,7 +45,7 @@ private object GoToTypeId {
         parent match {
           case Node(enumFieldSelector: Ast.EnumFieldSelector[_], _) if enumFieldSelector.enumId == typeId =>
             // They selected an enum type. Take 'em there!
-            GoTo.inScope(
+            GoTo.inheritedParents(
               sourceCode = sourceCode,
               workspace = workspace,
               searcher = goToEnumType(enumFieldSelector, _)
@@ -60,7 +60,7 @@ private object GoToTypeId {
 
           case Node(emitEvent: Ast.EmitEvent[_], _) if emitEvent.id == typeId =>
             // They selected an event emit. Take 'em there!
-            GoTo.inScope(
+            GoTo.inheritedParents(
               sourceCode = sourceCode,
               workspace = workspace,
               searcher = goToEventDef(emitEvent, _)
@@ -172,7 +172,7 @@ private object GoToTypeId {
       typeId: Ast.TypeId,
       workspace: WorkspaceState.IsSourceAware): Iterator[GoToLocation] =
     WorkspaceSearcher
-      .collectParsedInScope(workspace)
+      .collectParsed(workspace)
       .iterator
       .flatMap {
         parsed =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcher.scala
@@ -126,6 +126,29 @@ object SourceCodeSearcher {
     }
 
   /**
+   * Collects all children implementing or extending the given
+   * source tree within the provided source code files.
+   *
+   * @param source    The source tree to search for child implementations.
+   * @param allSource The source code files containing the child implementations.
+   * @return All child trees along with their corresponding source files.
+   */
+  def collectImplementingChildren(
+      source: Tree.Source,
+      allSource: ArraySeq[SourceCodeState.Parsed]): Seq[SourceTreeInScope] =
+    source.ast match {
+      case Left(contract) =>
+        collectImplementingChildren(
+          contract = contract,
+          allSource = allSource,
+          processedTrees = ListBuffer(source)
+        )
+
+      case Right(_) =>
+        Seq.empty
+    }
+
+  /**
    * Collects all source-trees representing implementations of the provided inheritances.
    *
    * @param inheritances   The inheritances to search for.
@@ -168,5 +191,46 @@ object SourceCodeSearcher {
               Seq.empty
           }
       }
+
+  /**
+   * Collects all source-trees representing children that implement or extend the given contract.
+   *
+   * @param contract       The contract for which its children are being searched.
+   * @param allSource      The source code files containing the inheritances.
+   * @param processedTrees A buffer to store processed source trees to avoid duplicate processing.
+   *                       This is a mutable collection, so this function must be private.
+   * @return All child trees along with their corresponding source files.
+   */
+  private def collectImplementingChildren(
+      contract: Ast.ContractWithState,
+      allSource: ArraySeq[SourceCodeState.Parsed],
+      processedTrees: ListBuffer[Tree.Source]): Seq[SourceTreeInScope] =
+    allSource flatMap {
+      parsed =>
+        parsed.ast.statements flatMap {
+          // collect the trees that belong to one of the inheritances and the ones that are not already processed
+          case source: Tree.Source if source.ast.left.exists(_.inheritances.exists(_.parentId == contract.ident)) && !processedTrees.contains(source) =>
+            processedTrees addOne source
+
+            source.ast match {
+              case Left(contract) =>
+                // TODO: There might a need for this to be tail-recursive to avoid stackoverflow on very large codebases.
+                val children =
+                  collectImplementingChildren(
+                    contract = contract,
+                    allSource = allSource,
+                    processedTrees = processedTrees
+                  )
+
+                children :+ SourceTreeInScope(source, parsed)
+
+              case Right(_) =>
+                Seq.empty
+            }
+
+          case _ =>
+            Seq.empty
+        }
+    }
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcher.scala
@@ -110,12 +110,12 @@ object SourceCodeSearcher {
    * @param allSource The source code files containing the parent implementations.
    * @return All parent source implementations found.
    */
-  def collectInheritanceInScope(
+  def collectInheritedParents(
       source: Tree.Source,
       allSource: ArraySeq[SourceCodeState.Parsed]): Seq[SourceTreeInScope] =
     source.ast match {
       case Left(contract) =>
-        collectParentsInherited(
+        collectInheritedParents(
           inheritances = contract.inheritances,
           allSource = allSource,
           processedTrees = ListBuffer(source)
@@ -131,10 +131,10 @@ object SourceCodeSearcher {
    * @param inheritances   The inheritances to search for.
    * @param allSource      The source code files containing the inheritance implementations.
    * @param processedTrees A buffer to store processed source trees to avoid duplicate processing.
-   *                       This is a mutable collection so this function must be private.
+   *                       This is a mutable collection, so this function must be private.
    * @return All inheritance implementations along with their corresponding source files.
    */
-  private def collectParentsInherited(
+  private def collectInheritedParents(
       inheritances: Seq[Ast.Inheritance],
       allSource: ArraySeq[SourceCodeState.Parsed],
       processedTrees: ListBuffer[Tree.Source]): Seq[SourceTreeInScope] =
@@ -152,7 +152,7 @@ object SourceCodeSearcher {
                 case Left(contract) =>
                   // TODO: There might a need for this to be tail-recursive to avoid stackoverflow on very large codebases.
                   val parents =
-                    collectParentsInherited(
+                    collectInheritedParents(
                       inheritances = contract.inheritances,
                       allSource = allSource,
                       processedTrees = processedTrees

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
@@ -76,6 +76,29 @@ object WorkspaceSearcher {
   }
 
   /**
+   * Collects all children implementing or extending the given
+   * source tree and public contracts/structs.
+   *
+   * @param sourceCode The source code for which in-scope files are being searched.
+   * @param workspace  The workspace that may contain files within the scope.
+   * @return The source trees within the scope.
+   */
+  def collectImplementingChildren(
+      sourceCode: SourceTreeInScope,
+      workspace: WorkspaceState.IsSourceAware): Seq[SourceTreeInScope] = {
+    val allInScopeCode =
+      collectParsed(workspace)
+
+    val inheritancesInScope =
+      SourceCodeSearcher.collectImplementingChildren(
+        source = sourceCode.tree,
+        allSource = allInScopeCode
+      )
+
+    inheritancesInScope :+ sourceCode
+  }
+
+  /**
    * Collects all parsed source files, excluding `std` dependency source files
    * that are not imported.
    *

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
@@ -54,20 +54,20 @@ object WorkspaceSearcher {
     }
 
   /**
-   * Collects all source trees within the scope of the provided source code.
+   * Collects all parent source implementations inherited by the given source tree.
    *
    * @param sourceCode The source code for which in-scope files are being searched.
    * @param workspace  The workspace that may contain files within the scope.
    * @return The source trees within the scope.
    */
-  def collectInScope(
+  def collectInheritedParents(
       sourceCode: SourceTreeInScope,
       workspace: WorkspaceState.IsSourceAware): Seq[SourceTreeInScope] = {
     val allInScopeCode =
-      collectParsedInScope(workspace)
+      collectParsed(workspace)
 
     val inheritancesInScope =
-      SourceCodeSearcher.collectInheritanceInScope(
+      SourceCodeSearcher.collectInheritedParents(
         source = sourceCode.tree,
         allSource = allInScopeCode
       )
@@ -82,7 +82,7 @@ object WorkspaceSearcher {
    * @param workspace The workspace with dependencies.
    * @return Parsed source files in scope.
    */
-  def collectParsedInScope(workspace: WorkspaceState.IsSourceAware): ArraySeq[SourceCodeState.Parsed] = {
+  def collectParsed(workspace: WorkspaceState.IsSourceAware): ArraySeq[SourceCodeState.Parsed] = {
     // fetch the `std` dependency
     val stdSourceParsedCode =
       workspace

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumTypeUsageSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumTypeUsageSpec.scala
@@ -68,6 +68,39 @@ class GoToEnumTypeUsageSpec extends AnyWordSpec with Matchers {
           |""".stripMargin
       )
     }
+
+    "there is inheritance" in {
+      goTo(
+        """
+          |Abstract Contract Parent() {
+          |  enum Enum@@Type {
+          |    Field0 = 0
+          |    Field1 = 1
+          |  }
+          |
+          |  fn functionParent() -> () {
+          |    let field0 = >>EnumType<<.Field0
+          |  }
+          |}
+          |
+          |Contract Parent1() extends Parent() {
+          |
+          |  pub fn function() -> () {
+          |  let field1 = >>EnumType<<.Field1
+          |    let field0 = >>EnumType<<.Field0
+          |  }
+          |}
+          |
+          |Contract Child() extends Parent1() {
+          |
+          |  pub fn function() -> () {
+          |    let field0 = >>EnumType<<.Field0
+          |    let field1 = >>EnumType<<.Field1
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
   }
 
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectImplementingChildrenSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectImplementingChildrenSpec.scala
@@ -1,0 +1,230 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.pc.sourcecode
+
+import org.alephium.ralph.lsp.access.compiler.CompilerAccess
+import org.alephium.ralph.lsp.access.compiler.ast.Tree
+import org.alephium.ralph.lsp.access.file.FileAccess
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.EitherValues._
+
+import scala.collection.immutable.ArraySeq
+
+class SourceCodeSearcherCollectImplementingChildrenSpec extends AnyWordSpec with Matchers {
+
+  implicit val file: FileAccess         = FileAccess.disk
+  implicit val compiler: CompilerAccess = CompilerAccess.ralphc
+
+  "return empty" when {
+    "input source-code has no inheritance" in {
+      val parsed =
+        TestSourceCode
+          .genParsed(
+            """
+            |Contract MyContract() {
+            |  fn function1() -> () {}
+            |}
+            |""".stripMargin
+          )
+          .sample
+          .get
+          .asInstanceOf[SourceCodeState.Parsed]
+
+      val tree =
+        parsed.ast.statements.head.asInstanceOf[Tree.Source]
+
+      SourceCodeSearcher.collectImplementingChildren(
+        source = tree,
+        allSource = ArraySeq.empty
+      ) shouldBe empty
+
+      TestSourceCode deleteIfExists parsed
+    }
+  }
+
+  "collect single child implementation" when {
+    def doTest(code: String) = {
+      val parsed =
+        TestSourceCode
+          .genParsed(code)
+          .sample
+          .get
+          .asInstanceOf[SourceCodeState.Parsed]
+
+      // first statement is Parent()
+      val parent = parsed.ast.statements.head.asInstanceOf[Tree.Source]
+      parent.ast.merge.name shouldBe "Parent"
+
+      // second statement is Child()
+      val child = parsed.ast.statements.last.asInstanceOf[Tree.Source]
+      child.ast.merge.name shouldBe "Child"
+
+      // expect parent to be returned
+      val expected =
+        SourceTreeInScope(
+          tree = child,
+          parsed = parsed
+        )
+
+      val actual =
+        SourceCodeSearcher.collectImplementingChildren(
+          source = parent,
+          allSource = ArraySeq(parsed)
+        )
+
+      actual should contain only expected
+
+      TestSourceCode deleteIfExists parsed
+    }
+
+    "parent is an Abstract Contract" in {
+      doTest {
+        """
+          |Abstract Contract Parent() { }
+          |
+          |Contract Child() extends Parent() {
+          |  fn function1() -> () {}
+          |}
+          |""".stripMargin
+      }
+    }
+
+    "parent is an Interface" in {
+      doTest {
+        """
+          |Interface Parent {
+          |  pub fn parent() -> U256
+          |}
+          |
+          |Contract Child() implements Parent {
+          |  pub fn parent() -> U256 {
+          |    return 1
+          |  }
+          |}
+          |""".stripMargin
+      }
+    }
+  }
+
+  "collect deep inheritance" when {
+    "it also contains cyclic and duplicate inheritance" in {
+
+      val file1 =
+        TestSourceCode
+          .genParsedOK(
+            """
+              |Abstract Contract Parent2() extends Parent4(), Parent6() implements Parent1 { }
+              |
+              |// Interface is implemented
+              |Interface Parent1 {
+              |  pub fn parent() -> U256
+              |}
+              |
+              |// Parent3 is not extends by Child(), it should not be in the result
+              |Abstract Contract Parent3() extends Parent1(), Parent1() { }
+              |
+              |Contract Child() extends Parent2(), Child(), Parent5() implements Parent1 {
+              |  pub fn parent() -> U256 {
+              |    return 1
+              |  }
+              |}
+              |""".stripMargin
+          )
+          .sample
+          .get
+
+      // file2 contains the Parent6() contract for which the children are collected.
+      val file2 =
+        TestSourceCode
+          .genParsedOK(
+            """
+              |// Parent6's children are being collect in this test
+              |Abstract Contract Parent6() extends Parent4() { }
+              |
+              |Abstract Contract Parent5() extends Parent4(), Parent5() { }
+              |
+              |Abstract Contract Parent4() extends Parent5(), Parent6(), Parent4() { }
+              |""".stripMargin
+          )
+          .sample
+          .get
+
+      // collect all trees from file1
+      val treesFromFile1 =
+        file1.ast.statements.map(_.asInstanceOf[Tree.Source])
+
+      // collect all trees from file2
+      val treesFromFile2 =
+        file2.ast.statements.map(_.asInstanceOf[Tree.Source])
+
+      // the first statement in file2 is Parent6()
+      val parent = treesFromFile2.head
+      parent.ast.merge.name shouldBe "Parent6"
+
+      // expect children to be returned excluding Parent1() and Parent3()
+      val expectedTreesFromFile1 =
+        treesFromFile1
+          .filterNot {
+            tree =>
+              tree.ast.merge.name == "Parent1" || tree.ast.merge.name == "Parent3"
+          }
+          .map {
+            child =>
+              SourceTreeInScope(
+                tree = child,
+                parsed = file1 // file1 is in scope
+              )
+          }
+
+      val expectedTreesFromFile2 =
+        treesFromFile2
+          .filterNot {
+            tree =>
+              tree.ast.merge.name == "Parent6"
+          }
+          .map {
+            child =>
+              SourceTreeInScope(
+                tree = child,
+                parsed = file2 // file2 is in scope
+              )
+          }
+
+      // collect all parent trees to expect
+      val expectedTrees =
+        expectedTreesFromFile1 ++ expectedTreesFromFile2
+
+      // actual trees returned
+      val actual =
+        SourceCodeSearcher.collectImplementingChildren(
+          source = parent,
+          allSource = ArraySeq(file1, file2)
+        )
+
+      actual should contain theSameElementsAs expectedTrees
+
+      // Double check: Also assert the names of the parents.
+      val parentNames = actual.map(_.tree.ast.left.value.name)
+      // Note: Parent3 and Child are not included.
+      parentNames should contain only ("Parent4", "Parent2", "Parent5", "Child")
+
+      TestSourceCode deleteAllIfExists Array(file1, file2)
+    }
+  }
+
+}

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectInheritanceInScopeSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectInheritanceInScopeSpec.scala
@@ -48,7 +48,7 @@ class SourceCodeSearcherCollectInheritanceInScopeSpec extends AnyWordSpec with M
       val tree =
         parsed.ast.statements.head.asInstanceOf[Tree.Source]
 
-      SourceCodeSearcher.collectInheritanceInScope(
+      SourceCodeSearcher.collectInheritedParents(
         source = tree,
         allSource = ArraySeq.empty
       ) shouldBe empty
@@ -82,7 +82,7 @@ class SourceCodeSearcherCollectInheritanceInScopeSpec extends AnyWordSpec with M
         )
 
       val actual =
-        SourceCodeSearcher.collectInheritanceInScope(
+        SourceCodeSearcher.collectInheritedParents(
           source = child,
           allSource = ArraySeq(parsed)
         )
@@ -209,7 +209,7 @@ class SourceCodeSearcherCollectInheritanceInScopeSpec extends AnyWordSpec with M
 
       // actual trees returned
       val actual =
-        SourceCodeSearcher.collectInheritanceInScope(
+        SourceCodeSearcher.collectInheritedParents(
           source = child,
           allSource = ArraySeq(file1, file2)
         )

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectInheritanceInScopeSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectInheritanceInScopeSpec.scala
@@ -31,7 +31,7 @@ class SourceCodeSearcherCollectInheritanceInScopeSpec extends AnyWordSpec with M
   implicit val compiler: CompilerAccess = CompilerAccess.ralphc
 
   "return empty" when {
-    "input source-code is empty" in {
+    "source-code has no inheritance" in {
       val parsed =
         TestSourceCode
           .genParsed(

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectInheritedParentsSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectInheritedParentsSpec.scala
@@ -25,7 +25,7 @@ import org.scalatest.EitherValues._
 
 import scala.collection.immutable.ArraySeq
 
-class SourceCodeSearcherCollectInheritanceInScopeSpec extends AnyWordSpec with Matchers {
+class SourceCodeSearcherCollectInheritedParentsSpec extends AnyWordSpec with Matchers {
 
   implicit val file: FileAccess         = FileAccess.disk
   implicit val compiler: CompilerAccess = CompilerAccess.ralphc

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcherCollectInheritedParentsSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcherCollectInheritedParentsSpec.scala
@@ -29,7 +29,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 import scala.collection.immutable.ArraySeq
 
-class WorkspaceSearcherCollectInScopeSpec extends AnyWordSpec with Matchers {
+class WorkspaceSearcherCollectInheritedParentsSpec extends AnyWordSpec with Matchers {
 
   implicit val file: FileAccess         = FileAccess.disk
   implicit val compiler: CompilerAccess = CompilerAccess.ralphc
@@ -150,7 +150,7 @@ class WorkspaceSearcherCollectInScopeSpec extends AnyWordSpec with Matchers {
 
     // execute the function
     val actual =
-      WorkspaceSearcher.collectInScope(
+      WorkspaceSearcher.collectInheritedParents(
         sourceCode = SourceTreeInScope(
           tree = childTree.tree,
           parsed = sourceFile1


### PR DESCRIPTION
Implements `GoTo.implementingChildren`, it searches all the children implementing a parent `Contract`.

For example: Selecting `MyEnum` in `Parent()` contract would provides its usages within both children `Child1` and `Child2` contracts.

```rust
Abstract Contract Parent() {
  enum MyEnum {
    Field = 1
  }
}


Contract Child1() extends Parent() {
  fn function() -> () {
    let _ = MyEnum.Field
  }
}

Contract Child2() extends Parent() {
  fn function() -> () {
    let _ = MyEnum.Field
  }

}
```

This PR applies `implementingChildren` to just `enum` types. Following PR #185 applies it to all.

Towards #105.