### PR TITLE
Revert fix for issue #135

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/Tree.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/Tree.scala
@@ -73,22 +73,6 @@ object Tree {
     lazy val rootNode: Node[Ast.UniqueDef, Ast.Positioned] =
       NodeBuilder.buildRootNode(ast)
 
-    /**
-     * Solution for issue <a href="https://github.com/alephium/ralph-lsp/issues/135">#135</a>.
-     *
-     * Clear AST cached objects to enable recompilation of [[Ast.Struct]].
-     */
-    def clearStructCache(): Unit =
-      rootNode
-        .walkDown
-        .map(_.data)
-        .foreach {
-          case typed: Ast.StructCtor[_] =>
-            typed.tpe = None
-
-          case _ =>
-        }
-
     def typeId(): Ast.TypeId =
       ast match {
         case Left(contract) =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
@@ -254,11 +254,7 @@ private[pc] object SourceCode {
     // Compile only the source-code. Import statements are already expected to be processed and included in `importedCode` collection.
     val (contracts, structs) =
       allCode
-        .map {
-          source =>
-            source.clearStructCache()
-            source.ast
-        }
+        .map(_.ast)
         .partitionMap(identity)
 
     // compile the source-code


### PR DESCRIPTION
Deep cloning solution in #233 should've allowed us to revert the fix for issue #135, which sets `Ast.StructCtor.tpe = None` so that `Struct` get revalidated. Although the issue does get resolved, it results in another one:

# Replication

Create a struct file `my_struct.ral`.

```rust
struct MyStruct {
  x: U256
}
```

Create a contract file `my_contract.ral` using the `struct`.

```rust
Contract MyContract() {
  
  pub fn getBool() -> () {
    let struct_instance = MyStruct { x: 1 }
  }

}

```

After successful initial compilation, change the type name `MyStruct` to `MyStruct2`

```rust
struct MyStruct2 {
  x: U256
}
```

![image](https://github.com/alephium/ralph-lsp/assets/1773953/2f9d1d74-da30-4b5e-add5-8cb4736e20a4)

The error `Struct "MyStruct" does not exist` should've been reported on `MyContract`. This is resolved when `MyContract` is saved or if double compilation step calls in #233 are called only once.

# TODO

Transform this into a test-case. 