### PR TITLE
Move search function out from go-to types

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleter.scala
@@ -20,13 +20,41 @@ import org.alephium.ralph.lsp.access.compiler.ast.node.Node
 import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
 import org.alephium.ralph.Ast
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.SourceIndexExtension
+import org.alephium.ralph.lsp.pc.search.gotodef.GoToIdent
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 import org.alephium.ralph.lsp.pc.workspace.{WorkspaceState, WorkspaceSearcher}
 
 object FunctionBodyCompleter {
 
   /**
-   * Provides suggestions available at the given position within the body of a function.
+   * Provides all code completion suggestions within the scope of a function for the given index.
+   *
+   * @param cursorIndex     The index representing the cursor position where the request was submitted.
+   * @param closestToCursor The node closest to the cursor index.
+   * @param sourceCode      The source code where the completion is requested.
+   * @param workspace       The workspace state containing the source code.
+   * @return An iterator over code completion suggestions.
+   */
+  def suggest(
+      cursorIndex: Int,
+      closestToCursor: Node[Ast.Positioned, Ast.Positioned],
+      sourceCode: SourceLocation.Code,
+      workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion.NodeAPI] =
+    GoToIdent.goToNearestFuncDef(closestToCursor) match {
+      case Some(functionNode) =>
+        suggestInFunctionBody(
+          cursorIndex = cursorIndex,
+          functionNode = functionNode,
+          sourceCode = sourceCode,
+          workspace = workspace
+        )
+
+      case None =>
+        Iterator.empty
+    }
+
+  /**
+   * Provides suggestions available within the body of a function at the given position.
    *
    * @param cursorIndex  The position where this search was executed.
    * @param functionNode The node representing the function where this search was executed.
@@ -34,7 +62,7 @@ object FunctionBodyCompleter {
    * @param workspace    The workspace containing the source code.
    * @return An iterator over suggestions available before the cursor position within the function.
    */
-  def suggest(
+  private def suggestInFunctionBody(
       cursorIndex: Int,
       functionNode: Node[Ast.FuncDef[_], Ast.Positioned],
       sourceCode: SourceLocation.Code,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleter.scala
@@ -20,7 +20,7 @@ import org.alephium.ralph.lsp.access.compiler.ast.node.Node
 import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
 import org.alephium.ralph.Ast
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.SourceIndexExtension
-import org.alephium.ralph.lsp.pc.search.gotodef.GoToIdent
+import org.alephium.ralph.lsp.pc.search.gotodef.GoToFuncId
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 import org.alephium.ralph.lsp.pc.workspace.{WorkspaceState, WorkspaceSearcher}
 
@@ -40,7 +40,7 @@ object FunctionBodyCompleter {
       closestToCursor: Node[Ast.Positioned, Ast.Positioned],
       sourceCode: SourceLocation.Code,
       workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion.NodeAPI] =
-    GoToIdent.goToNearestFuncDef(closestToCursor) match {
+    GoToFuncId.goToNearestFuncDef(closestToCursor) match {
       case Some(functionNode) =>
         suggestInFunctionBody(
           cursorIndex = cursorIndex,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleter.scala
@@ -38,7 +38,7 @@ object FunctionBodyCompleter {
       cursorIndex: Int,
       functionNode: Node[Ast.FuncDef[_], Ast.Positioned],
       sourceCode: SourceLocation.Code,
-      workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion] = {
+      workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion.NodeAPI] = {
     // fetch suggestions local to this function
     val localFunctionSuggestions =
       suggestLocalFunctionVariables(
@@ -74,7 +74,7 @@ object FunctionBodyCompleter {
   private def suggestLocalFunctionVariables(
       cursorIndex: Int,
       functionNode: Node[Ast.FuncDef[_], Ast.Positioned],
-      sourceCode: SourceLocation.Code): Iterator[Suggestion] =
+      sourceCode: SourceLocation.Code): Iterator[Suggestion.NodeAPI] =
     functionNode
       .walkDown
       .filter(_.data.sourceIndex.exists(_.from <= cursorIndex))
@@ -98,7 +98,7 @@ object FunctionBodyCompleter {
    */
   private def suggestInheritedAPIs(
       sourceCode: SourceLocation.Code,
-      workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion] =
+      workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion.InheritedAPI] =
     WorkspaceSearcher
       .collectInheritedParents(
         sourceCode = sourceCode,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/SourceCodeCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/SourceCodeCompleter.scala
@@ -36,7 +36,7 @@ object SourceCodeCompleter {
   def complete(
       cursorIndex: Int,
       sourceCode: SourceLocation.Code,
-      workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion] =
+      workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion.NodeAPI] =
     sourceCode.tree.rootNode.findLast(_.sourceIndex.exists(_ contains cursorIndex)) match { // find the node closest to this source-index
       case Some(closest) =>
         closest.parent match {

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
@@ -20,12 +20,13 @@ import org.alephium.protocol.vm.StatefulContext
 import org.alephium.ralph.Ast
 import org.alephium.ralph.lsp.access.compiler.ast.AstExtra
 import org.alephium.ralph.lsp.access.compiler.ast.node.Node
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.SourceIndexExtension
 import org.alephium.ralph.lsp.pc.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
 import org.alephium.ralph.lsp.pc.workspace.{WorkspaceState, WorkspaceSearcher}
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 
-private object GoToFuncId extends StrictImplicitLogging {
+private[search] object GoToFuncId extends StrictImplicitLogging {
 
   /**
    * Navigate to the definition of a function for the given [[Ast.FuncId]].
@@ -90,6 +91,34 @@ private object GoToFuncId extends StrictImplicitLogging {
 
       case None =>
         Iterator.empty
+    }
+
+  /**
+   * Navigate to the nearest function definition for which the given child node is in scope.
+   *
+   * @param childNode The node to traverse up from.
+   * @return An Option containing the nearest function definition, if found.
+   */
+  def goToNearestFuncDef(childNode: Node[Ast.Positioned, Ast.Positioned]): Option[Node[Ast.FuncDef[_], Ast.Positioned]] =
+    childNode.data match {
+      case function: Ast.FuncDef[_] =>
+        // Nested function definitions are not allowed in Ralph.
+        // If the input node is a function, return the node itself.
+        Some(childNode.upcast(function))
+
+      case ast: Ast.Positioned =>
+        // For everything else, find the nearest function.
+        ast
+          .sourceIndex
+          .flatMap {
+            childNodeIndex =>
+              childNode
+                .walkParents
+                .collectFirst {
+                  case node @ Node(function: Ast.FuncDef[_], _) if function.sourceIndex.exists(_ contains childNodeIndex.index) =>
+                    node.upcast(function)
+                }
+          }
     }
 
   /**

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcher.scala
@@ -310,6 +310,51 @@ object SourceCodeSearcher {
   }
 
   /**
+   * Collects all function definitions from the provided source code.
+   *
+   * @param sourceCode The source code from which to collect function definitions.
+   * @return           An iterator containing all function implementations.
+   */
+  def collectFunctions(sourceCode: SourceLocation.Code): Iterator[SourceLocation.Node[Ast.FuncDef[StatefulContext]]] =
+    // TODO: Improve selection by checking function argument count and types.
+    sourceCode.tree.ast match {
+      case Left(ast) =>
+        ast
+          .funcs
+          .iterator
+          .map {
+            funcDef =>
+              SourceLocation.Node(
+                ast = funcDef,
+                source = sourceCode
+              )
+          }
+
+      case Right(_) =>
+        Iterator.empty
+    }
+
+  /**
+   * Collects all function definitions from the provided parsed source code.
+   *
+   * @param source The parsed source code from which to collect function definitions.
+   * @return An iterator containing all function implementations.
+   */
+  def collectFunctions(source: SourceCodeState.Parsed): Iterator[SourceLocation.Node[Ast.FuncDef[StatefulContext]]] =
+    source
+      .ast
+      .statements
+      .iterator
+      .flatMap {
+        case tree: Tree.Source =>
+          // search for the matching functionIds within the built-in source file.
+          SourceCodeSearcher.collectFunctions(SourceLocation.Code(tree, source))
+
+        case _: Tree.Import =>
+          Iterator.empty
+      }
+
+  /**
    * Collects all parent source implementations inherited by the given
    * source tree within the provided source code files.
    *

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
@@ -16,6 +16,8 @@
 
 package org.alephium.ralph.lsp.pc.workspace
 
+import org.alephium.protocol.vm.StatefulContext
+import org.alephium.ralph.{Type, Ast}
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceLocation, SourceCodeState, SourceCodeSearcher}
@@ -152,6 +154,25 @@ object WorkspaceSearcher {
       SourceCodeSearcher.collectSourceTrees(workspaceCode)
 
     workspaceTrees ++ allImportedCode
+  }
+
+  /**
+   * Collects all functions from trees with the given types.
+   *
+   * @param types     The types of trees from which to collect functions.
+   * @param workspace The workspace state containing all source code to search from.
+   * @return An iterator containing all function implementations.
+   */
+  def collectFunctions(
+      types: Seq[Type],
+      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.FuncDef[StatefulContext]]] = {
+    val workspaceTrees =
+      collectTrees(workspace)
+
+    SourceCodeSearcher.collectFunctions(
+      types = types,
+      workspaceSource = workspaceTrees
+    )
   }
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
@@ -175,4 +175,31 @@ object WorkspaceSearcher {
     )
   }
 
+  /**
+   * Collects all function definitions from the provided compiled workspace state.
+   *
+   * @param workspace The compiled workspace state from which to collect function definitions.
+   * @return An iterator containing all function implementations.
+   */
+  def collectFunctions(workspace: WorkspaceState.Parsed): Iterator[SourceLocation.Node[Ast.FuncDef[StatefulContext]]] =
+    workspace
+      .sourceCode
+      .iterator // iterator over dependant source-code files
+      .flatMap(SourceCodeSearcher.collectFunctions)
+
+  /**
+   * Collects all function definitions, including inherited ones, from the provided source code.
+   *
+   * @param sourceCode The source code from which to collect function definitions.
+   * @param workspace  The workspace state that is source aware.
+   * @return An iterator containing all function implementations, including inherited ones.
+   */
+  def collectFunctionsIncludingInherited(
+      sourceCode: SourceLocation.Code,
+      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.FuncDef[StatefulContext]]] =
+    WorkspaceSearcher
+      .collectInheritedParents(sourceCode, workspace)
+      .iterator
+      .flatMap(SourceCodeSearcher.collectFunctions)
+
 }


### PR DESCRIPTION
A little bit of refactoring: Moves a few functions out of `GoTo*` types to `*Search` objects, making them reusable. These functions are not specific to go-to definitions only but are general workspace/source-code search functions.