### PR TITLE
Optional `artifactsPath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,7 @@ directory under the folder `.ralph-lsp/ralph.json`. The file contains the follow
     "ignoreUpdateFieldsCheckWarnings": false,
     "ignoreCheckExternalCallerWarnings": false
   },
-  "contractPath": "contracts",
-  "artifactPath": "artifacts"
+  "contractPath": "contracts"
 }
 ```
 

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
@@ -51,6 +51,26 @@ object SourceIndexExtra {
         fileURI = Some(fileURI)
       )
 
+  /**
+   * Similar to `String.lastIndexOf`, this returns the last index of
+   * the given token in the provided code.
+   *
+   * @param token   The token to find.
+   * @param code    The code within which to search for the token.
+   * @param fileURI The file URI of the input code.
+   * @return A [[SourceIndex]] if the token was found, otherwise the [[SourceIndex]]
+   *         for the zeroth index.
+   */
+  def lastIndexOf(
+      token: String,
+      code: String,
+      fileURI: URI): SourceIndex =
+    SourceIndexExtra.ensurePositive(
+      index = code.lastIndexOf(token), // TODO: lastIndexOf is temporary solution until an AST is available.
+      width = token.length,
+      fileURI = fileURI
+    )
+
   implicit class SourceIndexExtension(val sourceIndex: SourceIndex) extends AnyVal {
 
     def from: Int =

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/util/PicklerUtil.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/util/PicklerUtil.scala
@@ -17,7 +17,7 @@
 package org.alephium.ralph.lsp.pc.util
 
 import org.alephium.ralph.CompilerOptions
-import org.alephium.ralph.lsp.pc.workspace.build.RalphcConfig.{RalphcCompiledConfig, RalphcParsedConfig}
+import org.alephium.ralph.lsp.pc.workspace.build.RalphcConfig.RalphcParsedConfig
 import upickle.default._
 
 import java.nio.file.{Path, Paths}
@@ -37,9 +37,6 @@ object PicklerUtil {
     macroRW
 
   implicit val ralphcConfigReaderWriter: ReadWriter[RalphcParsedConfig] =
-    macroRW
-
-  implicit val ralphcCompiledReaderWriter: ReadWriter[RalphcCompiledConfig] =
     macroRW
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/util/URIUtil.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/util/URIUtil.scala
@@ -16,6 +16,10 @@
 
 package org.alephium.ralph.lsp.pc.util
 
+import org.alephium.ralph.SourceIndex
+import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
+import org.alephium.ralph.lsp.access.file.FileAccess
+
 import java.net.URI
 import java.nio.file.{Path, Paths}
 import scala.jdk.CollectionConverters.IteratorHasAsScala
@@ -53,6 +57,26 @@ object URIUtil {
       parent = Paths.get(parent),
       child = Paths.get(child)
     )
+
+  /**
+   * Checks if a given path exists or is undefined.
+   *
+   * @param path      Path to check.
+   * @param pathIndex Index to report error.
+   * @return An [[CompilerMessage.AnyError]] if an error occurs,
+   *         otherwise a `true` indicating the existence of the path or if the path is undefined.
+   */
+  def existsOrUndefined(
+      path: Option[Path],
+      pathIndex: SourceIndex
+    )(implicit file: FileAccess): Either[CompilerMessage.AnyError, Boolean] =
+    path match {
+      case Some(path) =>
+        file.exists(path.toUri, pathIndex)
+
+      case None =>
+        Right(true)
+    }
 
   /** Is the child [[Path]] within the parent [[Path]] */
   def contains(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildState.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildState.scala
@@ -79,10 +79,10 @@ object BuildState {
       parsed.code
 
     def contractURI: URI =
-      config.contractPath.toUri
+      config.contractURI
 
-    def artifactURI: URI =
-      config.artifactPath.toUri
+    def artifactURI: Option[URI] =
+      config.artifactURI
 
     override def findDependency(id: DependencyID): Option[WorkspaceState.Compiled] =
       BuildState.findDependency(dependencies, id)

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/Dependency.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/Dependency.scala
@@ -21,6 +21,7 @@ import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.log.ClientLogger
+import org.alephium.ralph.lsp.pc.workspace.build.RalphcConfig.RalphcCompiledConfig
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader.DependencyDownloader
 import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorDefaultDependencyDirectoryDoesNotExists
 import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState}
@@ -167,10 +168,16 @@ object Dependency {
         Build.getAbsoluteContractArtifactPaths(parentWorkspaceBuild)
 
       val config =
-        Config(
-          compilerOptions = parentWorkspaceBuild.config.compilerOptions,
-          contractPath = absoluteContractPath,
-          artifactPath = absoluteArtifactPath
+        RalphcCompiledConfig(
+          isArtifactsPathDefinedInBuild = absoluteArtifactPath.isDefined,
+          config = Config(
+            compilerOptions = parentWorkspaceBuild.config.compilerOptions,
+            contractPath = absoluteContractPath,
+            // Issue https://github.com/alephium/ralph-lsp/issues/247 requests to "not require the existence of artifacts folder".
+            // But artifactPath is mandatory in compiler's Config instance.
+            // Therefore, if the `artifactPath` is not provided, use the `contractPath` as the `artifactPath`.
+            artifactPath = absoluteArtifactPath.map(_._2) getOrElse absoluteContractPath
+          )
         )
 
       // Build OK. Promote build to compiled state.

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/DependencyDownloader.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/DependencyDownloader.scala
@@ -96,28 +96,37 @@ object DependencyDownloader {
     val buildDir =
       Build.toBuildFile(workspaceDir)
 
-    val compiledConfig =
-      org
-        .alephium
-        .ralphc
-        .Config(
-          compilerOptions = CompilerOptions.Default,
-          contractPath = workspaceDir,
-          artifactPath = workspaceDir
-        )
+    // Create a config with the workspace directory as the only directory.
+    // Sets`contractPath` as the workspace directory.
+    val parsedConfig =
+      RalphcConfig.RalphcParsedConfig(
+        compilerOptions = CompilerOptions.Default,
+        contractPath = workspaceDir.toString,
+        artifactPath = None
+      )
 
     val json =
-      RalphcConfig.write(compiledConfig)
+      RalphcConfig.write(parsedConfig)
 
     val parsed =
       BuildState.Parsed(
         buildURI = buildDir.toUri,
         code = json,
-        config = RalphcConfig.RalphcParsedConfig(
-          compilerOptions = CompilerOptions.Default,
-          contractPath = workspaceDir.toString,
-          artifactPath = workspaceDir.toString
-        )
+        config = parsedConfig
+      )
+
+    // a compiled config
+    val compiledConfig =
+      RalphcConfig.RalphcCompiledConfig(
+        isArtifactsPathDefinedInBuild = parsedConfig.artifactPath.isDefined,
+        config = org
+          .alephium
+          .ralphc
+          .Config(
+            compilerOptions = CompilerOptions.Default,
+            contractPath = workspaceDir,
+            artifactPath = workspaceDir
+          )
       )
 
     BuildState.Compiled(

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/PCDeleteOrCreateSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/PCDeleteOrCreateSpec.scala
@@ -104,15 +104,18 @@ class PCDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCheckDriv
                     build = BuildState.Compiled(
                       dependencies = build.dependencies,               // default dependencies are written
                       dependencyPath = Dependency.defaultPath().value, // Default dependency build path i.e. .ralph-lsp is used
-                      config = org                                     // compiled build file has full paths defined
-                        .alephium
-                        .ralphc
-                        .Config(
-                          // compiled build file contains configurations from the default build coming from node
-                          compilerOptions = RalphcConfig.defaultParsedConfig.compilerOptions,
-                          contractPath = Paths.get(build.workspaceURI).resolve(RalphcConfig.defaultParsedConfig.contractPath),
-                          artifactPath = Paths.get(build.workspaceURI).resolve(RalphcConfig.defaultParsedConfig.artifactPath)
-                        ),
+                      config = RalphcConfig.RalphcCompiledConfig(
+                        isArtifactsPathDefinedInBuild = false, // the default build config is used above, so artifactsPath is not defined
+                        config = org                           // compiled build file has full paths defined
+                          .alephium
+                          .ralphc
+                          .Config(
+                            // compiled build file contains configurations from the default build coming from node
+                            compilerOptions = RalphcConfig.defaultParsedConfig.compilerOptions,
+                            contractPath = Paths.get(build.workspaceURI).resolve(RalphcConfig.defaultParsedConfig.contractPath),
+                            artifactPath = Paths.get(build.workspaceURI).resolve(RalphcConfig.defaultParsedConfig.contractPath)
+                          )
+                      ),
                       parsed = BuildState.Parsed(
                         build.buildURI,
                         RalphcConfig.write(RalphcConfig.defaultParsedConfig, indent = 2), // Default build file is written,
@@ -208,15 +211,18 @@ class PCDeleteOrCreateSpec extends AnyWordSpec with Matchers with ScalaCheckDriv
               BuildState.Compiled(
                 dependencies = build.dependencies,               // default dependencies are written
                 dependencyPath = Dependency.defaultPath().value, // Default dependency build path i.e. .ralph-lsp is used
-                config = org                                     // compiled build file has full paths defined
-                  .alephium
-                  .ralphc
-                  .Config(
-                    // compiled build file contains configurations from the default build coming from node
-                    compilerOptions = RalphcConfig.defaultParsedConfig.compilerOptions,
-                    contractPath = Paths.get(build.workspaceURI).resolve(RalphcConfig.defaultParsedConfig.contractPath),
-                    artifactPath = Paths.get(build.workspaceURI).resolve(RalphcConfig.defaultParsedConfig.artifactPath)
-                  ),
+                config = RalphcConfig.RalphcCompiledConfig(
+                  isArtifactsPathDefinedInBuild = false, // the default build config is used above, so artifactsPath is not defined
+                  config = org                           // compiled build file has full paths defined
+                    .alephium
+                    .ralphc
+                    .Config(
+                      // compiled build file contains configurations from the default build coming from node
+                      compilerOptions = RalphcConfig.defaultParsedConfig.compilerOptions,
+                      contractPath = Paths.get(build.workspaceURI).resolve(RalphcConfig.defaultParsedConfig.contractPath),
+                      artifactPath = Paths.get(build.workspaceURI).resolve(RalphcConfig.defaultParsedConfig.contractPath)
+                    )
+                ),
                 BuildState.Parsed(
                   buildURI = build.buildURI,
                   code = RalphcConfig.write(RalphcConfig.defaultParsedConfig, indent = 2), // Default build file is written

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcherFindParsedSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcherFindParsedSpec.scala
@@ -78,10 +78,13 @@ class WorkspaceSearcherFindParsedSpec extends AnyWordSpec with Matchers with Sca
           ) shouldBe None
 
           // file is in the artifact directory
-          WorkspaceSearcher.findParsed(
-            fileURI = build.artifactURI.resolve("blah.ral"),
-            workspace = workspace
-          ) shouldBe None
+          build.artifactURI foreach {
+            artifactURI =>
+              WorkspaceSearcher.findParsed(
+                fileURI = artifactURI.resolve("blah.ral"),
+                workspace = workspace
+              ) shouldBe None
+          }
       }
     }
   }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildValidatorSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildValidatorSpec.scala
@@ -36,18 +36,18 @@ class BuildValidatorSpec extends AnyWordSpec with Matchers {
           .defaultParsedConfig
           .copy(
             contractPath = "contracts",
-            artifactPath = "artifacts"
+            artifactPath = Some("artifacts")
           )
 
       val config2 = config1.copy(
         contractPath = "./contracts",
-        artifactPath = "./artifacts"
+        artifactPath = Some("./artifacts")
       )
 
       val workspacePath = Files.createTempDirectory("root_workspace")
 
       Files.createDirectory(workspacePath.resolve(config1.contractPath))
-      Files.createDirectory(workspacePath.resolve(config1.artifactPath))
+      Files.createDirectory(workspacePath.resolve(config1.artifactPath.value))
       Files.createDirectory(Build.toBuildDir(workspacePath))
 
       val buildPath       = Build.toBuildFile(workspacePath)
@@ -106,7 +106,7 @@ class BuildValidatorSpec extends AnyWordSpec with Matchers {
             .defaultParsedConfig
             .copy(
               contractPath = "contracts",
-              artifactPath = "artifacts",
+              artifactPath = Some("artifacts"),
               dependencyPath = Some("contracts")
             )
 
@@ -119,7 +119,7 @@ class BuildValidatorSpec extends AnyWordSpec with Matchers {
             .defaultParsedConfig
             .copy(
               contractPath = "dependencies/contracts",
-              artifactPath = "artifacts",
+              artifactPath = Some("artifacts"),
               dependencyPath = Some("dependencies")
             )
 
@@ -132,7 +132,7 @@ class BuildValidatorSpec extends AnyWordSpec with Matchers {
             .defaultParsedConfig
             .copy(
               contractPath = "contracts",
-              artifactPath = "artifacts",
+              artifactPath = Some("artifacts"),
               dependencyPath = Some("contracts/dependencies")
             )
 
@@ -169,7 +169,7 @@ class BuildValidatorSpec extends AnyWordSpec with Matchers {
             .defaultParsedConfig
             .copy(
               contractPath = "contracts",
-              artifactPath = "artifacts",
+              artifactPath = Some("artifacts"),
               dependencyPath = Some("dependencies")
             )
 
@@ -182,7 +182,7 @@ class BuildValidatorSpec extends AnyWordSpec with Matchers {
             .defaultParsedConfig
             .copy(
               contractPath = "my_code/contracts",
-              artifactPath = "artifacts",
+              artifactPath = Some("artifacts"),
               dependencyPath = Some("my_code/dependencies")
             )
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestBuild.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestBuild.scala
@@ -135,7 +135,12 @@ object TestBuild {
 
     val workspacePath = Paths.get(parsed.workspaceURI)
     TestFile.createDirectories(workspacePath.resolve(parsed.config.contractPath))
-    TestFile.createDirectories(workspacePath.resolve(parsed.config.artifactPath))
+
+    parsed.config.artifactPath foreach {
+      artifactPath =>
+        TestFile.createDirectories(workspacePath.resolve(artifactPath))
+    }
+
     parsed
       .config
       .dependencyPath
@@ -152,7 +157,12 @@ object TestBuild {
 
     val workspacePath = Paths.get(compiled.workspaceURI)
     TestFile.createDirectories(workspacePath.resolve(compiled.config.contractPath))
-    TestFile.createDirectories(workspacePath.resolve(compiled.config.artifactPath))
+
+    compiled.config.artifactPath foreach {
+      artifactPath =>
+        TestFile.createDirectories(workspacePath.resolve(artifactPath))
+    }
+
     TestFile.createDirectories(workspacePath.resolve(compiled.dependencyPath))
 
     compiled

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestRalphc.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestRalphc.scala
@@ -44,7 +44,7 @@ object TestRalphc {
   def genRalphcParsedConfig(
       compilerOptions: Gen[CompilerOptions] = genCompilerOptions(),
       contractsFolderName: Gen[String] = genName,
-      artifactsFolderName: Gen[String] = genName,
+      artifactsFolderName: Gen[Option[String]] = Gen.option(genName),
       dependenciesFolderName: Gen[Option[String]] = Gen.option(genName)): Gen[RalphcParsedConfig] =
     for {
       compilerOptions        <- compilerOptions


### PR DESCRIPTION
- Resolves #247.
- `artifactsPath` is now made optional. If #84 does not require `artifactsPath`, it can be removed then.