### PR TITLE
Reduce release size

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,8 +15,14 @@ object Dependencies {
   lazy val scalaMock  = "org.scalamock"     %% "scalamock"       % "6.0.0"    % Test
 
   /** Core */
-  lazy val ralphc = "org.alephium"     %% "alephium-ralphc"   % "2.12.0"
-  lazy val lsp4j  = "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.22.0"
+  lazy val ralphc = "org.alephium" %% "alephium-ralphc" % "2.12.0" excludeAll (
+    ExclusionRule(organization = "org.rocksdb"),
+    ExclusionRule(organization = "io.prometheus"),
+    ExclusionRule(organization = "org.alephium", name = "alephium-api_2.13"),
+    ExclusionRule(organization = "org.alephium", name = "alephium-io_2.13")
+  )
+
+  lazy val lsp4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.22.0"
 
   /** Logging */
   lazy val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging"   % "3.9.5"


### PR DESCRIPTION
84mb -> 28mb

We can't remove `bouncycastle` and `akka (ByteString)` as it's used by some stuff we use from the node.

Before:
![image](https://github.com/alephium/ralph-lsp/assets/2979182/0c30e077-df74-492c-823c-23eb681a20d9)

After:
![image](https://github.com/alephium/ralph-lsp/assets/2979182/5efa50cf-efff-43de-bbef-a1a0ab779e8e)
