### PR TITLE
Improve plugin start

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Currently supports text document level events and diagnostics.
 
 # Install VSCode plugin
 
+`Ralph LSP` is available on the [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=alephium.ralph-lsp).
+
+### Manual Installation
+
 Follow these steps:
 
 1. Download: Get the `.vsix` plugin file from the [latest release](https://github.com/alephium/ralph-lsp/releases/latest).

--- a/README.md
+++ b/README.md
@@ -52,6 +52,23 @@ lazy_plugin_config = {
 
 The plugin adds file type detection, syntax highlighting and start the LSP server, make sure you have `ralph-lsp` available in your `PATH`
 
+# Integrate new editor
+
+Please help us integrate Ralph LSP into your favorite editor. We are happy to assist you with any questions you may have.
+
+You can either create your own repository or add a new folder in this repository following the `plugin-<editor>` naming convention.
+
+### Define Root Directory
+
+It's important to ensure that your plugin can find the correct root directory for your Ralph project.
+For example, if you open your editor while inside the `contracts` folder, the plugin should be able to identify the root directory as `../contracts`.
+
+In our current plugins, we follow this heuristic:
+
+* Look for the presence of either `alephium.config.ts`, `contracts`, or `.ralph.json`.
+
+If none of these are found, the plugin will use the current directory as the root directory.
+
 # Build the JAR
 
 ```shell

--- a/plugin-nvim/plugin/ralph.lua
+++ b/plugin-nvim/plugin/ralph.lua
@@ -4,7 +4,7 @@ local function ralph_init()
 
   capabilities.workspace.didChangeWatchedFiles.dynamicRegistration = true
 
-  local root_dir = vim.fs.dirname(vim.fs.find({'build.ralph', 'contracts', 'artifacts'}, { upward = true })[1])
+  local root_dir = vim.fs.dirname(vim.fs.find({'alephium.config.ts', 'contracts', '.ralph-lsp'}, { upward = true })[1])
 
   if root_dir == nil then root_dir = vim.fn.getcwd() end
 


### PR DESCRIPTION
Resolves #237

I searched for a while, but vscode doesn't seems to have builtin stuff for finding a different the root dir.

For testing I tried manually every case I could think, starting from various places, with/without the `rootFiles` etc.

Please give it a try, the goal is really to have a good UX so users don't need to care about how/where ralph-lsp is launched.