### PR TITLE
Redundant imports

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToTypeId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToTypeId.scala
@@ -17,7 +17,6 @@
 package org.alephium.ralph.lsp.pc.search.gotodef
 
 import org.alephium.ralph.Ast
-import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.ast.node.Node
 import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
 import org.alephium.ralph.lsp.pc.workspace.{WorkspaceState, WorkspaceSearcher}
@@ -174,22 +173,12 @@ private object GoToTypeId {
     WorkspaceSearcher
       .collectParsed(workspace)
       .iterator
-      .flatMap {
-        parsed =>
-          parsed
-            .ast
-            .statements
-            .iterator
-            .collect {
-              case tree: Tree.Source if tree.typeId() == typeId =>
-                SourceLocation.Node(
-                  ast = tree.typeId(),
-                  source = SourceLocation.Code(
-                    tree = tree,
-                    parsed = parsed
-                  )
-                )
-            }
+      .collect {
+        case source if source.tree.typeId() == typeId =>
+          SourceLocation.Node(
+            ast = source.tree.typeId(),
+            source = source
+          )
       }
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
@@ -136,13 +136,22 @@ object WorkspaceSearcher {
             }
       }
 
+    // Pull in all inherited source-files for the used import statements.
+    val importedInheritedParentTrees =
+      SourceCodeSearcher.collectInheritedParentsForAll(
+        sourceCode = importedCode,
+        workspace = stdSourceParsedCode
+      )
+
+    // collect all imported code including the inherited code.
+    val allImportedCode =
+      (SourceCodeSearcher.collectSourceTrees(importedCode) ++ importedInheritedParentTrees).distinct
+
+    // The entire local local dev workspace source-code is available.
     val workspaceTrees =
       SourceCodeSearcher.collectSourceTrees(workspaceCode)
 
-    val importedTrees =
-      SourceCodeSearcher.collectSourceTrees(importedCode)
-
-    workspaceTrees ++ importedTrees
+    workspaceTrees ++ allImportedCode
   }
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
@@ -68,7 +68,7 @@ object WorkspaceSearcher {
 
     val inheritancesInScope =
       SourceCodeSearcher.collectInheritedParents(
-        source = sourceCode.tree,
+        source = sourceCode,
         allSource = allInScopeCode
       )
 
@@ -91,7 +91,7 @@ object WorkspaceSearcher {
 
     val inheritancesInScope =
       SourceCodeSearcher.collectImplementingChildren(
-        source = sourceCode.tree,
+        source = sourceCode,
         allSource = allInScopeCode
       )
 
@@ -105,13 +105,13 @@ object WorkspaceSearcher {
    * @param workspace The workspace with dependencies.
    * @return Parsed source files in scope.
    */
-  def collectParsed(workspace: WorkspaceState.IsSourceAware): ArraySeq[SourceCodeState.Parsed] = {
+  def collectParsed(workspace: WorkspaceState.IsSourceAware): ArraySeq[SourceLocation.Code] = {
     // fetch the `std` dependency
     val stdSourceParsedCode =
       workspace
         .build
         .findDependency(DependencyID.Std)
-        .toSeq
+        .to(ArraySeq)
         .flatMap(_.sourceCode.map(_.parsed))
 
     // collect all parsed source-files
@@ -136,7 +136,13 @@ object WorkspaceSearcher {
             }
       }
 
-    workspaceCode ++ importedCode
+    val workspaceTrees =
+      SourceCodeSearcher.collectSourceTrees(workspaceCode)
+
+    val importedTrees =
+      SourceCodeSearcher.collectSourceTrees(importedCode)
+
+    workspaceTrees ++ importedTrees
   }
 
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToCodeSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToCodeSpec.scala
@@ -94,6 +94,33 @@ class GoToCodeSpec extends AnyWordSpec with Matchers {
            |""".stripMargin
       )
     }
+
+    "implemented interfaces is indirectly imported" in {
+      goToStd(
+        """
+          |// This import does not contain the implemented INFTCollection interface,
+          |// but it has INFTCollectionWithRoyalty that implements it.
+          |import "std/nft_collection_with_royalty_interface"
+          |
+          |Abstract Contract TheContract() implements INFTCollection@@ { }
+          |
+          |""".stripMargin,
+        Some(("Interface INFTCollection {", "INFTCollection"))
+      )
+    }
+
+    "implemented interfaces is directly imported" in {
+      goToStd(
+        """
+          |// An obvious import.
+          |import "std/nft_collection_with_royalty_interface"
+          |
+          |Abstract Contract TheContract() implements INFTCollectionWithRoyalty@@ { }
+          |
+          |""".stripMargin,
+        Some(("Interface INFTCollectionWithRoyalty extends INFTCollection {", "INFTCollectionWithRoyalty"))
+      )
+    }
   }
 
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeCompileSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeCompileSpec.scala
@@ -32,106 +32,104 @@ import scala.collection.immutable.ArraySeq
 
 class SourceCodeCompileSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
-  "compile" should {
-    "return empty compiled source-code" when {
-      "source-code and dependency are empty" in {
-        implicit val compiler: CompilerAccess =
-          CompilerAccess.ralphc
+  "return empty compiled source-code" when {
+    "source-code and dependency are empty" in {
+      implicit val compiler: CompilerAccess =
+        CompilerAccess.ralphc
 
-        val result =
-          SourceCode
-            .compile(
-              sourceCode = ArraySeq.empty,
-              dependency = ArraySeq.empty,
-              compilerOptions = CompilerOptions.Default,
-              workspaceErrorURI = TestFile.genFolderURI().sample.value
-            )
-            .value
+      val result =
+        SourceCode
+          .compile(
+            sourceCode = ArraySeq.empty,
+            dependency = ArraySeq.empty,
+            compilerOptions = CompilerOptions.Default,
+            workspaceErrorURI = TestFile.genFolderURI().sample.value
+          )
+          .value
 
-        result shouldBe empty
-      }
-
-      "only source-code are empty" in {
-        implicit val compiler: CompilerAccess =
-          CompilerAccess.ralphc
-
-        val dependencyBuild =
-          TestDependency.buildStd()
-
-        val result =
-          SourceCode
-            .compile(
-              sourceCode = ArraySeq.empty,
-              dependency = dependencyBuild.findDependency(DependencyID.Std).value.sourceCode,
-              compilerOptions = CompilerOptions.Default,
-              workspaceErrorURI = TestFile.genFolderURI().sample.value
-            )
-            .value
-
-        result shouldBe empty
-      }
+      result shouldBe empty
     }
 
-    "all source files" should {
-      "have a SourceCodeState.Compiled entry" in {
-        implicit val compiler: CompilerAccess =
-          CompilerAccess.ralphc
+    "only source-code are empty" in {
+      implicit val compiler: CompilerAccess =
+        CompilerAccess.ralphc
 
-        // No File IO should occur because all code is already in-memory.
-        implicit val file: FileAccess =
-          null
+      val dependencyBuild =
+        TestDependency.buildStd()
 
-        // all source types
-        val source =
-          ArraySeq(
-            TestCode.genContract("MyContract"),   // A Contract
-            TestCode.genAbstract("MyAbstract"),   // An Abstract
-            TestCode.genInterface("MyInterface"), // An Interface
-            TestCode.genScript("MyScript")        // A Script
+      val result =
+        SourceCode
+          .compile(
+            sourceCode = ArraySeq.empty,
+            dependency = dependencyBuild.findDependency(DependencyID.Std).value.sourceCode,
+            compilerOptions = CompilerOptions.Default,
+            workspaceErrorURI = TestFile.genFolderURI().sample.value
           )
-            .map(TestSourceCode.genParsedOK(_))
-            .map(_.sample.get)
+          .value
 
-        // Expected that all source files have a SourceCodeState.Compiled entry
-        val result =
-          SourceCode
-            .compile(
-              sourceCode = source,
-              dependency = ArraySeq.empty,
-              compilerOptions = CompilerOptions.Default,
-              workspaceErrorURI = Paths.get(source.head.fileURI).getParent.toUri // workspace URI
-            )
-            .value
-            .map(_.asInstanceOf[SourceCodeState.Compiled])
+      result shouldBe empty
+    }
+  }
 
-        result should have size source.size.toLong
+  "all source files" should {
+    "have a SourceCodeState.Compiled entry" in {
+      implicit val compiler: CompilerAccess =
+        CompilerAccess.ralphc
 
-        /** First: MyContract */
-        result.head.fileURI shouldBe source.head.fileURI
-        result.head.code shouldBe source.head.code
-        result.head.parsed shouldBe source.head
-        result.head.compiledCode should have size 1
-        result.head.compiledCode.head.left.value shouldBe a[CompiledContract] // Contract is compiled
+      // No File IO should occur because all code is already in-memory.
+      implicit val file: FileAccess =
+        null
 
-        /** Second: MyAbstract */
-        result(1).fileURI shouldBe source(1).fileURI
-        result(1).code shouldBe source(1).code
-        result(1).parsed shouldBe source(1)
-        result(1).compiledCode shouldBe empty // Abstract is not compiled
+      // all source types
+      val source =
+        ArraySeq(
+          TestCode.genContract("MyContract"),   // A Contract
+          TestCode.genAbstract("MyAbstract"),   // An Abstract
+          TestCode.genInterface("MyInterface"), // An Interface
+          TestCode.genScript("MyScript")        // A Script
+        )
+          .map(TestSourceCode.genParsedOK(_))
+          .map(_.sample.get)
 
-        /** Third: MyInterface */
-        result(2).fileURI shouldBe source(2).fileURI
-        result(2).code shouldBe source(2).code
-        result(2).parsed shouldBe source(2)
-        result(2).compiledCode shouldBe empty // Interface is not compiled
+      // Expected that all source files have a SourceCodeState.Compiled entry
+      val result =
+        SourceCode
+          .compile(
+            sourceCode = source,
+            dependency = ArraySeq.empty,
+            compilerOptions = CompilerOptions.Default,
+            workspaceErrorURI = Paths.get(source.head.fileURI).getParent.toUri // workspace URI
+          )
+          .value
+          .map(_.asInstanceOf[SourceCodeState.Compiled])
 
-        /** Fourth: MyInterface */
-        result(3).fileURI shouldBe source(3).fileURI
-        result(3).code shouldBe source(3).code
-        result(3).parsed shouldBe source(3)
-        result(3).compiledCode should have size 1
-        result(3).compiledCode.head.value shouldBe a[CompiledScript] // Script is compiled
-      }
+      result should have size source.size.toLong
+
+      /** First: MyContract */
+      result.head.fileURI shouldBe source.head.fileURI
+      result.head.code shouldBe source.head.code
+      result.head.parsed shouldBe source.head
+      result.head.compiledCode should have size 1
+      result.head.compiledCode.head.left.value shouldBe a[CompiledContract] // Contract is compiled
+
+      /** Second: MyAbstract */
+      result(1).fileURI shouldBe source(1).fileURI
+      result(1).code shouldBe source(1).code
+      result(1).parsed shouldBe source(1)
+      result(1).compiledCode shouldBe empty // Abstract is not compiled
+
+      /** Third: MyInterface */
+      result(2).fileURI shouldBe source(2).fileURI
+      result(2).code shouldBe source(2).code
+      result(2).parsed shouldBe source(2)
+      result(2).compiledCode shouldBe empty // Interface is not compiled
+
+      /** Fourth: MyInterface */
+      result(3).fileURI shouldBe source(3).fileURI
+      result(3).code shouldBe source(3).code
+      result(3).parsed shouldBe source(3)
+      result(3).compiledCode should have size 1
+      result(3).compiledCode.head.value shouldBe a[CompiledScript] // Script is compiled
     }
   }
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectInheritedParentsForAllSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectInheritedParentsForAllSpec.scala
@@ -1,0 +1,150 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.pc.sourcecode
+
+import org.alephium.ralph.lsp.access.compiler.CompilerAccess
+import org.alephium.ralph.lsp.access.file.FileAccess
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.collection.immutable.ArraySeq
+
+class SourceCodeSearcherCollectInheritedParentsForAllSpec extends AnyWordSpec with Matchers {
+
+  implicit val file: FileAccess         = FileAccess.disk
+  implicit val compiler: CompilerAccess = CompilerAccess.ralphc
+
+  "return empty" when {
+    "source-code has no inheritance" in {
+      val parsed =
+        TestSourceCode
+          .genParsedOK(
+            """
+              |Contract MyContract() {
+              |  fn function1() -> () {}
+              |}
+              |""".stripMargin
+          )
+          .sample
+          .get
+
+      SourceCodeSearcher.collectInheritedParentsForAll(
+        sourceCode = ArraySeq(parsed),
+        workspace = ArraySeq.empty
+      ) shouldBe empty
+
+      TestSourceCode deleteIfExists parsed
+    }
+  }
+
+  "collect unique parent implementations" when {
+    "input is a single file" in {
+      val parsed =
+        TestSourceCode
+          .genParsedOK(
+            """
+              |// Struct should not be included
+              |struct MyStruct {bool: Bool}
+              |
+              |Interface Parent3 {
+              |  pub fn parent() -> U256
+              |}
+              |
+              |Abstract Contract Parent2() extends Parent2() implements Parent3 { }
+              |
+              |Abstract Contract Parent1() extends Parent2(), Parent2() { }
+              |
+              |Contract Child1() extends Parent1() implements Parent3 {
+              |  fn function1() -> () {}
+              |}
+              |
+              |Contract Child2() extends Parent1() implements Parent3 {
+              |  fn function1() -> () {}
+              |}
+              |""".stripMargin
+          )
+          .sample
+          .get
+
+      val result =
+        SourceCodeSearcher.collectInheritedParentsForAllTrees(
+          sourceCode = parsed,
+          workspace = ArraySeq(parsed)
+        )
+
+      val actualNames =
+        result.map(_.tree.ast.merge.name)
+
+      val expectedNames =
+        Array("Parent1", "Parent2", "Parent3")
+
+      actualNames should contain theSameElementsAs expectedNames
+    }
+
+    "input contains multiple file" in {
+      val parsed1 =
+        TestSourceCode
+          .genParsedOK(
+            """
+              |// Struct should not be included
+              |struct MyStruct {bool: Bool}
+              |
+              |Abstract Contract Parent2() extends Parent2() implements Parent3 { }
+              |
+              |Contract Child1() extends Parent1() implements Parent3 {
+              |  fn function1() -> () {}
+              |}
+              |""".stripMargin
+          )
+          .sample
+          .get
+
+      val parsed2 =
+        TestSourceCode
+          .genParsedOK(
+            """
+              |Interface Parent3 {
+              |  pub fn parent() -> U256
+              |}
+              |
+              |Abstract Contract Parent1() extends Parent2(), Parent2() { }
+              |
+              |Contract Child2() extends Parent1() implements Parent3 {
+              |  fn function1() -> () {}
+              |}
+              |""".stripMargin
+          )
+          .sample
+          .get
+
+      val result =
+        SourceCodeSearcher.collectInheritedParentsForAll(
+          sourceCode = ArraySeq(parsed1, parsed2),
+          workspace = ArraySeq(parsed1, parsed2)
+        )
+
+      val actualNames =
+        result.map(_.tree.ast.merge.name)
+
+      val expectedNames =
+        Array("Parent1", "Parent2", "Parent3")
+
+      actualNames should contain theSameElementsAs expectedNames
+    }
+  }
+
+}


### PR DESCRIPTION
Currently, the following code also requires the inclusion of the second `import` statement. This behaviour is incorrect. This PR addresses this by ensuring all inherited `Tree`s required for the `Contract` are provided during compilation.

```rust
import "std/nft_collection_with_royalty_interface"
// import "std/nft_collection_interface"

Interface Test extends INFTCollectionWithRoyalty {
   fn function() -> ()
}
```

TODO: Use `Set` to replace `.distinct` calls.