### PR TITLE
Go-to template arguments (handle missing cases)

### DIFF
--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArgumentSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArgumentSpec.scala
@@ -136,6 +136,55 @@ class GoToArgumentSpec extends AnyWordSpec with Matchers {
           |""".stripMargin
       )
     }
+
+    "template arguments are passed as inheritance parameter" when {
+      "there are no duplicates" in {
+        goTo(
+          """
+            |Abstract Contract SomeType() { }
+            |
+            |Abstract Contract Parent(param: SomeType) { }
+            |
+            |Abstract Contract Child(>>param: SomeType<<) extends Parent(@@param) { }
+            |""".stripMargin
+        )
+      }
+
+      "duplicates exist" when {
+        "template parameter is duplicated" in {
+          goTo(
+            """
+              |Abstract Contract SomeType() { }
+              |
+              |Abstract Contract Parent(param: SomeType) { }
+              |
+              |Abstract Contract Child(>>param: SomeType<<,
+              |                        >>param: SomeType<<) extends Parent(@@param) { }
+              |""".stripMargin
+          )
+        }
+
+        "function parameter is duplicated" should {
+          "not be included in search result" in {
+            goTo(
+              """
+                |Abstract Contract SomeType() { }
+                |
+                |Abstract Contract Parent(param: SomeType) { }
+                |
+                |Abstract Contract Child(>>param: SomeType<<) extends Parent(@@param) {
+                |
+                |  // the parameter `param` is not in the scope of template `param`, it's a function level scope,
+                |  // so it should not be included in the search result.
+                |  fn function(param: SomeType) -> () { }
+                |}
+                |""".stripMargin
+            )
+          }
+        }
+      }
+
+    }
   }
 
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArgumentUsageInContractSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArgumentUsageInContractSpec.scala
@@ -20,7 +20,7 @@ import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class GoTotArgumentUsageInContractSpec extends AnyWordSpec with Matchers {
+class GoToArgumentUsageInContractSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "argument is not used" in {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArgumentUsageInTxScriptSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArgumentUsageInTxScriptSpec.scala
@@ -20,7 +20,7 @@ import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class GoTotArgumentUsageInTxScriptSpec extends AnyWordSpec with Matchers {
+class GoToArgumentUsageInTxScriptSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "argument is not used" in {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoTotArgumentUsageInContractSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoTotArgumentUsageInContractSpec.scala
@@ -120,9 +120,10 @@ class GoTotArgumentUsageInContractSpec extends AnyWordSpec with Matchers {
       }
 
       "from the template" when {
-        "there are no duplicate names" in {
-          goTo(
-            """
+        "parameter is defined in Parent" when {
+          "there are no duplicate names" in {
+            goTo(
+              """
               |Abstract Contract Parent(param1@@: ParamType) {
               |
               |  pub fn function(param1: ParamType, param2: ParamType) -> () {
@@ -143,12 +144,12 @@ class GoTotArgumentUsageInContractSpec extends AnyWordSpec with Matchers {
               |
               |}
               |""".stripMargin
-          )
-        }
+            )
+          }
 
-        "there are duplicate names" in {
-          goTo(
-            """
+          "there are duplicate names" in {
+            goTo(
+              """
               |Abstract Contract Parent(param1@@: ParamType) {
               |
               |  pub fn function(param1: ParamType, param2: ParamType) -> () {
@@ -169,7 +170,38 @@ class GoTotArgumentUsageInContractSpec extends AnyWordSpec with Matchers {
               |
               |}
               |""".stripMargin
-          )
+            )
+          }
+        }
+
+        "in Child" when {
+          "parameter is defined in Child" in {
+            goTo(
+              """
+                |// Parent should not have any usages
+                |Abstract Contract Parent(param1: ParamType) {
+                |
+                |  pub fn function(param1: ParamType, param2: ParamType) -> () {
+                |    let result = param1.someFunction()
+                |  }
+                |
+                |}
+                |
+                |Contract Child(param1@@: ParamType)
+                |  extends Parent(>>param1<<) {  // parent's input parameter should be added to usage
+                |
+                |  pub fn function(param2: ParamType) -> () {
+                |    let result = >>param1<<.someFunction()
+                |  }
+                |
+                |  pub fn function2(param1: ParamType, param2: ParamType) -> () {
+                |    let result = >>param1<<.someFunction()
+                |  }
+                |
+                |}
+                |""".stripMargin
+            )
+          }
         }
       }
 


### PR DESCRIPTION
Enables go-to definition for the following cases.

#### Go-to usage

```rust
Contract Child(@@param: Bool) extends Parent(>>param<<) { }
```

#### Go-to definition

```rust
Contract Child(>>param: Bool<<) extends Parent(@@param) { }
```

