### PR TITLE
Version 2: Code completion local to a function

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/SourceCodeCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/SourceCodeCompleter.scala
@@ -18,9 +18,8 @@ package org.alephium.ralph.lsp.pc.search.completion
 
 import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
-import org.alephium.ralph.Ast
-import org.alephium.ralph.lsp.access.compiler.ast.node.Node
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.SourceIndexExtension
+import org.alephium.ralph.lsp.pc.search.gotodef.GoToIdent
 
 object SourceCodeCompleter {
 
@@ -38,16 +37,16 @@ object SourceCodeCompleter {
       workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion] =
     sourceCode.tree.rootNode.findLast(_.sourceIndex.exists(_ contains cursorIndex)) match { // find the node closest to this source-index
       case Some(closest) =>
-        closest match {
-          case functionNode @ Node(function: Ast.FuncDef[_], _) =>
+        GoToIdent.goToNearestFuncDef(closest) match {
+          case Some(functionNode) =>
             FunctionBodyCompleter.suggest(
               cursorIndex = cursorIndex,
-              functionNode = functionNode.upcast(function),
+              functionNode = functionNode,
               sourceCode = sourceCode,
               workspace = workspace
             )
 
-          case _ =>
+          case None =>
             Iterator.empty
         }
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
@@ -420,9 +420,9 @@ private[search] object GoToIdent {
         // If the input node is a function, return the node itself.
         Some(childNode.upcast(function))
 
-      case _ =>
-        childNode
-          .data
+      case ast: Ast.Positioned =>
+        // For everything else, find the nearest function.
+        ast
           .sourceIndex
           .flatMap {
             childNodeIndex =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
@@ -23,7 +23,7 @@ import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra._
 import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
 import org.alephium.ralph.lsp.pc.workspace.{WorkspaceState, WorkspaceSearcher}
 
-private object GoToIdent {
+private[search] object GoToIdent {
 
   /**
    * Navigate to the argument(s) for the given identifier.
@@ -413,7 +413,7 @@ private object GoToIdent {
    * @param childNode The node to traverse up from.
    * @return An Option containing the nearest function definition, if found.
    */
-  private def goToNearestFuncDef(childNode: Node[Ast.Positioned, Ast.Positioned]): Option[Node[Ast.FuncDef[_], Ast.Positioned]] =
+  def goToNearestFuncDef(childNode: Node[Ast.Positioned, Ast.Positioned]): Option[Node[Ast.FuncDef[_], Ast.Positioned]] =
     childNode.data match {
       case function: Ast.FuncDef[_] =>
         // Nested function definitions are not allowed in Ralph.

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleterSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleterSpec.scala
@@ -215,6 +215,96 @@ class FunctionBodyCompleterSpec extends AnyWordSpec with Matchers {
 
       actual should contain allElementsOf expected
     }
+
+    "after variable assignment" in {
+      val suggestions =
+        suggest {
+          """
+          |Contract Test() {
+          |
+          |  fn aFunction() -> () {
+          |    let aVariable = true
+          |    let copyVariable = a@@
+          |  }
+          |
+          |}
+          |""".stripMargin
+        }
+
+      val actual =
+        suggestions.flatMap(_.toCompletion())
+
+      val expected =
+        Array(
+          Completion.Method(
+            label = "aFunction() -> ()",
+            insert = "aFunction()",
+            detail = ""
+          ),
+          Completion.Variable(
+            label = "aVariable",
+            insert = "aVariable",
+            detail = ""
+          )
+        )
+
+      actual should contain allElementsOf expected
+    }
+
+    "within nested for loops" in {
+      val suggestions =
+        suggest {
+          """
+            |Contract Test() {
+            |
+            |  fn aFunction() -> () {
+            |    let mut counter = 1
+            |    for (let mut index1 = 0; index1 <= 4; index1 = index2 + 1) {
+            |      counter = counter + 1
+            |      for (let mut index2 = 0; index1 <= 4; index2 = i@@ + 1) {
+            |        counter = counter + 1
+            |      }
+            |    }
+            |  }
+            |
+            |}
+            |""".stripMargin
+        }
+
+      val actual =
+        suggestions.flatMap(_.toCompletion())
+
+      val expected =
+        Array(
+          Completion.Method(
+            label = "aFunction() -> ()",
+            insert = "aFunction()",
+            detail = ""
+          ),
+          Completion.Variable(
+            label = "mut counter",
+            insert = "counter",
+            detail = ""
+          ),
+          Completion.Variable(
+            label = "mut counter",
+            insert = "counter",
+            detail = ""
+          ),
+          Completion.Variable(
+            label = "mut index1",
+            insert = "index1",
+            detail = ""
+          ),
+          Completion.Variable(
+            label = "mut index2",
+            insert = "index2",
+            detail = ""
+          )
+        )
+
+      actual should contain allElementsOf expected
+    }
   }
 
 }


### PR DESCRIPTION
Following PR #193, this PR enables requests for code-completion everywhere in a function's body.

![image](https://github.com/alephium/ralph-lsp/assets/1773953/e3b1f3cb-ca74-4749-ab00-dec54fd65dc6)

Note: This will also suggest everything within the scope of a function for completion requests on `enum` types, for example, `MyEnum.E@@` will also suggest built-in functions etc. This will resolve itself as code-completion for enums and object function calls gets implemented.

Edit: The above "Note" is temporarily resolved in #196.

Towards #98.