### PR TITLE
Provide template body completion

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/ContractBodyCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/ContractBodyCompleter.scala
@@ -1,0 +1,43 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.pc.search.completion
+
+import org.alephium.ralph.Keyword
+
+import scala.collection.immutable.ArraySeq
+
+object ContractBodyCompleter {
+
+  def suggest(): Iterator[Suggestion.Keyword] =
+    suggestKeywords().iterator
+
+  /**
+   * Suggests keywords relevant to a Contract's body.
+   */
+  private def suggestKeywords(): ArraySeq[Suggestion.Keyword] =
+    ArraySeq(
+      Suggestion.Keyword.expression(Keyword.pub),
+      Suggestion.Keyword.expression(Keyword.fn),
+      Suggestion.Keyword.expression(Keyword.`enum`),
+      Suggestion.Keyword.expression(Keyword.event),
+      Suggestion.Keyword.expression(Keyword.mapping),
+      Suggestion.Keyword.expression(Keyword.struct),
+      Suggestion.Keyword.expression(Keyword.`extends`),
+      Suggestion.Keyword.expression(Keyword.implements)
+    )
+
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/ContractBodyCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/ContractBodyCompleter.scala
@@ -18,18 +18,16 @@ package org.alephium.ralph.lsp.pc.search.completion
 
 import org.alephium.ralph.Keyword
 
-import scala.collection.immutable.ArraySeq
-
 object ContractBodyCompleter {
 
   def suggest(): Iterator[Suggestion.Keyword] =
-    suggestKeywords().iterator
+    suggestKeywords()
 
   /**
    * Suggests keywords relevant to a Contract's body.
    */
-  private def suggestKeywords(): ArraySeq[Suggestion.Keyword] =
-    ArraySeq(
+  private def suggestKeywords(): Iterator[Suggestion.Keyword] =
+    Iterator(
       Suggestion.Keyword.expression(Keyword.pub),
       Suggestion.Keyword.expression(Keyword.fn),
       Suggestion.Keyword.expression(Keyword.`enum`),

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/SourceCodeCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/SourceCodeCompleter.scala
@@ -64,7 +64,8 @@ object SourceCodeCompleter {
 
       case Some(Node(_: Ast.ContractWithState, _)) =>
         // FIXME: At the moment there is no AST that represents the code immediately after the contract definition and before the contract body.
-        //        Therefore, all keywords all `pub`, `fn`, `extends`, `implements` etc are suggested in both cases,
+        //        Therefore, all keywords all `pub`, `fn`, `extends`, `implements` etc are suggested in both cases.
+        //        See PR: https://github.com/alephium/ralph-lsp/pull/221.
         ContractBodyCompleter.suggest()
 
       case Some(closest) =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/SourceCodeCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/SourceCodeCompleter.scala
@@ -62,6 +62,11 @@ object SourceCodeCompleter {
         // Request is for an annotation value. Eg: `@using(updateFields = tr@@ue)`
         AnnotationCompleter.suggestAnnotationValues()
 
+      case Some(Node(_: Ast.ContractWithState, _)) =>
+        // FIXME: At the moment there is no AST that represents the code immediately after the contract definition and before the contract body.
+        //        Therefore, all keywords all `pub`, `fn`, `extends`, `implements` etc are suggested in both cases,
+        ContractBodyCompleter.suggest()
+
       case Some(closest) =>
         FunctionBodyCompleter.suggest(
           cursorIndex = cursorIndex,

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/completion/ContractBodyCompleterSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/completion/ContractBodyCompleterSpec.scala
@@ -1,0 +1,103 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.pc.search.completion
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
+
+class ContractBodyCompleterSpec extends AnyWordSpec with Matchers {
+
+  "suggest non-empty" when {
+    def testItSuggestsKeywordOnly(code: String) = {
+      // run completion
+      val suggestions =
+        suggest(code)
+
+      val actual =
+        suggestions
+          .map(_.asInstanceOf[Suggestion.Keyword])
+          .sortBy(_.label)
+
+      // expect all template level keywords are suggested
+      val expected =
+        ContractBodyCompleter
+          .suggest()
+          .toList
+          .sortBy(_.label)
+
+      actual shouldBe expected
+    }
+
+    "Contract" when {
+      "request is within the body" in {
+        testItSuggestsKeywordOnly {
+          """
+            |Contract Test(bool: Bool) {
+            |
+            |  @@
+            |
+            |  fn function() -> () { }
+            |}
+            |""".stripMargin
+        }
+      }
+
+      "request is at the template extension" in {
+        testItSuggestsKeywordOnly {
+          """
+            |Abstract Contract Test(bool: Bool) @@ {
+            |
+            |  fn function() -> ()
+            |}
+            |""".stripMargin
+        }
+      }
+    }
+
+    "TxScript" when {
+      "request is within the body" in {
+        testItSuggestsKeywordOnly {
+          """
+            |TxScript MyTxScript {
+            |
+            |  @@
+            |
+            |  assert!(true, Error.SomeError)
+            |
+            |}
+            |
+            |""".stripMargin
+        }
+      }
+
+      "request is at the template extension" in {
+        testItSuggestsKeywordOnly {
+          """
+            |TxScript MyTxScript @@ {
+            |
+            |  assert!(true, Error.SomeError)
+            |
+            |}
+            |""".stripMargin
+        }
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
I'm unable to find an AST that represents the code immediately after the contract definition and before the contract body

```rust
Contract MyContract() @@ {

}
```

So in context of code-completion there is no distinction between the above and the following code. Therefore, all keywords `pub`, `fn`, `extends`, `implements` etc are suggested in both cases, even though suggesting `extends` and `implements` does not make sense in the following code, and suggesting `pub` and `fn` does not make sense in the above code. 

```rust
Contract MyContract() {
  @@ 
}
```

This can be resolved with manual calculation but an AST would be nicer. Deferring alternative solutions until later.

Towards #98.