### PR TITLE
Reset contracts state before compilation

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/Tree.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/ast/Tree.scala
@@ -73,22 +73,6 @@ object Tree {
     lazy val rootNode: Node[Ast.UniqueDef, Ast.Positioned] =
       NodeBuilder.buildRootNode(ast)
 
-    /**
-     * Solution for issue <a href="https://github.com/alephium/ralph-lsp/issues/135">#135</a>.
-     *
-     * Clear AST cached objects to enable recompilation of [[Ast.Struct]].
-     */
-    def clearStructCache(): Unit =
-      rootNode
-        .walkDown
-        .map(_.data)
-        .foreach {
-          case typed: Ast.StructCtor[_] =>
-            typed.tpe = None
-
-          case _ =>
-        }
-
     def typeId(): Ast.TypeId =
       ast match {
         case Left(contract) =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/ExprCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/ExprCompleter.scala
@@ -26,7 +26,7 @@ object ExprCompleter extends StrictImplicitLogging {
       expr: Ast.Expr[_],
       workspace: WorkspaceState.IsSourceAware
     )(implicit logger: ClientLogger): Iterator[Suggestion.FuncDef] =
-    expr.tpe match {
+    expr.getCachedType() match {
       case Some(types) =>
         WorkspaceSearcher
           .collectFunctions(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFuncId.scala
@@ -216,7 +216,7 @@ private[search] object GoToFuncId extends StrictImplicitLogging {
               // function ID matches, but does it also match the type ID?
               call
                 .obj
-                .tpe
+                .getCachedType()
                 .map(_.flatMap(AstExtra.getTypeId)) // fetch the type ID of this function call
                 .iterator
                 .flatMap {
@@ -271,7 +271,7 @@ private[search] object GoToFuncId extends StrictImplicitLogging {
       typeExpr: Ast.Expr[_],
       workspace: WorkspaceState.IsSourceAware
     )(implicit logger: ClientLogger): Iterator[SourceLocation.Node[Ast.Positioned]] =
-    typeExpr.tpe match {
+    typeExpr.getCachedType() match {
       case Some(types) =>
         val allFunctions =
           WorkspaceSearcher.collectFunctions(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
@@ -254,12 +254,11 @@ private[pc] object SourceCode {
     // Compile only the source-code. Import statements are already expected to be processed and included in `importedCode` collection.
     val (contracts, structs) =
       allCode
-        .map {
-          source =>
-            source.clearStructCache()
-            source.ast
-        }
+        .map(_.ast)
         .partitionMap(identity)
+
+    // Reset contracts state before compilation. This is necessary to ensure that contracts are fully recompiled.
+    contracts.foreach(_.reset())
 
     // compile the source-code
     val compilationResult =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   lazy val scalaMock  = "org.scalamock"     %% "scalamock"       % "6.0.0"    % Test
 
   /** Core */
-  lazy val ralphc = "org.alephium" %% "alephium-ralphc" % "3.1.2" excludeAll (
+  lazy val ralphc = "org.alephium" %% "alephium-ralphc" % "3.2.1" excludeAll (
     ExclusionRule(organization = "org.rocksdb"),
     ExclusionRule(organization = "io.prometheus"),
     ExclusionRule(organization = "org.alephium", name = "alephium-api_2.13"),


### PR DESCRIPTION
Thx to the new [reset()](https://github.com/alephium/alephium/blob/c2ebcc1adbbc596fce3f5db2a496df718ee95123/ralph/src/main/scala/org/alephium/ralph/Ast.scala#L203) function introduced [here](https://github.com/alephium/alephium/pull/1150).

We can now always have a proper full recompile, this solve multiple issue. 

* Inconsistent warnings: https://github.com/alephium/ralph-lsp/issues/61 and https://github.com/alephium/ralph-lsp/issues/232
* We can also remove the fix introduced in https://github.com/alephium/ralph-lsp/issues/135
* The new issue mentioned in the open PR https://github.com/alephium/ralph-lsp/pull/234 is also fixed with that.
* The deep clone of https://github.com/alephium/ralph-lsp/pull/233  isn't necessary anymore

Please @simerplaha double check that all the above are fixed, thx.