### PR TITLE
Better error on empty build file

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/error/ErrorEmptyBuildFile.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/error/ErrorEmptyBuildFile.scala
@@ -1,0 +1,37 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.pc.workspace.build.error
+
+import org.alephium.ralph.SourceIndex
+import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, SourceIndexExtra}
+import org.alephium.ralph.lsp.pc.workspace.build.RalphcConfig
+
+import java.net.URI
+
+case class ErrorEmptyBuildFile(fileURI: URI) extends CompilerMessage.Error {
+
+  override def message: String = {
+    val defaultBuild = RalphcConfig.write(RalphcConfig.defaultParsedConfig)
+
+    s"""Empty build file detected. Consider copying the following default build JSON or refer to the documentation for guidance.
+         |$defaultBuild""".stripMargin
+  }
+
+  override def index: SourceIndex =
+    SourceIndexExtra.zero(fileURI)
+
+}

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/RalphcConfigSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/RalphcConfigSpec.scala
@@ -21,6 +21,7 @@ import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.Dependency
+import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorEmptyBuildFile
 import org.alephium.ralph.lsp.pc.workspace.{WorkspaceState, TestWorkspace}
 import org.alephium.ralphc.Config
 import org.scalatest.EitherValues._
@@ -82,6 +83,20 @@ class RalphcConfigSpec extends AnyWordSpec with Matchers {
         val actual   = RalphcConfig.parse(URI.create(""), build_ralph).value
 
         actual shouldBe expected
+      }
+    }
+
+    "fail" when {
+      "build file is empty" in {
+        val build_ralph =
+          """
+            |
+            |""".stripMargin
+
+        val fileURI = URI.create(Build.BUILD_FILE_NAME)
+        val actual  = RalphcConfig.parse(fileURI, build_ralph).left.value
+
+        actual shouldBe ErrorEmptyBuildFile(fileURI)
       }
     }
   }


### PR DESCRIPTION
When creating a new project, the following error message is reported for the missing build file.

> Build file not found. Create a 'ralph.json' file in the project's root folder.

Creating a new build file `ralph.json` reports the following error message for it being empty. This error message is less helpful.

> exhausted input

This PR updates the error message to include the default JSON that can be copied.

> Empty build file detected. Consider copying the following default build JSON or refer to the documentation for guidance.
{"compilerOptions":{"ignoreUnusedConstantsWarnings":false,"ignoreUnusedVariablesWarnings":false,"ignoreUnusedFieldsWarnings":false,"ignoreUnusedPrivateFunctionsWarnings":false,"ignoreUpdateFieldsCheckWarnings":false,"ignoreCheckExternalCallerWarnings":false},"contractPath":"contracts","artifactPath":"artifacts"}

TODO: It would be much better to generate the build file after getting a confirmation. 