### PR TITLE
Go-to assignment usages

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToIdent.scala
@@ -417,6 +417,10 @@ private[search] object GoToIdent {
         // find all the selections matching the variable name.
         case Node(variable: Ast.Variable[_], _) if variable.id == ident =>
           SourceLocation.Node(variable.id, sourceCode)
+
+        // collect all assignments
+        case Node(variable: Ast.AssignmentTarget[_], _) if variable.ident == ident =>
+          SourceLocation.Node(variable.ident, sourceCode)
       }
 
   /**

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToLocalVariableUsageSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToLocalVariableUsageSpec.scala
@@ -91,6 +91,26 @@ class GoToLocalVariableUsageSpec extends AnyWordSpec with Matchers {
           |""".stripMargin
       )
     }
+
+    "usages exist in a for loop" in {
+      goTo(
+        """
+          |Contract Test() {
+          |
+          |  pub fn function() -> U256 {
+          |    for(let mut @@counter = 1;
+          |                >>counter<< <= 4;
+          |                >>counter<< =
+          |                     >>counter<< + 1) {
+          |      return >>counter<<
+          |    }
+          |    return >>counter<<
+          |  }
+          |}
+          |
+          |""".stripMargin
+      )
+    }
   }
 
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoTotArgumentUsageInContractSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoTotArgumentUsageInContractSpec.scala
@@ -45,7 +45,8 @@ class GoTotArgumentUsageInContractSpec extends AnyWordSpec with Matchers {
           |    let result = >>param1<<.someFunction()
           |    assert!(abc == >>param1<<, ErrorCode.SomeError)
           |    let param1_copy = >>param1<<
-          |    param1 = >>param1<< + 1
+          |    >>param1<<
+          |          = >>param1<< + 1
           |    emit Mint(>>param1<<, 1)
           |    function(
           |      >>param1<<,
@@ -70,7 +71,8 @@ class GoTotArgumentUsageInContractSpec extends AnyWordSpec with Matchers {
           |    let result = >>param1<<.someFunction()
           |    assert!(abc == >>param1<<, ErrorCode.SomeError)
           |    let param1_copy = >>param1<<
-          |    param1 = >>param1<< + 1
+          |    >>param1<< =
+          |        >>param1<< + 1
           |    emit Mint(>>param1<<, 1)
           |    function(
           |      >>param1<<,

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoTotArgumentUsageInTxScriptSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoTotArgumentUsageInTxScriptSpec.scala
@@ -42,7 +42,9 @@ class GoTotArgumentUsageInTxScriptSpec extends AnyWordSpec with Matchers {
           |  let result = >>param2<<.someFunction()
           |  assert!(abc == >>param2<<, ErrorCode.SomeError)
           |  let param2_copy = >>param2<<
-          |  param2 = >>param2<< + 1
+          |  >>param2<< =
+          |       >>param2<< + 1
+          |  >>param2<< = 0 // reset
           |  emit Mint(>>param2<<, 1)
           |  function(
           |    >>param2<<,


### PR DESCRIPTION
Currently assignments are not included in usages

```rust
let mut @@counter = 0
counter = >>counter<< + 1
```

This PR resolves this

```rust
let mut @@counter = 0
>>counter<< = >>counter<< + 1
```

Towards #105.