### PR TITLE
Suggest top level keywords

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/CodeCompletionProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/CodeCompletionProvider.scala
@@ -56,8 +56,9 @@ private[search] object CodeCompletionProvider extends CodeProvider[Suggestion] w
         }
 
       case None =>
-        // TODO: Provide top level completion.
-        Iterator.empty
+        TopLevelCompleter
+          .suggest()
+          .iterator
     }
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/TopLevelCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/TopLevelCompleter.scala
@@ -1,0 +1,72 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.pc.search.completion
+
+import scala.collection.immutable.ArraySeq
+
+object TopLevelCompleter {
+
+  def suggest(): ArraySeq[Suggestion.Keyword] =
+    ArraySeq(
+      suggestImport(),
+      suggestContract(),
+      suggestAbstractContract(),
+      suggestInterface(),
+      suggestTxScript()
+    )
+
+  private def suggestImport(): Suggestion.Keyword =
+    Suggestion.Keyword(
+      label = "import",
+      insert = """import """"",
+      detail = "Import a dependency file to the project",
+      documentation = ""
+    )
+
+  private def suggestContract(): Suggestion.Keyword =
+    Suggestion.Keyword(
+      label = "Contract",
+      insert = "Contract ",
+      detail = "Similar to classes in object-oriented languages",
+      documentation = ""
+    )
+
+  private def suggestAbstractContract(): Suggestion.Keyword =
+    Suggestion.Keyword(
+      label = "Abstract Contract",
+      insert = "Abstract Contract ",
+      detail = "Similar to abstract classes in object-oriented languages",
+      documentation = ""
+    )
+
+  private def suggestInterface(): Suggestion.Keyword =
+    Suggestion.Keyword(
+      label = "Interface",
+      insert = "Interface ",
+      detail = "Similar to interfaces in object-oriented languages",
+      documentation = ""
+    )
+
+  private def suggestTxScript(): Suggestion.Keyword =
+    Suggestion.Keyword(
+      label = "TxScript",
+      insert = "TxScript ",
+      detail = "Code to interact with contracts on the blockchain",
+      documentation = ""
+    )
+
+}

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/completion/TopLevelCompleterSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/completion/TopLevelCompleterSpec.scala
@@ -16,39 +16,38 @@
 
 package org.alephium.ralph.lsp.pc.search.completion
 
-sealed trait Suggestion extends Product {
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
 
-  def label: String
+class TopLevelCompleterSpec extends AnyWordSpec with Matchers {
 
-  def insert: String
+  "suggest top level statements" when {
+    "requested for the first line" in {
+      val suggestions =
+        suggest {
+          """
+            |@@
+            |
+            |Abstract Contract Dummy() { }
+            |""".stripMargin
+        }
 
-  def detail: String
+      suggestions shouldBe TopLevelCompleter.suggest()
+    }
 
-  def documentation: String
+    "requested for the second line" in {
+      val suggestions =
+        suggest {
+          """
+            |Abstract Contract Dummy() { }
+            |
+            |@@
+            |""".stripMargin
+        }
 
-}
-
-object Suggestion {
-
-  case class Function(
-      label: String,
-      insert: String,
-      detail: String,
-      documentation: String)
-    extends Suggestion
-
-  case class Field(
-      label: String,
-      insert: String,
-      detail: String,
-      documentation: String)
-    extends Suggestion
-
-  case class Keyword(
-      label: String,
-      insert: String,
-      detail: String,
-      documentation: String)
-    extends Suggestion
+      suggestions shouldBe TopLevelCompleter.suggest()
+    }
+  }
 
 }


### PR DESCRIPTION
- Towards #98.
- Blocker issue #104.

I've added `Similar to <...> in object-oriented languages` style details for now because it seems like they will be more helpful for beginners. Can always change these later.

![image](https://github.com/alephium/ralph-lsp/assets/1773953/bf250bf7-5d45-4936-82f9-b6923ca92d28)

# Unsuccessful Scenarios

Top level code completion in following empty file is unable to do work because the parser fails to provide an AST.

```scala
val suggestions =
  suggest {
    """
      |@@
      |""".stripMargin
  }
```

Requesting code completion after `Contr` also fails for the same reason.

```scala
val suggestions =
  suggest {
    """
      |Contr@@
      |""".stripMargin
  }
```

There are many other cases like these. Issue #104 is a blocker here.