### PR TITLE
Generates default build file

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Run the plugin by selecting the menu option `Run -> Run Without Debugging` or `R
 
 # Configuration
 
-After your IDE has booted up, create a mandatory config file named `ralph.json` in your project's root directory.
-You can use the following sample as reference:
+After your IDE has booted up, a config file named `ralph.json` is generated in your project's root
+directory under the folder `.ralph-lsp/ralph.json`. The file contains the following default values:
 
 ```json
 {
@@ -89,11 +89,14 @@ You can use the following sample as reference:
 ```
 
 The `dependencyPath` field is optional. If not set, the default path (`<user.home>/.ralph-lsp/dependencies/`) will be
-used.
+used. If you wish to specify a custom path, add the following to your `ralph.json` file:
 
 ```json
 "dependencyPath": "dependencies"
 ```
+
+This configuration allows you to customise the behavior of the compiler and define the paths for
+your contracts, artifacts, and dependencies.
 
 ## Configure trace (VSCode)
 

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/file/FileAccess.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/file/FileAccess.scala
@@ -29,6 +29,9 @@ object FileAccess {
   def disk: FileAccess =
     DiskFileAccess
 
+  def RALPH_LSP_HOME: String =
+    ".ralph-lsp"
+
   def USER_HOME: Option[Path] =
     Option(System.getProperty("user.home"))
       .map(Paths.get(_))

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/util/URIUtil.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/util/URIUtil.scala
@@ -94,6 +94,44 @@ object URIUtil {
   }
 
   /**
+   * Drops the specified number of path segments from the tail end of the URI path.
+   *
+   * Prerequisite: An empty URI cannot be created so the drop count must be less than segment count.
+   *
+   * @param uri   The original URI.
+   * @param count The number of path segments to drop the tail end.
+   * @return A new URI with tail segments removed.
+   */
+  def dropRight(
+      uri: URI,
+      count: Int): URI = {
+    val segments =
+      uri
+        .getPath
+        .split("/")
+        .filter(_.nonEmpty)
+
+    // We do not have a use case where we need to drop more than the segment count.
+    // If such case does occur, that is a bug and should be resolved with the following condition check.
+    require(count < segments.length, s"Drop count of $count is not less than segment count of ${segments.length}")
+
+    val trimmedPath =
+      segments
+        .dropRight(count)
+        .mkString("/", "/", "")
+
+    new URI(
+      uri.getScheme,
+      uri.getUserInfo,
+      uri.getHost,
+      uri.getPort,
+      trimmedPath,
+      uri.getQuery,
+      uri.getFragment
+    )
+  }
+
+  /**
    * String literal that defines an import statement for a source file.
    *
    * @return If the file is named `std/my_code.ral`, the import statement returned

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceState.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceState.scala
@@ -28,7 +28,7 @@ sealed trait WorkspaceState {
   def workspaceURI: URI
 
   final def buildURI: URI =
-    Build.toBuildURI(workspaceURI)
+    Build.toBuildFile(workspaceURI)
 
 }
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/Build.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/Build.scala
@@ -32,13 +32,27 @@ object Build {
   val BUILD_FILE_EXTENSION = "json"
 
   /** Build file of a workspace */
-  val BUILD_FILE_NAME = s"ralph.$BUILD_FILE_EXTENSION"
+  val FILE_NAME = s"ralph.$BUILD_FILE_EXTENSION"
 
-  def toBuildPath(workspacePath: Path): Path =
-    workspacePath.resolve(BUILD_FILE_NAME)
+  /** Directory name where the [[Build.FILE_NAME]] is located */
+  private val HOME_DIR_NAME =
+    FileAccess.RALPH_LSP_HOME
 
-  def toBuildURI(workspaceURI: URI): URI =
-    toBuildPath(Paths.get(workspaceURI)).toUri
+  /** Constructs the path to the workspace's build directory. */
+  def toBuildDir(workspacePath: Path): Path =
+    workspacePath.resolve(HOME_DIR_NAME)
+
+  /** Constructs the URI to the workspace's build directory. */
+  def toBuildDir(workspaceURI: URI): URI =
+    toBuildDir(Paths.get(workspaceURI)).toUri
+
+  /** Constructs the path to the workspace's build file. */
+  def toBuildFile(workspacePath: Path): Path =
+    toBuildDir(workspacePath).resolve(FILE_NAME)
+
+  /** Constructs the URI to the workspace's build file. */
+  def toBuildFile(workspaceURI: URI): URI =
+    toBuildFile(Paths.get(workspaceURI)).toUri
 
   /** Parse a build that is in-memory */
   def parse(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/Build.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/Build.scala
@@ -22,7 +22,6 @@ import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.{DependencyDB, Dependency}
-import org.alephium.ralph.lsp.pc.workspace.build.error._
 
 import java.net.URI
 import java.nio.file.{Path, Paths}
@@ -147,13 +146,20 @@ object Build {
             currentBuild = currentBuild
           )
         else
-          BuildState.Errored(
+          createDefaultBuildFile(
             buildURI = buildURI,
-            codeOption = None,
-            errors = ArraySeq(ErrorBuildFileNotFound(buildURI)),
-            dependencies = currentBuild.to(ArraySeq).flatMap(_.dependencies),
-            activateWorkspace = None
-          )
+            currentBuild = currentBuild
+          ) match {
+            case Some(buildErrored) =>
+              buildErrored
+
+            case None =>
+              // default build file created! Parse and compile it!
+              parseAndCompile(
+                buildURI = buildURI,
+                currentBuild = currentBuild
+              )
+          }
     }
 
   /** Parse and compile from memory */
@@ -316,5 +322,37 @@ object Build {
       fileURI = parsed.buildURI
     )
   }
+
+  /**
+   * Generate and persist a default build file.
+   *
+   * @param buildURI     The location of the build file.
+   * @param currentBuild The existing build, used to carry dependencies forward in case of error.
+   * @return `Some(error)` if there were IO errors, else `None` for successful creation.
+   */
+  private def createDefaultBuildFile(
+      buildURI: URI,
+      currentBuild: Option[BuildState.IsCompiled]
+    )(implicit file: FileAccess): Option[BuildState.Errored] =
+    file.write(
+      fileURI = buildURI,
+      string = RalphcConfig.write(RalphcConfig.defaultParsedConfig, indent = 2),
+      index = SourceIndexExtra.zero(buildURI)
+    ) match {
+      case Left(error) =>
+        val buildState =
+          BuildState.Errored(
+            buildURI = buildURI,
+            codeOption = None,
+            errors = ArraySeq(error),
+            dependencies = currentBuild.to(ArraySeq).flatMap(_.dependencies),
+            activateWorkspace = None
+          )
+
+        Some(buildState)
+
+      case Right(_) =>
+        None
+    }
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildState.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildState.scala
@@ -23,7 +23,7 @@ import org.alephium.ralph.lsp.pc.workspace.build.RalphcConfig.{RalphcCompiledCon
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 
 import java.net.URI
-import java.nio.file.{Path, Paths}
+import java.nio.file.Path
 import scala.collection.immutable.ArraySeq
 
 sealed trait BuildState {
@@ -33,7 +33,7 @@ sealed trait BuildState {
   def buildURI: URI
 
   def workspaceURI: URI =
-    Paths.get(buildURI).getParent.toUri
+    URIUtil.dropRight(buildURI, count = 2) // Drop the 2 from the URI's tail end `.../.ralph-lsp/ralph.json`
 
 }
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildValidator.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildValidator.scala
@@ -40,9 +40,9 @@ object BuildValidator {
   def validateBuildURI(
       buildURI: URI,
       workspaceURI: URI): Either[CompilerMessage.Error, URI] =
-    if (!URIUtil.isFileName(buildURI, Build.BUILD_FILE_NAME))
+    if (!URIUtil.isFileName(buildURI, Build.FILE_NAME))
       Left(ErrorBuildFileNotFound(buildURI))
-    else if (!URIUtil.isFirstChild(workspaceURI, buildURI)) // Build file must be in the root workspace directory.
+    else if (!URIUtil.isFirstChild(Build.toBuildDir(workspaceURI), buildURI)) // Build file must be in the root workspace directory.
       Left(
         ErrorInvalidBuildFileLocation(
           buildURI = buildURI,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/RalphcConfig.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/RalphcConfig.scala
@@ -19,7 +19,6 @@ package org.alephium.ralph.lsp.pc.workspace.build
 import org.alephium.ralph.CompilerOptions
 import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, SourceIndexExtra}
 import org.alephium.ralph.lsp.pc.util.PicklerUtil._
-import org.alephium.ralph.lsp.pc.workspace.build.Build.toBuildPath
 import org.alephium.ralph.lsp.pc.workspace.build.error.{ErrorInvalidBuildSyntax, ErrorEmptyBuildFile}
 
 import java.net.URI
@@ -123,7 +122,7 @@ object RalphcConfig {
       config: RalphcParsedConfig): Try[Path] =
     Try {
       val bytes         = RalphcConfig.write(config).getBytes(StandardCharsets.UTF_8)
-      val buildFilePath = toBuildPath(workspacePath)
+      val buildFilePath = Build.toBuildFile(workspacePath)
       Files.write(buildFilePath, bytes)
     }
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/RalphcConfig.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/RalphcConfig.scala
@@ -99,8 +99,10 @@ object RalphcConfig {
       }
 
   /** Write a parsed config */
-  def write(config: RalphcParsedConfig): String =
-    upickle.default.write[RalphcParsedConfig](config)
+  def write(
+      config: RalphcParsedConfig,
+      indent: Int = -1): String =
+    upickle.default.write[RalphcParsedConfig](config, indent = indent)
 
   /** Write a compiled config */
   def write(config: RalphcCompiledConfig): String =

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/Dependency.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/Dependency.scala
@@ -35,7 +35,7 @@ object Dependency {
   def defaultPath(): Option[Path] =
     FileAccess
       .USER_HOME
-      .map(_.resolve(".ralph-lsp").resolve("dependencies"))
+      .map(_.resolve(FileAccess.RALPH_LSP_HOME).resolve("dependencies"))
 
   /**
    * Compile this build's dependency.

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/DependencyDownloader.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/DependencyDownloader.scala
@@ -94,7 +94,7 @@ object DependencyDownloader {
    */
   def defaultBuild(workspaceDir: Path): BuildState.Compiled = {
     val buildDir =
-      workspaceDir resolve Build.BUILD_FILE_NAME
+      Build.toBuildFile(workspaceDir)
 
     val compiledConfig =
       org

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/error/ErrorBuildFileNotFound.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/error/ErrorBuildFileNotFound.scala
@@ -25,7 +25,7 @@ import java.net.URI
 case class ErrorBuildFileNotFound(buildURI: URI) extends CompilerMessage.Error {
 
   override def message: String =
-    s"Build file not found. Create a '${Build.BUILD_FILE_NAME}' file in the project's root folder."
+    s"Build file not found. Create a '${Build.FILE_NAME}' file in the project's root folder."
 
   override def index: SourceIndex =
     SourceIndexExtra.zero(buildURI)

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/error/ErrorDefaultDependencyDirectoryDoesNotExists.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/error/ErrorDefaultDependencyDirectoryDoesNotExists.scala
@@ -24,7 +24,7 @@ case class ErrorDefaultDependencyDirectoryDoesNotExists(index: SourceIndex) exte
 
   override def message: String =
     s"""Unable to write dependencies because `dependencyPath` or the system property `user.home` is not configured.
-       |To fix this, either add the setting "dependencyPath": "dependencies" in ${Build.BUILD_FILE_NAME} and create a directory named "dependencies" in your project, or set the system property `user.home`.
+       |To fix this, either add the setting "dependencyPath": "dependencies" in ${Build.FILE_NAME} and create a directory named "dependencies" in your project, or set the system property `user.home`.
        |""".stripMargin
 
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/PCDeleteOrCreateSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/PCDeleteOrCreateSpec.scala
@@ -43,7 +43,7 @@ class PCDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCheckDriv
 
   "report failure" when {
     "build file is deleted" when {
-      "current workspace is Created" in {
+      "current workspace is Created" ignore {
         implicit val file: FileAccess =
           FileAccess.disk
 
@@ -95,7 +95,7 @@ class PCDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCheckDriv
         }
       }
 
-      "current workspace is UnCompiled" in {
+      "current workspace is UnCompiled" ignore {
         implicit val file: FileAccess =
           FileAccess.disk
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/PCDeleteOrCreateSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/PCDeleteOrCreateSpec.scala
@@ -16,20 +16,23 @@
 
 package org.alephium.ralph.lsp.pc
 
+import org.alephium.ralph.lsp.TestFile
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.sourcecode.{TestSourceCode, SourceCodeState}
-import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorBuildFileNotFound
-import org.alephium.ralph.lsp.pc.workspace.build.{BuildState, TestBuild}
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.Dependency
+import org.alephium.ralph.lsp.pc.workspace.build.{RalphcConfig, TestRalphc, BuildState, TestBuild}
 import org.alephium.ralph.lsp.pc.workspace.{WorkspaceState, TestWorkspace, WorkspaceFileEvent}
 import org.scalacheck.Gen
 import org.scalamock.scalatest.MockFactory
+import org.scalatest.OptionValues.convertOptionToValuable
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
+import java.nio.file.Paths
 import scala.collection.immutable.ArraySeq
 import scala.util.Random
 
@@ -43,22 +46,32 @@ class PCDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCheckDriv
 
   "report failure" when {
     "build file is deleted" when {
-      "current workspace is Created" ignore {
+      "current workspace is Created" in {
         implicit val file: FileAccess =
           FileAccess.disk
 
         implicit val compiler: CompilerAccess =
           CompilerAccess.ralphc
 
-        forAll(TestBuild.genCompiledOK()) {
+        // set `dependenciesFolderName` to `None` so that dependencies get written to the default folder.
+        val buildGenerator =
+          TestBuild.genCompiledOK(
+            config = TestRalphc.genRalphcParsedConfig(
+              dependenciesFolderName = None,
+              contractsFolderName = RalphcConfig.defaultParsedConfig.contractPath,
+              artifactsFolderName = RalphcConfig.defaultParsedConfig.artifactPath
+            )
+          )
+
+        forAll(buildGenerator) {
           build =>
             // delete the build file
             TestBuild delete build
+            TestFile.exists(build.buildURI) shouldBe false
             // also create a deleted event
             val event =
               WorkspaceFileEvent.Deleted(build.buildURI)
 
-            // initial/current workspace
             val workspace =
               WorkspaceState.Created(build.workspaceURI)
 
@@ -77,39 +90,65 @@ class PCDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCheckDriv
 
             val expectedPCState =
               PCState(
-                workspace = workspace,
-                buildErrors = Some(
-                  BuildState.Errored(
-                    buildURI = build.buildURI,
-                    codeOption = None,                                         // because workspace is in created state
-                    errors = ArraySeq(ErrorBuildFileNotFound(build.buildURI)), // the error is reported
-                    dependencies = ArraySeq.empty,                             // because workspace is in created state
-                    activateWorkspace = None
+                // expected workspace
+                workspace = WorkspaceState.Compiled(
+                  sourceCode = ArraySeq.empty,    // there is no source code
+                  parsed = WorkspaceState.Parsed( // Workspace is successful parsed
+                    build = BuildState.Compiled(
+                      buildURI = build.buildURI,
+                      code = RalphcConfig.write(RalphcConfig.defaultParsedConfig, indent = 2), // Default build file is written
+                      dependencies = build.dependencies,                                       // default dependencies are written
+                      dependencyPath = Dependency.defaultPath().value,                         // Default dependency build path i.e. .ralph-lsp is used
+                      config = org                                                             // compiled build file has full paths defined
+                        .alephium
+                        .ralphc
+                        .Config(
+                          // compiled build file contains configurations from the default build coming from node
+                          compilerOptions = RalphcConfig.defaultParsedConfig.compilerOptions,
+                          contractPath = Paths.get(build.workspaceURI).resolve(RalphcConfig.defaultParsedConfig.contractPath),
+                          artifactPath = Paths.get(build.workspaceURI).resolve(RalphcConfig.defaultParsedConfig.artifactPath)
+                        )
+                    ),
+                    sourceCode = ArraySeq.empty // there is no source-code in this workspace
                   )
-                )
+                ),
+                buildErrors = None // there are no build errors
               )
+
+            // build file exists on disk
+            TestFile.exists(build.buildURI) shouldBe true
 
             actualPCState shouldBe expectedPCState
 
+            // clear workspace
             TestWorkspace delete workspace
         }
       }
 
-      "current workspace is UnCompiled" ignore {
+      "current workspace is UnCompiled" in {
         implicit val file: FileAccess =
           FileAccess.disk
 
         implicit val compiler: CompilerAccess =
           CompilerAccess.ralphc
 
-        forAll(TestBuild.genCompiledWithSourceCodeInAndOut()) {
-          case (build, sourceCodeIn, sourceCodeOut) =>
-            /**
-             * FAIL SCENARIO
-             */
+        // Generate
+        val buildGenerator =
+          TestBuild
+            .genCompiledWithSourceCodeInAndOut(
+              config = TestRalphc
+                .genRalphcParsedConfig(
+                  dependenciesFolderName = None,
+                  contractsFolderName = RalphcConfig.defaultParsedConfig.contractPath,
+                  artifactsFolderName = RalphcConfig.defaultParsedConfig.artifactPath
+                )
+            )
 
+        forAll(buildGenerator) {
+          case (build, sourceCodeIn, sourceCodeOut) =>
             // delete the build file
             TestBuild delete build
+            TestFile.exists(build.buildURI) shouldBe false
             // also create a deleted event
             val event =
               WorkspaceFileEvent.Deleted(build.buildURI)
@@ -130,37 +169,6 @@ class PCDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCheckDriv
                 buildErrors = None
               )
 
-            // invoke build event
-            val actualPCState =
-              PC.deleteOrCreate(
-                events = ArraySeq(event),
-                pcState = currentPCState
-              )
-
-            // expect PC state should maintain existing workspace (include )
-            val expectedPCState =
-              PCState(
-                workspace = workspace,
-                buildErrors = Some(
-                  BuildState.Errored(
-                    buildURI = build.buildURI,
-                    codeOption = None,                                         // no code is stored because the build is deleted
-                    errors = ArraySeq(ErrorBuildFileNotFound(build.buildURI)), // the error is reported
-                    dependencies = build.dependencies,                         // dependency from previous build is carried
-                    activateWorkspace = Some(workspace)                        // the same workspace with inside-code and outside-code is stored.
-                  )
-                )
-              )
-
-            actualPCState shouldBe expectedPCState
-
-            /**
-             * PASS SCENARIO: For the same test data execute pass scenario (Just piggy back off this test).
-             */
-            info("PASS SCENARIO: When build is OK")
-            // also test pass behaviour when build is persisted
-            TestBuild persist build
-
             // invoke the same event
             val actualPCStateOK =
               PC.deleteOrCreate(
@@ -168,12 +176,35 @@ class PCDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCheckDriv
                 pcState = currentPCState
               )
 
-            // no build errors this time because build file is on-disk
+            // A build file is generated
+            TestFile.exists(build.buildURI) shouldBe true
+
+            // no build errors because build file is generate
             actualPCStateOK.buildErrors shouldBe None
             // workspace is compiled
             val compiledWorkspace = actualPCStateOK.workspace.asInstanceOf[WorkspaceState.Compiled]
             // final workspace should contain ONLY the inside source-code, outside source-code is removed
             compiledWorkspace.sourceCode.map(_.fileURI) should contain theSameElementsAs sourceCodeIn.map(_.fileURI)
+
+            // Expect this default build file
+            val expectedBuild =
+              BuildState.Compiled(
+                buildURI = build.buildURI,
+                code = RalphcConfig.write(RalphcConfig.defaultParsedConfig, indent = 2), // Default build file is written
+                dependencies = build.dependencies,                                       // default dependencies are written
+                dependencyPath = Dependency.defaultPath().value,                         // Default dependency build path i.e. .ralph-lsp is used
+                config = org                                                             // compiled build file has full paths defined
+                  .alephium
+                  .ralphc
+                  .Config(
+                    // compiled build file contains configurations from the default build coming from node
+                    compilerOptions = RalphcConfig.defaultParsedConfig.compilerOptions,
+                    contractPath = Paths.get(build.workspaceURI).resolve(RalphcConfig.defaultParsedConfig.contractPath),
+                    artifactPath = Paths.get(build.workspaceURI).resolve(RalphcConfig.defaultParsedConfig.artifactPath)
+                  )
+              )
+
+            compiledWorkspace.build shouldBe expectedBuild
 
             // clear test data
             TestWorkspace delete workspace

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
@@ -71,7 +71,7 @@ object TestSourceCode {
   def genOnDiskForBuild(build: Gen[BuildState.Parsed] = TestBuild.genParsed()): Gen[SourceCodeState.OnDisk] =
     for {
       build <- build
-      workspacePath = Gen.const(Paths.get(build.workspaceURI.resolve(build.config.contractPath)))
+      workspacePath = Paths.get(build.workspaceURI).resolve(build.config.contractPath)
       fileURI       = genFileURI(rootFolder = workspacePath)
       sourceCode <- TestSourceCode.genOnDisk(fileURI)
     } yield sourceCode

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/util/URIUtilSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/util/URIUtilSpec.scala
@@ -20,6 +20,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import java.net.URI
+import scala.util.Try
 
 class URIUtilSpec extends AnyWordSpec with Matchers {
 
@@ -31,6 +32,32 @@ class URIUtilSpec extends AnyWordSpec with Matchers {
           val expected = "file:///c:/Users/user/test.ral"
 
           URIUtil.uri(uri) shouldBe new URI(expected)
+        }
+      }
+    }
+
+    "dropRight" should {
+      "fail" when {
+        "drop count is greater than the number of segments" in {
+          val exception = Try(URIUtil.dropRight(URIUtil.uri("file:///a/b"), 3)).failed.get
+          exception shouldBe a[IllegalArgumentException]
+          exception.getMessage shouldBe "requirement failed: Drop count of 3 is not less than segment count of 2"
+        }
+
+        "drop count is equal to than the number of segments" in {
+          val exception = Try(URIUtil.dropRight(URIUtil.uri("file:///a/b"), 2)).failed.get
+          exception shouldBe a[IllegalArgumentException]
+          exception.getMessage shouldBe "requirement failed: Drop count of 2 is not less than segment count of 2"
+        }
+      }
+
+      "pass" when {
+        "folders are dropped" in {
+          URIUtil.dropRight(URIUtil.uri("file:///a/b/c"), 2) shouldBe URIUtil.uri("file:///a")
+        }
+
+        "file is dropped" in {
+          URIUtil.dropRight(URIUtil.uri("file:///a/b/c/d.txt"), 2) shouldBe URIUtil.uri("file:///a/b")
         }
       }
     }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuild1Spec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuild1Spec.scala
@@ -52,7 +52,7 @@ class WorkspaceBuild1Spec extends AnyWordSpec with Matchers with ScalaCheckDrive
        * FAIL TEST CASES
        */
       "fail" when {
-        "workspace directory does not exist" in {
+        "workspace directory does not exist" ignore {
           implicit val file: FileAccess =
             FileAccess.disk
 
@@ -74,7 +74,7 @@ class WorkspaceBuild1Spec extends AnyWordSpec with Matchers with ScalaCheckDrive
           }
         }
 
-        "workspace directory exists with no build file" in {
+        "workspace directory exists with no build file" ignore {
           implicit val file: FileAccess =
             FileAccess.disk
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildSpec.scala
@@ -123,7 +123,7 @@ class BuildSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyC
         forAll(generator) {
           case (build, currentBuild) =>
             // build is within a nested folder
-            val buildParentFolder     = Paths.get(build.buildURI).getParent
+            val buildParentFolder     = Paths.get(build.buildURI).getParent.getParent
             val workspaceNestedFolder = Paths.get(currentBuild.workspaceURI.resolve("nested_folder"))
             buildParentFolder shouldBe workspaceNestedFolder
 
@@ -177,8 +177,8 @@ class BuildSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyC
         workspaceDir =>
           val buildURI =
             TestFile
-              .createDirectories(workspaceDir)
-              .resolve(Build.BUILD_FILE_NAME)
+              .createDirectories(Build.toBuildDir(workspaceDir)) // build directory exists
+              .resolve(Build.FILE_NAME)                          // build file does not exist
               .toUri
 
           implicit val file: FileAccess =

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildSpec.scala
@@ -172,7 +172,7 @@ class BuildSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyC
   }
 
   "parseAndCompile" should {
-    "report missing build file" in {
+    "report missing build file" ignore {
       forAll(genFolderURI()) {
         workspaceDir =>
           val buildURI =

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildValidatorSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildValidatorSpec.scala
@@ -48,8 +48,9 @@ class BuildValidatorSpec extends AnyWordSpec with Matchers {
 
       Files.createDirectory(workspacePath.resolve(config1.contractPath))
       Files.createDirectory(workspacePath.resolve(config1.artifactPath))
+      Files.createDirectory(Build.toBuildDir(workspacePath))
 
-      val buildPath       = workspacePath.resolve(Build.BUILD_FILE_NAME)
+      val buildPath       = Build.toBuildFile(workspacePath)
       val actualBuildPath = RalphcConfig.persist(workspacePath, config1).success.value
 
       actualBuildPath shouldBe buildPath

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/RalphcConfigSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/RalphcConfigSpec.scala
@@ -93,7 +93,7 @@ class RalphcConfigSpec extends AnyWordSpec with Matchers {
             |
             |""".stripMargin
 
-        val fileURI = URI.create(Build.BUILD_FILE_NAME)
+        val fileURI = URI.create(Build.FILE_NAME)
         val actual  = RalphcConfig.parse(fileURI, build_ralph).left.value
 
         actual shouldBe ErrorEmptyBuildFile(fileURI)
@@ -116,6 +116,7 @@ class RalphcConfigSpec extends AnyWordSpec with Matchers {
 
       Files.createDirectory(workspacePath.resolve(config.contractPath))
       Files.createDirectory(workspacePath.resolve(config.artifactPath))
+      Files.createDirectory(Build.toBuildDir(workspacePath))
       // create only if the dependencyPath is provided by the user i.e. is in the parsed config
       // otherwise expect the dependency compiler to write to the default dependencyPath
       config
@@ -126,7 +127,7 @@ class RalphcConfigSpec extends AnyWordSpec with Matchers {
         }
 
       // Persist the default config to the workspace
-      val expectedBuildPath = workspacePath.resolve(Build.BUILD_FILE_NAME)
+      val expectedBuildPath = Build.toBuildFile(workspacePath)
       val actualBuildPath   = RalphcConfig.persist(workspacePath, config).success.value
       actualBuildPath shouldBe expectedBuildPath
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestBuild.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestBuild.scala
@@ -29,6 +29,7 @@ import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers._
 
 import java.net.URI
+import java.nio.file.Paths
 
 /** Build specific generators */
 object TestBuild {
@@ -40,7 +41,7 @@ object TestBuild {
       workspaceURI <- workspaceURI
       parsedConfig <- config
     } yield {
-      val buildURI  = workspaceURI.resolve(Build.BUILD_FILE_NAME)
+      val buildURI  = Build.toBuildFile(workspaceURI)
       val buildJSON = RalphcConfig.write(parsedConfig)
       //      FileIO.write(buildJSON, buildURI).toUri shouldBe buildURI
       // run either one of the two parse functions
@@ -131,23 +132,29 @@ object TestBuild {
 
   def persist(parsed: BuildState.Parsed): BuildState.Parsed = {
     TestFile.write(parsed.buildURI, parsed.code)
-    TestFile.createDirectories(parsed.workspaceURI.resolve(parsed.config.contractPath))
-    TestFile.createDirectories(parsed.workspaceURI.resolve(parsed.config.artifactPath))
+
+    val workspacePath = Paths.get(parsed.workspaceURI)
+    TestFile.createDirectories(workspacePath.resolve(parsed.config.contractPath))
+    TestFile.createDirectories(workspacePath.resolve(parsed.config.artifactPath))
     parsed
       .config
       .dependencyPath
       .foreach {
         path =>
-          TestFile.createDirectories(parsed.workspaceURI.resolve(path))
+          TestFile.createDirectories(workspacePath.resolve(path))
       }
+
     parsed
   }
 
   def persist(compiled: BuildState.Compiled): BuildState.Compiled = {
     TestFile.write(compiled.buildURI, compiled.code)
-    TestFile.createDirectories(compiled.workspaceURI.resolve(compiled.config.contractPath.toUri))
-    TestFile.createDirectories(compiled.workspaceURI.resolve(compiled.config.artifactPath.toUri))
-    TestFile.createDirectories(compiled.workspaceURI.resolve(compiled.dependencyPath.toUri))
+
+    val workspacePath = Paths.get(compiled.workspaceURI)
+    TestFile.createDirectories(workspacePath.resolve(compiled.config.contractPath))
+    TestFile.createDirectories(workspacePath.resolve(compiled.config.artifactPath))
+    TestFile.createDirectories(workspacePath.resolve(compiled.dependencyPath))
+
     compiled
   }
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestBuild.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestBuild.scala
@@ -88,7 +88,8 @@ object TestBuild {
       workspaceURI: Gen[URI] = genFolderURI(),
       code: Gen[String] = TestCode.genGoodCode(),
       minSourceCount: Int = 0,
-      maxSourceCount: Int = 10
+      maxSourceCount: Int = 10,
+      config: Gen[RalphcParsedConfig] = genRalphcParsedConfig()
     )(implicit file: FileAccess,
       compiler: CompilerAccess,
       logger: ClientLogger): Gen[(BuildState.Compiled, List[SourceCodeState.OnDisk], List[SourceCodeState.OnDisk])] =
@@ -98,7 +99,8 @@ object TestBuild {
         genCompiledWithSourceCode(
           workspaceURI = workspaceURI,
           minSourceCount = minSourceCount,
-          maxSourceCount = maxSourceCount
+          maxSourceCount = maxSourceCount,
+          config = config
         )
       // write source-code files that are not in the workspace (expect these to get filtered out)
       outsideSourceCode <-
@@ -112,13 +114,14 @@ object TestBuild {
       workspaceURI: Gen[URI] = genFolderURI(),
       code: Gen[String] = TestCode.genGoodCode(),
       minSourceCount: Int = 0,
-      maxSourceCount: Int = 10
+      maxSourceCount: Int = 10,
+      config: Gen[RalphcParsedConfig] = genRalphcParsedConfig()
     )(implicit file: FileAccess,
       compiler: CompilerAccess,
       logger: ClientLogger): Gen[(BuildState.Compiled, List[SourceCodeState.OnDisk])] =
     for {
       // a compiled OK build file.
-      buildCompiled <- TestBuild.genCompiledOK(workspaceURI = workspaceURI)
+      buildCompiled <- TestBuild.genCompiledOK(workspaceURI = workspaceURI, config = config)
       // write source-code files to build's contract path
       workspaceSourceCode <-
         Gen

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestRalphc.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestRalphc.scala
@@ -41,12 +41,16 @@ object TestRalphc {
       ignoreCheckExternalCallerWarnings = ignoreCheckExternalCallerWarnings
     )
 
-  def genRalphcParsedConfig(compilerOptions: Gen[CompilerOptions] = genCompilerOptions()): Gen[RalphcParsedConfig] =
+  def genRalphcParsedConfig(
+      compilerOptions: Gen[CompilerOptions] = genCompilerOptions(),
+      contractsFolderName: Gen[String] = genName,
+      artifactsFolderName: Gen[String] = genName,
+      dependenciesFolderName: Gen[Option[String]] = Gen.option(genName)): Gen[RalphcParsedConfig] =
     for {
       compilerOptions        <- compilerOptions
-      contractsFolderName    <- genName
-      artifactsFolderName    <- genName
-      dependenciesFolderName <- Gen.option(genName)
+      contractsFolderName    <- contractsFolderName
+      artifactsFolderName    <- artifactsFolderName
+      dependenciesFolderName <- dependenciesFolderName
     } yield RalphcParsedConfig(
       compilerOptions = compilerOptions,
       contractPath = contractsFolderName,

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/TestDependency.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/TestDependency.scala
@@ -41,7 +41,7 @@ object TestDependency {
     // create a default build file.
     val parsed =
       BuildState.Parsed(
-        buildURI = Paths.get(Build.BUILD_FILE_NAME).toUri,
+        buildURI = Paths.get(Build.FILE_NAME).toUri,
         code = RalphcConfig.write(RalphcConfig.defaultParsedConfig),
         config = RalphcConfig.defaultParsedConfig
       )


### PR DESCRIPTION
Implements Requirement 1: If the build file `ralph.json` is absent, generate one with default values.

Few test-cases are ignored here because `ralph.json` is no longer mandatory. These tests will be re-enabled in the next PR where `alephium.config.ts` becomes mandatory (Requirements 2). 

<strike>You had also mentioned that we move `ralph.json` to `./ralph-lsp/ralph.json`, if this is still required it will be implemented in the next PR (Requirements 2) which will introduce other bigger changes for working with `alephium.config.ts`.</strike>

Towards #214.