### PR TITLE
Provide type suggestions in function body

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/FuncIdCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/FuncIdCompleter.scala
@@ -29,7 +29,7 @@ object FuncIdCompleter {
       funcId: Node[Ast.FuncId, Ast.Positioned],
       sourceCode: SourceLocation.Code,
       workspace: WorkspaceState.IsSourceAware
-    )(implicit logger: ClientLogger): Iterator[Suggestion.NodeAPI] =
+    )(implicit logger: ClientLogger): Iterator[Suggestion] =
     funcId.parent match {
       case Some(Node(call: Ast.ContractCallBase, _)) =>
         ExprCompleter.suggest(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleter.scala
@@ -39,7 +39,7 @@ object FunctionBodyCompleter {
       cursorIndex: Int,
       closestToCursor: Node[Ast.Positioned, Ast.Positioned],
       sourceCode: SourceLocation.Code,
-      workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion.NodeAPI] =
+      workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion] =
     GoToFuncId.goToNearestFuncDef(closestToCursor) match {
       case Some(functionNode) =>
         suggestInFunctionBody(
@@ -66,7 +66,7 @@ object FunctionBodyCompleter {
       cursorIndex: Int,
       functionNode: Node[Ast.FuncDef[_], Ast.Positioned],
       sourceCode: SourceLocation.Code,
-      workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion.NodeAPI] = {
+      workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion] = {
     // fetch suggestions local to this function
     val localFunctionSuggestions =
       suggestLocalFunctionVariables(
@@ -85,9 +85,13 @@ object FunctionBodyCompleter {
     val builtInFunctions =
       suggestBuiltinFunctions(workspace)
 
+    val types =
+      TypeCompleter.suggest(workspace)
+
     localFunctionSuggestions ++
       inheritedSuggestions ++
-      builtInFunctions
+      builtInFunctions ++
+      types
   }
 
   /**

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/IdentCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/IdentCompleter.scala
@@ -39,7 +39,7 @@ object IdentCompleter {
       ident: Node[Ast.Ident, Ast.Positioned],
       sourceCode: SourceLocation.Code,
       workspace: WorkspaceState.IsSourceAware
-    )(implicit logger: ClientLogger): Iterator[Suggestion.NodeAPI] =
+    )(implicit logger: ClientLogger): Iterator[Suggestion] =
     ident.parent match {
       case Some(Node(selector: Ast.EnumFieldSelector[_], _)) =>
         EnumFieldCompleter.suggest(

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleterSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleterSpec.scala
@@ -207,6 +207,23 @@ class FunctionBodyCompleterSpec extends AnyWordSpec with Matchers {
             label = "variable",
             insert = "variable",
             detail = ""
+          ),
+          // Also provide type information
+          Completion.Class(
+            label = "Test",
+            insert = "Test",
+            detail = ""
+          ),
+          Completion.Class(
+            label = "Parent",
+            insert = "Parent",
+            detail = ""
+          ),
+          // Test for one type information from dependency
+          Completion.Class(
+            label = "INFT",
+            insert = "INFT",
+            detail = ""
           )
         )
 
@@ -299,6 +316,18 @@ class FunctionBodyCompleterSpec extends AnyWordSpec with Matchers {
           Completion.Variable(
             label = "mut index2",
             insert = "index2",
+            detail = ""
+          ),
+          // Also provide type information
+          Completion.Class(
+            label = "Test",
+            insert = "Test",
+            detail = ""
+          ),
+          // Test for one type information from dependency
+          Completion.Class(
+            label = "INFT",
+            insert = "INFT",
             detail = ""
           )
         )


### PR DESCRIPTION
For example: Suggesting `INFT` in the following syntax

```rust
let tokenURI = INFT(collectionId).getTokenUri()
```

Towards #98.