### PR TITLE
Remove `BuiltIn.contains`

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleter.scala
@@ -128,7 +128,7 @@ object FunctionBodyCompleter {
 
         case Node(function: Ast.FuncDef[_], _) =>
           // suggest function names
-          Suggestion.Function(SourceLocation.Node(function, sourceCode))
+          Suggestion.FuncDef(SourceLocation.Node(function, sourceCode))
 
         case Node(eventDef: Ast.EventDef, _) =>
           // suggest events
@@ -149,7 +149,7 @@ object FunctionBodyCompleter {
    * @param workspace The workspace that contains the built-in dependency.
    * @return Iterator over built-in functions.
    */
-  private def suggestBuiltinFunctions(workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion.Function] =
+  private def suggestBuiltinFunctions(workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion.FuncDef] =
     workspace.build.findDependency(DependencyID.BuiltIn) match {
       case Some(builtIn) =>
         WorkspaceSearcher
@@ -167,7 +167,7 @@ object FunctionBodyCompleter {
    * @param source The source code that may contain functions.
    * @return An iterator over suggested functions.
    */
-  private def suggestsFunctions(source: SourceLocation.Code): Iterator[Suggestion.Function] =
+  private def suggestsFunctions(source: SourceLocation.Code): Iterator[Suggestion.FuncDef] =
     source.tree.ast match {
       case Left(contract) =>
         contract
@@ -181,7 +181,7 @@ object FunctionBodyCompleter {
                   source = source
                 )
 
-              Suggestion.Function(node)
+              Suggestion.FuncDef(node)
           }
 
       case Right(_) =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleter.scala
@@ -128,7 +128,10 @@ object FunctionBodyCompleter {
 
         case Node(function: Ast.FuncDef[_], _) =>
           // suggest function names
-          Suggestion.FuncDef(SourceLocation.Node(function, sourceCode))
+          Suggestion.FuncDef(
+            node = SourceLocation.Node(function, sourceCode),
+            isBuiltIn = false
+          )
 
         case Node(eventDef: Ast.EventDef, _) =>
           // suggest events
@@ -155,19 +158,28 @@ object FunctionBodyCompleter {
         WorkspaceSearcher
           .collectTrees(builtIn)
           .iterator
-          .flatMap(suggestsFunctions)
+          .flatMap {
+            source =>
+              suggestFunctions(
+                source = source,
+                isBuiltInSource = true
+              )
+          }
 
       case None =>
         Iterator.empty
     }
 
   /**
-   * Suggests all functions available from this source code.
+   * Suggests all functions available in the given source code.
    *
-   * @param source The source code that may contain functions.
-   * @return An iterator over suggested functions.
+   * @param source          The source code that may contain function definitions.
+   * @param isBuiltInSource True if the given source is from the built-in dependency, false otherwise.
+   * @return An iterator over the suggested functions.
    */
-  private def suggestsFunctions(source: SourceLocation.Code): Iterator[Suggestion.FuncDef] =
+  private def suggestFunctions(
+      source: SourceLocation.Code,
+      isBuiltInSource: Boolean): Iterator[Suggestion.FuncDef] =
     source.tree.ast match {
       case Left(contract) =>
         contract
@@ -181,7 +193,10 @@ object FunctionBodyCompleter {
                   source = source
                 )
 
-              Suggestion.FuncDef(node)
+              Suggestion.FuncDef(
+                node = node,
+                isBuiltIn = isBuiltInSource
+              )
           }
 
       case Right(_) =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/Suggestion.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/Suggestion.scala
@@ -145,7 +145,7 @@ object Suggestion {
 
   }
 
-  case class Function(node: SourceLocation.Node[Ast.FuncDef[_]]) extends Suggestion.InheritedAPI {
+  case class FuncDef(node: SourceLocation.Node[Ast.FuncDef[_]]) extends Suggestion.InheritedAPI {
 
     override def toCompletion(): Seq[Completion] = {
       val paramTypes =

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/Suggestion.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/Suggestion.scala
@@ -19,7 +19,6 @@ package org.alephium.ralph.lsp.pc.search.completion
 import org.alephium.ralph
 import org.alephium.ralph.Ast
 import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
-import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 
 sealed trait Suggestion {
 
@@ -145,7 +144,10 @@ object Suggestion {
 
   }
 
-  case class FuncDef(node: SourceLocation.Node[Ast.FuncDef[_]]) extends Suggestion.InheritedAPI {
+  case class FuncDef(
+      node: SourceLocation.Node[Ast.FuncDef[_]],
+      isBuiltIn: Boolean)
+    extends Suggestion.InheritedAPI {
 
     override def toCompletion(): Seq[Completion] = {
       val paramTypes =
@@ -157,9 +159,6 @@ object Suggestion {
               s"""${argument.ident.name}: ${argument.tpe.signature}"""
           }
           .mkString("(", ", ", ")")
-
-      val isBuiltIn =
-        DependencyID.BuiltIn contains node.parsed.fileURI
 
       val suffix =
         if (isBuiltIn)

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/DependencyID.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/DependencyID.scala
@@ -16,8 +16,6 @@
 
 package org.alephium.ralph.lsp.pc.workspace.build.dependency
 
-import java.net.URI
-import java.nio.file.{Paths, Path}
 import scala.collection.immutable.ArraySeq
 
 sealed trait DependencyID extends Product {
@@ -29,29 +27,8 @@ sealed trait DependencyID extends Product {
 
 object DependencyID {
 
-  case object Std extends DependencyID
-
-  case object BuiltIn extends DependencyID {
-
-    /**
-     * Checks if the built-in dependency contains the given file.
-     *
-     * @param fileURI The URI of the file to check.
-     * @return True if the file is contained in the built-in dependency, otherwise false.
-     */
-    def contains(fileURI: URI): Boolean =
-      contains(Paths.get(fileURI))
-
-    /**
-     * Checks if the built-in dependency contains the given file.
-     *
-     * @param filePath The Path of the file to check.
-     * @return True if the file is contained in the built-in dependency, otherwise false.
-     */
-    def contains(filePath: Path): Boolean =
-      filePath.getParent.getFileName.toString == BuiltIn.dirName
-
-  }
+  case object Std     extends DependencyID
+  case object BuiltIn extends DependencyID
 
   def all(): ArraySeq[DependencyID] =
     ArraySeq(


### PR DESCRIPTION
The `BuiltIn.contains` is incorrect; if I created a folder named `builtin` in my workspace, functions in that folder would get suggested as built-in (Not in master) 