### PR TITLE
Apply `GoTo.implementingChildren`

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
@@ -60,10 +60,15 @@ private object GoToFuncId {
             )
 
           case Node(funcDef: Ast.FuncDef[_], _) if funcDef.id == funcId =>
-            goToFunctionUsage(
-              funcId = funcDef.id,
-              source = sourceCode.tree
-            ).flatMap(GoToLocation(_, sourceCode.parsed))
+            GoTo.implementingChildren(
+              sourceCode = sourceCode,
+              workspace = workspace,
+              searcher = // search for function usages
+                goToFunctionUsage(
+                  funcId = funcDef.id,
+                  _
+                )
+            )
 
           case Node(callExpr: Ast.ContractCallExpr, _) if callExpr.callId == funcId =>
             // TODO: The user clicked on a external function call. Take 'em there!

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
@@ -79,11 +79,16 @@ private object GoToIdent {
               .collect {
                 // Check: Parent is an enum definition which contains the enum field.
                 case enumDef: Ast.EnumDef if enumDef.fields.exists(_.ident == field.ident) =>
-                  goToEnumFieldUsage(
-                    enumType = enumDef.id,
-                    enumField = field,
-                    source = sourceCode.tree
-                  ).flatMap(GoToLocation(_, sourceCode.parsed))
+                  GoTo.implementingChildren(
+                    sourceCode = sourceCode,
+                    workspace = workspace,
+                    searcher = // search for usages
+                      goToEnumFieldUsage(
+                        enumType = enumDef.id,
+                        enumField = field,
+                        _
+                      )
+                  )
               }
               .flatten
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
@@ -102,11 +102,16 @@ private object GoToIdent {
               .collect {
                 // Check: Parent is an event definition which contains the event field.
                 case eventDef: Ast.EventDef if eventDef.fields.exists(_.ident == field.ident) =>
-                  goToEventFieldUsage(
-                    eventDefId = eventDef.id,
-                    eventFieldIndex = eventDef.fields.indexWhere(_.ident == field.ident),
-                    source = sourceCode.tree
-                  ).flatMap(GoToLocation(_, sourceCode.parsed))
+                  GoTo.implementingChildren(
+                    sourceCode = sourceCode,
+                    workspace = workspace,
+                    searcher = // search for usages
+                      goToEventFieldUsage(
+                        eventDefId = eventDef.id,
+                        eventFieldIndex = eventDef.fields.indexWhere(_.ident == field.ident),
+                        _
+                      )
+                  )
               }
               .flatten
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
@@ -115,13 +115,18 @@ private object GoToIdent {
               }
               .flatten
 
-          case constantDefNode @ Node(constantDef: Ast.ConstantVarDef, _) if constantDef.ident == ident =>
+          case Node(constantDef: Ast.ConstantVarDef, _) if constantDef.ident == ident =>
             // They selected a constant definition. Take 'em there!
-            goToIdentUsage(
-              fromNode = constantDefNode,
-              fromNodeIdent = constantDef.ident,
-              source = sourceCode.tree
-            ).flatMap(GoToLocation(_, sourceCode.parsed))
+            GoTo.implementingChildren(
+              sourceCode = sourceCode,
+              workspace = workspace,
+              searcher = // search for usages
+                tree =>
+                  goToVariableUsages(
+                    ident = constantDef.ident,
+                    from = tree.rootNode
+                  )
+            )
 
           case namedVarNode @ Node(namedVar: Ast.NamedVar, _) if namedVar.ident == ident =>
             // User selected a named variable. Find its usages.

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToTypeId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToTypeId.scala
@@ -69,10 +69,11 @@ private object GoToTypeId {
 
           case Node(eventDef: Ast.EventDef, _) if eventDef.id == typeId =>
             // They selected an event definition. Find event usages.
-            goToEventDefUsage(
-              eventDef = eventDef,
-              source = sourceCode.tree
-            ).flatMap(GoToLocation(_, sourceCode.parsed))
+            GoTo.implementingChildren(
+              sourceCode = sourceCode,
+              workspace = workspace,
+              searcher = goToEventDefUsage(eventDef, _)
+            )
 
           case _ =>
             // For everything else find Contracts, Interfaces, or TxScripts with the given type ID.

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToConstantUsagesSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToConstantUsagesSpec.scala
@@ -73,6 +73,38 @@ class GoToConstantUsagesSpec extends AnyWordSpec with Matchers {
       }
 
     }
+
+    "there is inheritance" in {
+      goTo(
+        """
+          |Abstract Contract Parent() {
+          |
+          |  const MyCons@@tant = 0
+          |
+          |  fn function0() -> () {
+          |    let my_constant2 = >>MyConstant<<
+          |    let my_constant3 = MyConstant_B
+          |  }
+          |}
+          |
+          |Contract Parent1() extends Parent() {
+          |
+          |  pub fn function1() -> () {
+          |    let my_constant2 = >>MyConstant<<
+          |    let my_constant3 = MyConstant_B
+          |  }
+          |}
+          |
+          |Contract Child() extends Parent1() {
+          |
+          |  pub fn function2() -> () {
+          |    let my_constant2 = >>MyConstant<<
+          |    let my_constant3 = MyConstant_B
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
   }
 
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumFieldUsageSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumFieldUsageSpec.scala
@@ -95,6 +95,41 @@ class GoToEnumFieldUsageSpec extends AnyWordSpec with Matchers {
             |""".stripMargin
         )
       }
+
+      "there is inheritance" in {
+        goTo(
+          """
+            |Abstract Contract Parent() {
+            |
+            |  enum EnumType {
+            |    Field0 = 0
+            |    Fie@@ld1 = 1
+            |  }
+            |
+            |  fn function0() -> () {
+            |    let field0 = EnumType.Field0
+            |    let field1 = EnumType.>>Field1<<
+            |  }
+            |}
+            |
+            |Contract Parent1() extends Parent() {
+            |
+            |  pub fn function1() -> () {
+            |    let field1 = EnumType.>>Field1<<
+            |    let field0 = EnumType.Field0
+            |  }
+            |}
+            |
+            |Contract Child() extends Parent1() {
+            |
+            |  pub fn function2() -> () {
+            |    let field1 = EnumType.>>Field1<<
+            |    let field0 = EnumType.Field0
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
     }
   }
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEventFieldUsageSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEventFieldUsageSpec.scala
@@ -90,6 +90,35 @@ class GoToEventFieldUsageSpec extends AnyWordSpec with Matchers {
           |""".stripMargin
       )
     }
+
+    "there is inheritance" in {
+      goTo(
+        """
+          |Abstract Contract Parent() {
+          |
+          |  event Transfer(to: Address, a@@mount: U256)
+          |
+          |  fn function0() -> () {
+          |    emit Transfer(to, >>amount1<<)
+          |  }
+          |}
+          |
+          |Contract Parent1() extends Parent() {
+          |
+          |  pub fn function1() -> () {
+          |    emit Transfer(to, >>amount1<<)
+          |  }
+          |}
+          |
+          |Contract Child() extends Parent1() {
+          |
+          |  pub fn function2() -> () {
+          |    emit Transfer(to, >>amount1<<)
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
   }
 
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEventIdUsageSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEventIdUsageSpec.scala
@@ -74,6 +74,35 @@ class GoToEventIdUsageSpec extends AnyWordSpec with Matchers {
           |""".stripMargin
       )
     }
+
+    "there is inheritance" in {
+      goTo(
+        """
+          |Abstract Contract Parent() {
+          |
+          |  event Transfe@@r(to: Address, amount: U256)
+          |
+          |  fn function0() -> () {
+          |    emit >>Transfer<<(to, amount)
+          |  }
+          |}
+          |
+          |Contract Parent1() extends Parent() {
+          |
+          |  pub fn function1() -> () {
+          |    emit >>Transfer<<(to, amount)
+          |  }
+          |}
+          |
+          |Contract Child() extends Parent1() {
+          |
+          |  pub fn function2() -> () {
+          |    emit >>Transfer<<(to, amount)
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
   }
 
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFunctionUsageSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFunctionUsageSpec.scala
@@ -73,6 +73,28 @@ class GoToFunctionUsageSpec extends AnyWordSpec with Matchers {
           |""".stripMargin
       )
     }
+
+    "function usage exist within inheritance" in {
+      goTo(
+        """
+          |Abstract Contract Parent() {
+          |
+          |  pub fn @@function_a(boolean: Bool) -> () {
+          |    let call1 = >>function_a(true)<<
+          |    >>function_a(false)<<
+          |  }
+          |}
+          |
+          |Contract Child() extends Parent() {
+          |
+          |  pub fn function_b(boolean: Bool) -> () {
+          |    let call1 = >>function_a(true)<<
+          |    >>function_a(false)<<
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
   }
 
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFunctionUsageSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFunctionUsageSpec.scala
@@ -24,12 +24,12 @@ import org.scalatest.wordspec.AnyWordSpec
 class GoToFunctionUsageSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
-    "function calls do not exist" in {
+    "function usage do not exist" in {
       goTo(
         """
           |Contract MyContract(interface: MyInterface) {
           |
-          |  // function_a has no local calls
+          |  // function_a has no local usage
           |  pub fn @@function_a(boolean: Bool) -> () {
           |
           |  }
@@ -44,7 +44,7 @@ class GoToFunctionUsageSpec extends AnyWordSpec with Matchers {
   }
 
   "return non-empty" when {
-    "function calls exist" in {
+    "function usage exist" in {
       goTo(
         """
           |Contract MyContract(interface: MyInterface) {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoTotArgumentUsageInContractSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoTotArgumentUsageInContractSpec.scala
@@ -86,6 +86,92 @@ class GoTotArgumentUsageInContractSpec extends AnyWordSpec with Matchers {
           |""".stripMargin
       )
     }
+
+    "arguments are inherited" when {
+      "from a function" in {
+        goTo(
+          """
+            |// Nothing from parent gets used
+            |Abstract Contract Parent() {
+            |
+            |  pub fn function(param1: ParamType, param2: ParamType) -> () {
+            |    let result = param1.someFunction()
+            |  }
+            |
+            |}
+            |
+            |Contract Child() extends Parent() {
+            |
+            |  // its a function argument so parents should not output search results
+            |  // search should occur locally within this function
+            |  pub fn function(param1@@: ParamType, param2: ParamType) -> () {
+            |    let result = >>param1<<.someFunction()
+            |  }
+            |
+            |  pub fn function2(param1: ParamType, param2: ParamType) -> () {
+            |    let result = param1.someFunction()
+            |  }
+            |
+            |}
+            |""".stripMargin
+        )
+      }
+
+      "from the template" when {
+        "there are no duplicate names" in {
+          goTo(
+            """
+              |Abstract Contract Parent(param1@@: ParamType) {
+              |
+              |  pub fn function(param1: ParamType, param2: ParamType) -> () {
+              |    let result = >>param1<<.someFunction()
+              |  }
+              |
+              |}
+              |
+              |Contract Child() extends Parent() {
+              |
+              |  pub fn function(param2: ParamType) -> () {
+              |    let result = >>param1<<.someFunction()
+              |  }
+              |
+              |  pub fn function2(param1: ParamType, param2: ParamType) -> () {
+              |    let result = >>param1<<.someFunction()
+              |  }
+              |
+              |}
+              |""".stripMargin
+          )
+        }
+
+        "there are duplicate names" in {
+          goTo(
+            """
+              |Abstract Contract Parent(param1@@: ParamType) {
+              |
+              |  pub fn function(param1: ParamType, param2: ParamType) -> () {
+              |    let result = >>param1<<.someFunction()
+              |  }
+              |
+              |}
+              |
+              |Contract Child(param1: ParamType) extends Parent(param1) {
+              |
+              |  pub fn function(param2: ParamType) -> () {
+              |    let result = >>param1<<.someFunction()
+              |  }
+              |
+              |  pub fn function2(param1: ParamType, param2: ParamType) -> () {
+              |    let result = >>param1<<.someFunction()
+              |  }
+              |
+              |}
+              |""".stripMargin
+          )
+        }
+      }
+
+    }
   }
 
 }


### PR DESCRIPTION
- Builds on #184. 
- Applies `GoTo.implementingChildren` to all usage search functions.
- Towards #105.