### PR TITLE
Verify build directory deletion

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PC.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PC.scala
@@ -156,7 +156,10 @@ object PC {
 
         // is the build deleted?
         val isBuildDeleted =
-          workspaceEvents contains WorkspaceFileEvent.Deleted(workspace.buildURI)
+          workspaceEvents.collectFirst {
+            case event @ WorkspaceFileEvent.Deleted(deletedURI) if URIUtil.contains(deletedURI, workspace.buildURI) =>
+              event
+          }.isDefined
 
         val buildCode =
           if (isBuildDeleted) // if build is deleted, compile from disk

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/PCDeleteOrCreateSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/PCDeleteOrCreateSpec.scala
@@ -65,12 +65,19 @@ class PCDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCheckDriv
 
         forAll(buildGenerator) {
           build =>
-            // delete the build file
-            TestBuild delete build
-            TestFile.exists(build.buildURI) shouldBe false
-            // also create a deleted event
+            // delete the build and also create a deleted event
             val event =
-              WorkspaceFileEvent.Deleted(build.buildURI)
+              if (Random.nextBoolean()) {
+                // delete the `build.json` file
+                val buildURI = TestBuild deleteFile build
+                TestFile.exists(buildURI) shouldBe false
+                WorkspaceFileEvent.Deleted(buildURI)
+              } else {
+                // delete the `.ralph-lsp` directory containing the `build.json` file
+                val dirURI = TestBuild deleteDirectory build
+                TestFile.exists(dirURI) shouldBe false
+                WorkspaceFileEvent.Deleted(dirURI)
+              }
 
             val workspace =
               WorkspaceState.Created(build.workspaceURI)
@@ -146,12 +153,19 @@ class PCDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCheckDriv
 
         forAll(buildGenerator) {
           case (build, sourceCodeIn, sourceCodeOut) =>
-            // delete the build file
-            TestBuild delete build
-            TestFile.exists(build.buildURI) shouldBe false
-            // also create a deleted event
+            // delete the build and also create a deleted event
             val event =
-              WorkspaceFileEvent.Deleted(build.buildURI)
+              if (Random.nextBoolean()) {
+                // delete the `build.json` file
+                val buildURI = TestBuild deleteFile build
+                TestFile.exists(buildURI) shouldBe false
+                WorkspaceFileEvent.Deleted(buildURI)
+              } else {
+                // delete the `.ralph-lsp` directory containing the `build.json` file
+                val dirURI = TestBuild deleteDirectory build
+                TestFile.exists(dirURI) shouldBe false
+                WorkspaceFileEvent.Deleted(dirURI)
+              }
 
             val workspace =
               WorkspaceState.UnCompiled(

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcherCollectInheritedParentsSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcherCollectInheritedParentsSpec.scala
@@ -161,7 +161,7 @@ class WorkspaceSearcherCollectInheritedParentsSpec extends AnyWordSpec with Matc
     // it should contain all expected source-trees.
     actual should contain theSameElementsAs expected
 
-    TestBuild delete build
+    TestBuild deleteDirectory build
   }
 
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildValidatorSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildValidatorSpec.scala
@@ -97,7 +97,7 @@ class BuildValidatorSpec extends AnyWordSpec with Matchers {
             ErrorDependencyPathIsWithinContractPath(SourceIndex(build.code.lastIndexOf(config.contractPath), config.contractPath.length, Some(build.buildURI)))
           )
 
-        TestBuild delete build
+        TestBuild deleteDirectory build
       }
 
       "they are identical" in {
@@ -160,7 +160,7 @@ class BuildValidatorSpec extends AnyWordSpec with Matchers {
         // expect no errors
         actual shouldBe empty
 
-        TestBuild delete build
+        TestBuild deleteDirectory build
       }
 
       "they are distinct" in {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestBuild.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestBuild.scala
@@ -174,7 +174,19 @@ object TestBuild {
       (build, contractOnDisk, extensionOnDisk, extension, extensionName)
     }
 
-  def delete(build: BuildState): Unit =
-    TestFile delete build.buildURI
+  /** Deletes the build file located at `.ralph-lsp/ralph.json`. */
+  def deleteFile(build: BuildState): URI = {
+    val fileURI = build.buildURI
+    TestFile delete fileURI
+    fileURI
+  }
+
+  /** Deletes the directory `.ralph-lsp` along with the build file `ralph.json`. */
+  def deleteDirectory(build: BuildState): URI = {
+    deleteFile(build)
+    val directory = Build.toBuildDir(build.workspaceURI)
+    TestFile delete directory
+    directory
+  }
 
 }


### PR DESCRIPTION
Following PR #231, which moved `ralph.json` to `.ralph-lsp`, this PR updates the check for deleted build file `ralph.json` to also verify whether an event exists for deleted `.ralph-lsp` directory or any parent directory. Currently, it only checks if a delete event exists for the file `ralph.json` (since previously this file was in the root directory), deleting the `.ralph-lsp` directory should also behave similar.