### PR TITLE
Include contract call usage in function usages

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/AstExtra.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/AstExtra.scala
@@ -17,7 +17,7 @@
 package org.alephium.ralph.lsp.access.compiler.ast
 
 import org.alephium.protocol.vm.StatelessContext
-import org.alephium.ralph.Ast
+import org.alephium.ralph.{Type, Ast}
 
 object AstExtra {
 
@@ -61,5 +61,27 @@ object AstExtra {
       // FIXME: There is still a need to display just the function signature.
       //        At the moment there is no AST type that provides just the function signature.
       funcDef.id
+
+  /**
+   * Fetches the type identifier for a given type.
+   *
+   * @param tpe The type for which to fetch the identifier.
+   * @return `Some(TypeId)` if the type has an associated [[Ast.TypeId]], otherwise [[None]].
+   */
+  def getTypeId(tpe: Type): Option[Ast.TypeId] =
+    tpe match {
+      case Type.NamedType(id) =>
+        Some(id)
+
+      case Type.Struct(id) =>
+        Some(id)
+
+      case Type.Contract(id) =>
+        Some(id)
+
+      case Type.Bool | Type.I256 | Type.U256 | Type.ByteVec | Type.Address | _: Type.FixedSizeArray | _: Type.Map | Type.Panic =>
+        None
+
+    }
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
@@ -23,8 +23,10 @@ import org.alephium.ralph.lsp.access.compiler.ast.node.Node
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.SourceIndexExtension
 import org.alephium.ralph.lsp.pc.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
-import org.alephium.ralph.lsp.pc.workspace.{WorkspaceState, WorkspaceSearcher}
+import org.alephium.ralph.lsp.pc.workspace.{WorkspaceState, ImplementingChildrenResult, WorkspaceSearcher}
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
+
+import scala.collection.immutable.ArraySeq
 
 private[search] object GoToFuncId extends StrictImplicitLogging {
 
@@ -60,17 +62,11 @@ private[search] object GoToFuncId extends StrictImplicitLogging {
             )
 
           case Node(funcDef: Ast.FuncDef[_], _) if funcDef.id == funcIdNode.data =>
-            WorkspaceSearcher
-              .collectImplementingChildren(sourceCode, workspace)
-              .childTrees
-              .iterator
-              .flatMap {
-                sourceCode =>
-                  goToFunctionUsage(
-                    funcId = funcDef.id,
-                    sourceCode = sourceCode
-                  )
-              }
+            goToFunctionUsage(
+              funcId = funcIdNode.data,
+              sourceCode = sourceCode,
+              workspace = workspace
+            )
 
           case Node(call: Ast.ContractCallBase, _) if call.callId == funcIdNode.data =>
             goToFunctionImplementation(
@@ -147,6 +143,97 @@ private[search] object GoToFuncId extends StrictImplicitLogging {
       functions = functions
     )
   }
+
+  /**
+   * Navigate to all function usages within the source code for the specified [[Ast.FuncId]].
+   *
+   * @param funcId     The [[Ast.FuncId]] of the function to locate.
+   * @param sourceCode The source tree to search.
+   * @param workspace  The workspace where this search was executed and where all the source trees exist.
+   * @return An iterator over all searched function usages.
+   */
+  private def goToFunctionUsage(
+      funcId: Ast.FuncId,
+      sourceCode: SourceLocation.Code,
+      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.Positioned]] = {
+    val children =
+      WorkspaceSearcher.collectImplementingChildren(sourceCode, workspace)
+
+    // Direct calls can only occur within the scope of inheritance.
+    val directCallUsages =
+      goToDirectCallFunctionUsage(
+        funcId = funcId,
+        children = children.childTrees
+      )
+
+    // Contract call can occur anywhere where an instance of the Contract can be created.
+    val contractCallUsages =
+      goToContractCallFunctionUsage(
+        funcId = funcId,
+        children = children
+      )
+
+    directCallUsages ++ contractCallUsages
+  }
+
+  /**
+   * Navigates to all direct function call usages for the specified [[Ast.FuncId]].
+   *
+   * @param funcId   The [[Ast.FuncId]] of the function to locate usages for.
+   * @param children The sources to search within.
+   * @return An iterator over all found function call usages.
+   */
+  private def goToDirectCallFunctionUsage(
+      funcId: Ast.FuncId,
+      children: ArraySeq[SourceLocation.Code]): Iterator[SourceLocation.Node[Ast.Positioned]] =
+    children
+      .iterator
+      .flatMap {
+        sourceCode =>
+          goToFunctionUsage(
+            funcId = funcId,
+            sourceCode = sourceCode
+          )
+      }
+
+  /**
+   * Navigates to all contract call usages for the specified [[Ast.FuncId]].
+   *
+   * @param funcId   The [[Ast.FuncId]] of the function to locate contract call usages for.
+   * @param children The result containing the child trees and all trees in scope within the current workspace.
+   * @return An iterator over all found contract call usages.
+   */
+  private def goToContractCallFunctionUsage(
+      funcId: Ast.FuncId,
+      children: ImplementingChildrenResult): Iterator[SourceLocation.Node[Ast.Positioned]] =
+    children
+      .allTrees // traverse all trees to find contract call usages, eg: `myContract.function()` or `MyContract().function()`
+      .iterator
+      .flatMap {
+        code =>
+          code.tree.rootNode.walkDown.collect {
+            case Node(call: Ast.ContractCallBase, _) if call.callId == funcId =>
+              // function ID matches, but does it also match the type ID?
+              call
+                .obj
+                .tpe
+                .map(_.flatMap(AstExtra.getTypeId)) // fetch the type ID of this function call
+                .iterator
+                .flatMap {
+                  thisCallTypes =>
+                    children
+                      .childTrees // at least one of the child trees should match this call's object type
+                      .flatMap {
+                        childCode =>
+                          if (thisCallTypes contains childCode.tree.typeId())
+                            Some(SourceLocation.Node(call, code)) // Matched! Both the `funcId` and `typeId` are a match.
+                          else
+                            None
+                      }
+                }
+          }
+      }
+      .flatten
 
   /**
    * Navigate to all local function usage where the given function definition [[Ast.FuncDef]]

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
@@ -71,14 +71,7 @@ private[search] object GoToFuncId extends StrictImplicitLogging {
                   )
               }
 
-          case Node(call: Ast.ContractCall, _) if call.callId == funcIdNode.data =>
-            goToFunctionImplementation(
-              functionId = funcIdNode.data,
-              typeExpr = call.obj,
-              workspace = workspace
-            )
-
-          case Node(call: Ast.ContractCallExpr, _) if call.callId == funcIdNode.data =>
+          case Node(call: Ast.ContractCallBase, _) if call.callId == funcIdNode.data =>
             goToFunctionImplementation(
               functionId = funcIdNode.data,
               typeExpr = call.obj,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
@@ -62,6 +62,7 @@ private[search] object GoToFuncId extends StrictImplicitLogging {
           case Node(funcDef: Ast.FuncDef[_], _) if funcDef.id == funcIdNode.data =>
             WorkspaceSearcher
               .collectImplementingChildren(sourceCode, workspace)
+              .childTrees
               .iterator
               .flatMap {
                 sourceCode =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
@@ -133,7 +133,7 @@ private[search] object GoToFuncId extends StrictImplicitLogging {
       funcId: Ast.FuncId,
       sourceCode: SourceLocation.Code,
       workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.Positioned]] = {
-    val functions: Iterator[SourceLocation.Node[Ast.FuncDef[StatefulContext]]] =
+    val functions =
       if (funcId.isBuiltIn)
         workspace.build.findDependency(DependencyID.BuiltIn) match {
           case Some(builtInWorkspace) =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
@@ -90,6 +90,7 @@ private[search] object GoToIdent {
                 case enumDef: Ast.EnumDef[_] if enumDef.fields.exists(_.ident == field.ident) =>
                   WorkspaceSearcher
                     .collectImplementingChildren(sourceCode, workspace)
+                    .childTrees
                     .iterator
                     .flatMap {
                       sourceCode =>
@@ -114,6 +115,7 @@ private[search] object GoToIdent {
                 case eventDef: Ast.EventDef if eventDef.fields.exists(_.ident == field.ident) =>
                   WorkspaceSearcher
                     .collectImplementingChildren(sourceCode, workspace)
+                    .childTrees
                     .iterator
                     .flatMap {
                       sourceCode =>
@@ -130,6 +132,7 @@ private[search] object GoToIdent {
             // They selected a constant definition. Take 'em there!
             WorkspaceSearcher
               .collectImplementingChildren(sourceCode, workspace)
+              .childTrees
               .iterator
               .flatMap {
                 sourceCode =>
@@ -217,6 +220,7 @@ private[search] object GoToIdent {
         // It's a template argument, search within the source-tree and within all dependant code.
         WorkspaceSearcher
           .collectImplementingChildren(sourceCode, workspace)
+          .childTrees
           .iterator
           .flatMap {
             sourceCode =>
@@ -523,6 +527,7 @@ private[search] object GoToIdent {
     // Go-to MapDef usages.
     WorkspaceSearcher
       .collectImplementingChildren(sourceCode, workspace)
+      .childTrees
       .iterator
       .flatMap {
         code =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToTypeId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToTypeId.scala
@@ -49,6 +49,7 @@ private object GoToTypeId {
             // They selected an enum definition. Find enum usages.
             WorkspaceSearcher
               .collectImplementingChildren(sourceCode, workspace)
+              .childTrees
               .iterator
               .flatMap(goToEnumTypeUsage(enumDef, _))
 
@@ -63,6 +64,7 @@ private object GoToTypeId {
             // They selected an event definition. Find event usages.
             WorkspaceSearcher
               .collectImplementingChildren(sourceCode, workspace)
+              .childTrees
               .iterator
               .flatMap(goToEventDefUsage(eventDef, _))
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcher.scala
@@ -138,7 +138,7 @@ object SourceCodeSearcher {
    */
   def collectInheritedParentsForAllTrees(
       sourceCode: SourceCodeState.Parsed,
-      workspace: ArraySeq[SourceCodeState.Parsed]): Seq[SourceLocation.Code] =
+      workspace: ArraySeq[SourceCodeState.Parsed]): ArraySeq[SourceLocation.Code] =
     collectInheritedParentsForAll(
       sourceCode = sourceCode,
       workspace = collectSourceTrees(workspace)
@@ -153,7 +153,7 @@ object SourceCodeSearcher {
    */
   def collectInheritedParentsForAll(
       sourceCode: SourceCodeState.Parsed,
-      workspace: ArraySeq[SourceLocation.Code]): Seq[SourceLocation.Code] =
+      workspace: ArraySeq[SourceLocation.Code]): ArraySeq[SourceLocation.Code] =
     collectInheritedParents(
       source = collectSourceTrees(sourceCode).to(ArraySeq),
       allSource = workspace
@@ -398,7 +398,7 @@ object SourceCodeSearcher {
    */
   def collectInheritedParents(
       source: ArraySeq[SourceLocation.Code],
-      allSource: ArraySeq[SourceLocation.Code]): Seq[SourceLocation.Code] =
+      allSource: ArraySeq[SourceLocation.Code]): ArraySeq[SourceLocation.Code] =
     source.flatMap {
       source =>
         collectInheritedParents(
@@ -417,7 +417,7 @@ object SourceCodeSearcher {
    */
   def collectInheritedParents(
       source: SourceLocation.Code,
-      allSource: ArraySeq[SourceLocation.Code]): Seq[SourceLocation.Code] =
+      allSource: ArraySeq[SourceLocation.Code]): ArraySeq[SourceLocation.Code] =
     source.tree.ast match {
       case Left(contract) =>
         collectInheritedParents(
@@ -427,7 +427,7 @@ object SourceCodeSearcher {
         )
 
       case Right(_) =>
-        Seq.empty
+        ArraySeq.empty
     }
 
   /**
@@ -440,7 +440,7 @@ object SourceCodeSearcher {
    */
   def collectImplementingChildren(
       source: SourceLocation.Code,
-      allSource: ArraySeq[SourceLocation.Code]): Seq[SourceLocation.Code] =
+      allSource: ArraySeq[SourceLocation.Code]): ArraySeq[SourceLocation.Code] =
     source.tree.ast match {
       case Left(contract) =>
         collectImplementingChildren(
@@ -450,7 +450,7 @@ object SourceCodeSearcher {
         )
 
       case Right(_) =>
-        Seq.empty
+        ArraySeq.empty
     }
 
   /**
@@ -465,7 +465,7 @@ object SourceCodeSearcher {
   private def collectInheritedParents(
       inheritances: Seq[Ast.Inheritance],
       allSource: ArraySeq[SourceLocation.Code],
-      processedTrees: mutable.Set[SourceLocation.Code]): Seq[SourceLocation.Code] =
+      processedTrees: mutable.Set[SourceLocation.Code]): ArraySeq[SourceLocation.Code] =
     allSource flatMap {
       source =>
         // collect the trees that belong to one of the inheritances and the ones that are not already processed
@@ -485,11 +485,11 @@ object SourceCodeSearcher {
               parents :+ source
 
             case Right(_) =>
-              Seq.empty
+              ArraySeq.empty
           }
 
         } else {
-          Seq.empty
+          ArraySeq.empty
         }
     }
 
@@ -505,7 +505,7 @@ object SourceCodeSearcher {
   private def collectImplementingChildren(
       contract: Ast.ContractWithState,
       allSource: ArraySeq[SourceLocation.Code],
-      processedTrees: mutable.Set[SourceLocation.Code]): Seq[SourceLocation.Code] =
+      processedTrees: mutable.Set[SourceLocation.Code]): ArraySeq[SourceLocation.Code] =
     allSource flatMap {
       source =>
         // collect the trees that belong to one of the inheritances and the ones that are not already processed
@@ -525,10 +525,10 @@ object SourceCodeSearcher {
               children :+ source
 
             case Right(_) =>
-              Seq.empty
+              ArraySeq.empty
           }
         } else {
-          Seq.empty
+          ArraySeq.empty
         }
     }
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/ImplementingChildrenResult.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/ImplementingChildrenResult.scala
@@ -1,0 +1,31 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.pc.workspace
+
+import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
+
+import scala.collection.immutable.ArraySeq
+
+/**
+ * Result type for the function [[WorkspaceSearcher.collectImplementingChildren]].
+ *
+ * @param childTrees The resulting child trees within the current workspace.
+ * @param allTrees   All trees in scope within the current workspace.
+ */
+case class ImplementingChildrenResult(
+    childTrees: ArraySeq[SourceLocation.Code],
+    allTrees: ArraySeq[SourceLocation.Code])

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
@@ -83,11 +83,12 @@ object WorkspaceSearcher {
    *
    * @param sourceCode The source code for which in-scope files are being searched.
    * @param workspace  The workspace that may contain files within the scope.
-   * @return The source trees within the scope.
+   * @return An [[ImplementingChildrenResult]] instance that stores the resulting
+   *         child source trees and all trees in scope of the current workspace.
    */
   def collectImplementingChildren(
       sourceCode: SourceLocation.Code,
-      workspace: WorkspaceState.IsSourceAware): ArraySeq[SourceLocation.Code] = {
+      workspace: WorkspaceState.IsSourceAware): ImplementingChildrenResult = {
     val allInScopeCode =
       collectTrees(workspace, includeNonImportedCode = false)
 
@@ -97,7 +98,12 @@ object WorkspaceSearcher {
         allSource = allInScopeCode
       )
 
-    inheritancesInScope :+ sourceCode
+    val children = inheritancesInScope :+ sourceCode
+
+    ImplementingChildrenResult(
+      childTrees = children,
+      allTrees = allInScopeCode
+    )
   }
 
   /**

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
@@ -87,7 +87,7 @@ object WorkspaceSearcher {
    */
   def collectImplementingChildren(
       sourceCode: SourceLocation.Code,
-      workspace: WorkspaceState.IsSourceAware): Seq[SourceLocation.Code] = {
+      workspace: WorkspaceState.IsSourceAware): ArraySeq[SourceLocation.Code] = {
     val allInScopeCode =
       collectTrees(workspace, includeNonImportedCode = false)
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFunctionUsageSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFunctionUsageSpec.scala
@@ -80,16 +80,62 @@ class GoToFunctionUsageSpec extends AnyWordSpec with Matchers {
           |Abstract Contract Parent() {
           |
           |  pub fn @@function_a(boolean: Bool) -> () {
-          |    let call1 = >>function_a(true)<<
+          |    >>function_a(true)<<
           |    >>function_a(false)<<
           |  }
           |}
           |
           |Contract Child() extends Parent() {
           |
-          |  pub fn function_b(boolean: Bool) -> () {
-          |    let call1 = >>function_a(true)<<
+          |  pub fn function_b(parent: Parent,
+          |                    nftCollectionId: ByteVec) -> () {
+          |    >>function_a(true)<<
           |    >>function_a(false)<<
+          |    >>parent.function_a(true)<<
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
+
+    "function usage exist using a contract call" in {
+      goTo(
+        """
+          |Contract Parent() {
+          |
+          |  pub fn @@function_a(boolean: Bool) -> () {
+          |    >>function_a(true)<<
+          |    >>function_a(false)<<
+          |  }
+          |}
+          |
+          |Contract Child() {
+          |
+          |  pub fn function_b(parent: Parent,
+          |                    nftCollectionId: ByteVec) -> () {
+          |    >>parent.function_a(true)<<
+          |    >>Parent(nftCollectionId).function_a(true)<<
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
+
+    "function usage exist using brace syntax" in {
+      goTo(
+        """
+          |Contract Parent() {
+          |
+          |    @using(preapprovedAssets = true)
+          |    pub fn @@function_a(boolean: Bool) -> () {
+          |
+          |    }
+          |  }
+          |
+          |Contract Child() {
+          |
+          |  pub fn function_b(nftCollectionId: ByteVec) -> () {
+          |    >>Parent(nftCollectionId).function_a{callerAddress!() -> ALPH: 1 alph}(true)<<
           |  }
           |}
           |""".stripMargin

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFunctionUsageSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFunctionUsageSpec.scala
@@ -98,10 +98,10 @@ class GoToFunctionUsageSpec extends AnyWordSpec with Matchers {
       )
     }
 
-    "function usage exist using a contract call" in {
+    "function usage exist using a contract call (no inheritance)" in {
       goTo(
         """
-          |Contract Parent() {
+          |Contract MyContract() {
           |
           |  pub fn @@function_a(boolean: Bool) -> () {
           |    >>function_a(true)<<
@@ -109,38 +109,51 @@ class GoToFunctionUsageSpec extends AnyWordSpec with Matchers {
           |  }
           |}
           |
-          |Contract Child() {
+          |Contract Main() {
           |
-          |  pub fn function_b(parent: Parent,
+          |  pub fn function_b(myContract: MyContract,
           |                    nftCollectionId: ByteVec) -> () {
-          |    >>parent.function_a(true)<<
-          |    >>Parent(nftCollectionId).function_a(true)<<
+          |    >>myContract.function_a(true)<<
+          |    >>MyContract(nftCollectionId).function_a(true)<<
+          |    >>MyContract(nftCollectionId).function_a{callerAddress!() -> ALPH: 1 alph}(true)<<
           |  }
           |}
           |""".stripMargin
       )
     }
 
-    "function usage exist using brace syntax" in {
+    "function is defined in a Parent and usage is via an instance of the Child" in {
       goTo(
         """
-          |Contract Parent() {
+          |Abstract Contract Parent() {
           |
-          |    @using(preapprovedAssets = true)
-          |    pub fn @@function_a(boolean: Bool) -> () {
+          |  pub fn @@parentFunction(boolean: Bool) -> () {
           |
-          |    }
+          |  }
+          |}
+          |
+          |
+          |Contract Child() extends Parent() {
+          |
+          |  pub fn childFunction(boolean: Bool) -> () {
+          |
           |  }
           |
-          |Contract Child() {
+          |}
           |
-          |  pub fn function_b(nftCollectionId: ByteVec) -> () {
-          |    >>Parent(nftCollectionId).function_a{callerAddress!() -> ALPH: 1 alph}(true)<<
+          |Contract Main() {
+          |
+          |  pub fn main(nftCollectionId: ByteVec,
+          |              child: Child) -> () {
+          |    >>Child(nftCollectionId).parentFunction{callerAddress!() -> ALPH: 1 alph}(true)<<
+          |    >>child.parentFunction(true)<<
+          |    >>Child(nftCollectionId).parentFunction(true)<<
           |  }
           |}
           |""".stripMargin
       )
     }
+
   }
 
 }


### PR DESCRIPTION
Currently a function provides its usages within the scope of its inheritance i.e. direct function call syntax `myFunction()`. This PR ensures that all cases of function calls are covered including syntax such as `MyContract().myFunction()` and  brace syntax `MyContract(...).myFunction{...}()`.

Following the [documentation](https://docs.alephium.org/ralph/functions#function-calls) I think now all function call usages are covered.