### PR TITLE
Enable code-completion within `TxScript`'s `main` function

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/AstExtra.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/AstExtra.scala
@@ -22,6 +22,11 @@ import org.alephium.ralph.Ast
 object AstExtra {
 
   /**
+   * The name of the function created by [[Ast.FuncDef.main]].
+   */
+  final val TX_SCRIPT_MAIN_FUNCTION_NAME = "main"
+
+  /**
    * Checks if the variable definition [[Ast.VarDef]]
    * contains a named variable with the given identifier [[Ast.Ident]].
    *

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/completion/FuncIdCompleterSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/completion/FuncIdCompleterSpec.scala
@@ -20,7 +20,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
 
-class FuncIdCompleter extends AnyWordSpec with Matchers {
+class FuncIdCompleterSpec extends AnyWordSpec with Matchers {
 
   "return non-empty" when {
     "requested for functions on a local interface" in {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleterSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleterSpec.scala
@@ -408,4 +408,45 @@ class FunctionBodyCompleterSpec extends AnyWordSpec with Matchers {
     }
   }
 
+  "TxScript" should {
+    "enable code completion within the main function" in {
+      val suggestions =
+        suggest {
+          """
+            |TxScript MyScript {
+            |  let mut counterMain = 0
+            |  counterMain = cou@@nterMain + 1
+            |}
+            |""".stripMargin
+        }
+
+      val actual =
+        suggestions.flatMap(_.toCompletion())
+
+      val expected =
+        List(
+          // Selected a random type from dependency
+          Completion.Class(
+            label = "INFT",
+            insert = "INFT",
+            detail = ""
+          ),
+          // Selected a random keyword
+          Completion.Keyword(
+            label = "let",
+            insert = "let ",
+            detail = ""
+          ),
+          // Local variables are suggested
+          Completion.Variable(
+            label = "counterMain",
+            insert = "counterMain",
+            detail = "mut counterMain"
+          )
+        )
+
+      actual should contain allElementsOf expected
+    }
+  }
+
 }


### PR DESCRIPTION
The [`main`](https://github.com/alephium/alephium/blob/6d5648ff43fa870afdf90886ec23492cb31de8de/ralph/src/main/scala/org/alephium/ralph/Ast.scala#L1260-L1268) function within a `TxScript` that has no `SourceIndex`, which results in code-completion not working within that `main` function. This PR assumes that if the source is a `TxScript` and the function where the code-completion request was made is not found, then it must be requested within the `main` function.