### PR TITLE
Go-to jump testing on dependencies

### DIFF
--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/util/TestCodeUtil.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/util/TestCodeUtil.scala
@@ -22,7 +22,7 @@ import org.scalatest.Assertions.fail
 object TestCodeUtil {
 
   /** Use this in your test-case for */
-  private val SEARCH_INDICATOR =
+  val SEARCH_INDICATOR =
     "@@"
 
   def codeLines(code: String): Array[String] =

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/Workspace.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/Workspace.scala
@@ -23,6 +23,7 @@ import org.alephium.ralph.lsp.pc.sourcecode.{SourceCode, SourceCodeState}
 import org.alephium.ralph.lsp.pc.util.CollectionUtil._
 import org.alephium.ralph.lsp.pc.util.URIUtil
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader.DependencyDownloader
 import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState}
 
 import java.net.URI
@@ -67,7 +68,8 @@ private[pc] object Workspace extends StrictImplicitLogging {
           Build.parseAndCompile(
             buildURI = workspace.buildURI,
             code = None,
-            currentBuild = None
+            currentBuild = None,
+            dependencyDownloaders = DependencyDownloader.all()
           )
 
         initialise(newBuild)
@@ -99,7 +101,8 @@ private[pc] object Workspace extends StrictImplicitLogging {
               Build.parseAndCompile(
                 buildURI = code.fileURI,
                 code = code.text,
-                currentBuild = None
+                currentBuild = None,
+                dependencyDownloaders = DependencyDownloader.all()
               )
 
             initialise(build)
@@ -132,7 +135,8 @@ private[pc] object Workspace extends StrictImplicitLogging {
       Build.parseAndCompile(
         buildURI = currentBuild.buildURI,
         code = newBuildCode,
-        currentBuild = currentBuild
+        currentBuild = currentBuild,
+        dependencyDownloaders = DependencyDownloader.all()
       ) getOrElse currentBuild // if the build code is the same and existing build, then compile using existing build.
 
     newBuild match {
@@ -376,7 +380,8 @@ private[pc] object Workspace extends StrictImplicitLogging {
       Build.parseAndCompile(
         buildURI = buildURI,
         code = code,
-        currentBuild = workspace.build
+        currentBuild = workspace.build,
+        dependencyDownloaders = DependencyDownloader.all()
       ) match {
         case Some(newBuild) =>
           newBuild match {

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/Workspace.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/Workspace.scala
@@ -69,7 +69,7 @@ private[pc] object Workspace extends StrictImplicitLogging {
             buildURI = workspace.buildURI,
             code = None,
             currentBuild = None,
-            dependencyDownloaders = DependencyDownloader.all()
+            dependencyDownloaders = DependencyDownloader.natives()
           )
 
         initialise(newBuild)
@@ -102,7 +102,7 @@ private[pc] object Workspace extends StrictImplicitLogging {
                 buildURI = code.fileURI,
                 code = code.text,
                 currentBuild = None,
-                dependencyDownloaders = DependencyDownloader.all()
+                dependencyDownloaders = DependencyDownloader.natives()
               )
 
             initialise(build)
@@ -136,7 +136,7 @@ private[pc] object Workspace extends StrictImplicitLogging {
         buildURI = currentBuild.buildURI,
         code = newBuildCode,
         currentBuild = currentBuild,
-        dependencyDownloaders = DependencyDownloader.all()
+        dependencyDownloaders = DependencyDownloader.natives()
       ) getOrElse currentBuild // if the build code is the same and existing build, then compile using existing build.
 
     newBuild match {
@@ -381,7 +381,7 @@ private[pc] object Workspace extends StrictImplicitLogging {
         buildURI = buildURI,
         code = code,
         currentBuild = workspace.build,
-        dependencyDownloaders = DependencyDownloader.all()
+        dependencyDownloaders = DependencyDownloader.natives()
       ) match {
         case Some(newBuild) =>
           newBuild match {

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/Build.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/Build.scala
@@ -22,6 +22,7 @@ import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.workspace.build.config.{RalphcConfigState, RalphcConfig}
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader.DependencyDownloader
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.{DependencyDB, Dependency}
 
 import java.net.URI
@@ -102,7 +103,8 @@ object Build {
   /** Compile a parsed build */
   def compile(
       parsed: BuildState.IsParsed,
-      currentBuild: Option[BuildState.IsCompiled]
+      currentBuild: Option[BuildState.IsCompiled],
+      dependencyDownloaders: ArraySeq[DependencyDownloader]
     )(implicit file: FileAccess,
       compiler: CompilerAccess,
       logger: ClientLogger): BuildState.IsCompiled =
@@ -122,7 +124,8 @@ object Build {
         def compileDependencies() =
           Dependency.compile(
             parsed = parsed,
-            currentBuild = currentBuild
+            currentBuild = currentBuild,
+            downloaders = dependencyDownloaders
           )
 
         // parse successful. Perform compilation!
@@ -140,7 +143,8 @@ object Build {
   /** Parse and compile from disk */
   def parseAndCompile(
       buildURI: URI,
-      currentBuild: Option[BuildState.IsCompiled]
+      currentBuild: Option[BuildState.IsCompiled],
+      dependencyDownloaders: ArraySeq[DependencyDownloader]
     )(implicit file: FileAccess,
       compiler: CompilerAccess,
       logger: ClientLogger): BuildState.IsCompiled =
@@ -158,7 +162,8 @@ object Build {
         if (exists)
           compile(
             parsed = parse(buildURI),
-            currentBuild = currentBuild
+            currentBuild = currentBuild,
+            dependencyDownloaders = dependencyDownloaders
           )
         else
           createDefaultBuildFile(
@@ -172,7 +177,8 @@ object Build {
               // default build file created! Parse and compile it!
               parseAndCompile(
                 buildURI = buildURI,
-                currentBuild = currentBuild
+                currentBuild = currentBuild,
+                dependencyDownloaders = dependencyDownloaders
               )
           }
     }
@@ -181,7 +187,8 @@ object Build {
   def parseAndCompile(
       buildURI: URI,
       code: String,
-      currentBuild: Option[BuildState.IsCompiled]
+      currentBuild: Option[BuildState.IsCompiled],
+      dependencyDownloaders: ArraySeq[DependencyDownloader]
     )(implicit file: FileAccess,
       compiler: CompilerAccess,
       logger: ClientLogger): BuildState.IsCompiled = {
@@ -194,14 +201,16 @@ object Build {
 
     compile(
       parsed = parsed,
-      currentBuild = currentBuild
+      currentBuild = currentBuild,
+      dependencyDownloaders = dependencyDownloaders
     )
   }
 
   def parseAndCompile(
       buildURI: URI,
       code: Option[String],
-      currentBuild: Option[BuildState.IsCompiled]
+      currentBuild: Option[BuildState.IsCompiled],
+      dependencyDownloaders: ArraySeq[DependencyDownloader]
     )(implicit file: FileAccess,
       compiler: CompilerAccess,
       logger: ClientLogger): BuildState.IsCompiled =
@@ -210,14 +219,16 @@ object Build {
         parseAndCompile(
           buildURI = buildURI,
           code = code,
-          currentBuild = currentBuild
+          currentBuild = currentBuild,
+          dependencyDownloaders = dependencyDownloaders
         )
 
       case None =>
         // Code is not known. Parse and validate it from disk.
         parseAndCompile(
           buildURI = buildURI,
-          currentBuild = currentBuild
+          currentBuild = currentBuild,
+          dependencyDownloaders = dependencyDownloaders
         )
     }
 
@@ -227,7 +238,8 @@ object Build {
   def parseAndCompile(
       buildURI: URI,
       code: Option[String],
-      currentBuild: BuildState.Compiled
+      currentBuild: BuildState.Compiled,
+      dependencyDownloaders: ArraySeq[DependencyDownloader]
     )(implicit file: FileAccess,
       compiler: CompilerAccess,
       logger: ClientLogger): Option[BuildState.IsCompiled] =
@@ -251,7 +263,8 @@ object Build {
         Build.parseAndCompile(
           buildURI = buildURI,
           code = code,
-          currentBuild = Some(currentBuild)
+          currentBuild = Some(currentBuild),
+          dependencyDownloaders = dependencyDownloaders
         ) match {
           case newBuild: BuildState.Compiled =>
             // if the new build-file is the same as current build-file, return it as

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/Dependency.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/Dependency.scala
@@ -47,7 +47,8 @@ object Dependency {
    */
   def compile(
       parsed: BuildState.Parsed,
-      currentBuild: Option[BuildState.IsCompiled]
+      currentBuild: Option[BuildState.IsCompiled],
+      downloaders: ArraySeq[DependencyDownloader]
     )(implicit file: FileAccess,
       compiler: CompilerAccess,
       logger: ClientLogger): BuildState.IsCompiled = {
@@ -73,7 +74,7 @@ object Dependency {
             downloadAndCompileDependencies(
               parsed = parsed,
               absoluteDependencyPath = absoluteDependenciesPath,
-              dependencyDownloaders = DependencyDownloader.all()
+              dependencyDownloaders = downloaders
             )
         }
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/BuiltInFunctionDownloader.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/BuiltInFunctionDownloader.scala
@@ -27,7 +27,7 @@ import org.alephium.ralph.{SourceIndex, BuiltIn}
 import java.nio.file.Path
 import scala.collection.immutable.ArraySeq
 
-object BuiltInFunctionDownloader extends DependencyDownloader {
+object BuiltInFunctionDownloader extends DependencyDownloader.Native {
 
   override def dependencyID: DependencyID.BuiltIn.type =
     DependencyID.BuiltIn

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/BuiltInFunctionDownloader.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/BuiltInFunctionDownloader.scala
@@ -27,7 +27,10 @@ import org.alephium.ralph.{SourceIndex, BuiltIn}
 import java.nio.file.Path
 import scala.collection.immutable.ArraySeq
 
-private object BuiltInFunctionDownloader extends DependencyDownloader {
+object BuiltInFunctionDownloader extends DependencyDownloader {
+
+  override def dependencyID: DependencyID.BuiltIn.type =
+    DependencyID.BuiltIn
 
   /**
    * Downloads built-in function source files.
@@ -40,7 +43,7 @@ private object BuiltInFunctionDownloader extends DependencyDownloader {
       errorIndex: SourceIndex
     )(implicit logger: ClientLogger): Either[ArraySeq[CompilerMessage.AnyError], WorkspaceState.UnCompiled] = {
     val workspaceDir =
-      dependencyPath resolve DependencyID.BuiltIn.dirName
+      dependencyPath resolve dependencyID.dirName
 
     val sourceCode =
       toSourceCodeState(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/DependencyDownloader.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/DependencyDownloader.scala
@@ -88,7 +88,7 @@ object DependencyDownloader {
   trait Native extends DependencyDownloader
 
   /** All dependency downloaders */
-  def all(): ArraySeq[DependencyDownloader.Native] =
+  def natives(): ArraySeq[DependencyDownloader.Native] =
     ArraySeq(
       StdInterfaceDownloader,
       BuiltInFunctionDownloader

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/DependencyDownloader.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/DependencyDownloader.scala
@@ -82,8 +82,13 @@ trait DependencyDownloader extends StrictImplicitLogging { self =>
 
 object DependencyDownloader {
 
+  /**
+   * Indicates dependencies that are native to Ralph - `std` and builtin`.
+   */
+  trait Native extends DependencyDownloader
+
   /** All dependency downloaders */
-  def all(): ArraySeq[DependencyDownloader] =
+  def all(): ArraySeq[DependencyDownloader.Native] =
     ArraySeq(
       StdInterfaceDownloader,
       BuiltInFunctionDownloader

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/DependencyDownloader.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/DependencyDownloader.scala
@@ -20,6 +20,7 @@ import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.pc.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.pc.workspace.build.config.{RalphcConfigState, RalphcConfig}
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorEmptyErrorsOnDownload
 import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState}
 import org.alephium.ralph.{SourceIndex, CompilerOptions}
@@ -31,6 +32,8 @@ import scala.collection.immutable.ArraySeq
  * A dependency downloader, responsible for downloading code dependencies into an un-compiled workspace.
  */
 trait DependencyDownloader extends StrictImplicitLogging { self =>
+
+  def dependencyID: DependencyID
 
   /**
    * Downloads dependency code to an un-compiled workspace.

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/StdInterfaceDownloader.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/StdInterfaceDownloader.scala
@@ -31,7 +31,10 @@ import scala.io.Source
 import scala.jdk.CollectionConverters.{IteratorHasAsScala, MapHasAsJava}
 import scala.util.{Using, Success, Failure}
 
-private object StdInterfaceDownloader extends DependencyDownloader with StrictImplicitLogging {
+object StdInterfaceDownloader extends DependencyDownloader with StrictImplicitLogging {
+
+  override def dependencyID: DependencyID.Std.type =
+    DependencyID.Std
 
   /**
    * Download the Std package and return an un-compiled workspace for compilation.
@@ -48,7 +51,7 @@ private object StdInterfaceDownloader extends DependencyDownloader with StrictIm
     ) match {
       case Right(interfacesSource) =>
         val workspaceDir =
-          dependencyPath resolve DependencyID.Std.dirName
+          dependencyPath resolve dependencyID.dirName
 
         // a default build file.
         val build =
@@ -86,7 +89,7 @@ private object StdInterfaceDownloader extends DependencyDownloader with StrictIm
     )(implicit logger: ClientLogger): Either[ErrorDownloadingDependency, List[SourceCodeState.UnCompiled]] =
     Using.Manager {
       use =>
-        val stdURL = getClass.getResource(s"/${DependencyID.Std.dirName}")
+        val stdURL = getClass.getResource(s"/${dependencyID.dirName}")
 
         val stdPath = if (stdURL.getProtocol == "file") {
           Paths.get(stdURL.toURI)
@@ -101,7 +104,7 @@ private object StdInterfaceDownloader extends DependencyDownloader with StrictIm
         interfaceFiles.map {
           file =>
             val code     = use(Source.fromInputStream(Files.newInputStream(file), "UTF-8")).getLines().mkString("\n")
-            val filePath = dependencyPath.resolve(Paths.get(DependencyID.Std.dirName).resolve(file.getFileName.toString))
+            val filePath = dependencyPath.resolve(Paths.get(dependencyID.dirName).resolve(file.getFileName.toString))
             SourceCodeState.UnCompiled(
               fileURI = filePath.toUri,
               code = code
@@ -114,7 +117,7 @@ private object StdInterfaceDownloader extends DependencyDownloader with StrictIm
       case Failure(throwable) =>
         val error =
           ErrorDownloadingDependency(
-            dependencyID = DependencyID.Std.dirName,
+            dependencyID = dependencyID.dirName,
             throwable = throwable,
             index = errorIndex
           )

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/StdInterfaceDownloader.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/StdInterfaceDownloader.scala
@@ -31,7 +31,7 @@ import scala.io.Source
 import scala.jdk.CollectionConverters.{IteratorHasAsScala, MapHasAsJava}
 import scala.util.{Using, Success, Failure}
 
-object StdInterfaceDownloader extends DependencyDownloader with StrictImplicitLogging {
+object StdInterfaceDownloader extends DependencyDownloader.Native with StrictImplicitLogging {
 
   override def dependencyID: DependencyID.Std.type =
     DependencyID.Std

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
@@ -16,7 +16,7 @@
 
 package org.alephium.ralph.lsp.pc.search
 
-import org.alephium.ralph.lsp.TestFile
+import org.alephium.ralph.lsp.TestCommon
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.access.file.FileAccess
@@ -25,16 +25,16 @@ import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.search.completion.Suggestion
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceLocation, TestSourceCode, SourceCodeState}
-import org.alephium.ralph.lsp.pc.workspace.build.TestBuild
+import org.alephium.ralph.lsp.pc.workspace.build.{TestRalphc, BuildState, TestBuild}
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.{DependencyID, TestDependency}
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader.{StdInterfaceDownloader, DependencyDownloader, BuiltInFunctionDownloader}
 import org.alephium.ralph.lsp.pc.workspace.{WorkspaceState, TestWorkspace, Workspace}
-import org.scalacheck.Gen
 import org.scalatest.Assertion
 import org.scalatest.EitherValues._
 import org.scalatest.OptionValues._
 import org.scalatest.matchers.should.Matchers._
 
-import java.nio.file.Paths
+import java.net.URI
 import scala.collection.immutable.ArraySeq
 
 object TestCodeProvider {
@@ -92,8 +92,12 @@ object TestCodeProvider {
   }
 
   /**
+   * Tests directly on the `builtin` native library.
+   *
    * Runs go-to definition where `@@` is positioned, expecting
-   * the resulting go-to definition to be a built-in function.
+   * the resulting go-to definition to be a built-in function
+   * contained in the `builtin` library downloaded by native dependency
+   * downloader [[BuiltInFunctionDownloader]].
    *
    * @param code     The code with the search indicator '@@'.
    * @param expected Expected resulting built-in function.
@@ -111,12 +115,16 @@ object TestCodeProvider {
     )
 
   /**
-   * Runs go-to definition where `@@` is positioned, expecting
-   * the resulting go-to definition to be in a std file.
+   * Tests directly on the `std` native library.
    *
-   * @param code         The code with the search indicator '@@'.
-   * @param expected     An optional tuple where the first element is the expected line,
-   *                     and the second is the highlighted token in that line.
+   * Runs go-to definition where `@@` is positioned, expecting
+   * the resulting go-to definition to be in a std file
+   * contained in the `std` library downloaded by native dependency
+   * downloader [[StdInterfaceDownloader]].
+   *
+   * @param code     The code with the search indicator '@@'.
+   * @param expected An optional tuple where the first element is the expected line,
+   *                 and the second is the highlighted token in that line.
    */
   def goToStd(
       code: String,
@@ -128,18 +136,133 @@ object TestCodeProvider {
     )
 
   /**
+   * Runs go-to definition on a custom dependency and workspace source-code.
+   * Other go-to functions test directly on native `std` and `builtin` libraries,
+   * but this allows creating custom dependency code.
+   *
+   * @param dependencyId The dependency ID to assign to the custom dependency.
+   * @param dependency   The dependency code to write to the dependency.
+   * @param workspace    The developer's workspace code.
+   * @return
+   */
+  def goTo(
+      dependencyId: DependencyID,
+      dependency: String,
+      workspace: String): Unit = {
+    implicit val clientLogger: ClientLogger = TestClientLogger
+    implicit val file: FileAccess           = FileAccess.disk
+    implicit val compiler: CompilerAccess   = CompilerAccess.ralphc
+
+    // The indicator's gotta be in either the dependency or the workspace code.
+    val isIndicatorInDependency =
+      dependency contains TestCodeUtil.SEARCH_INDICATOR
+
+    val (indicatorPosition, _, codeWithoutIndicatorMarker) =
+      if (isIndicatorInDependency)
+        TestCodeUtil.indicatorPosition(dependency) // maybe the indicator in dependency code
+      else
+        TestCodeUtil.indicatorPosition(workspace) // otherwise, the indicator must be in dependency code
+
+    val (dependencyLineRange, dependencyCodeWithoutRangeMarkers, _, _) =
+      if (isIndicatorInDependency)
+        TestCodeUtil.lineRanges(codeWithoutIndicatorMarker) // indicator existed in dependency code, use codeWithoutIndicatorMarker
+      else
+        TestCodeUtil.lineRanges(dependency) // no indicator in dependency code, use dependency directly
+
+    val (workspaceCodeRange, workspaceCodeWithoutRangeMarkers, _, _) =
+      if (isIndicatorInDependency)
+        TestCodeUtil.lineRanges(workspace) // no indicator in workspace code, use workspace directly
+      else
+        TestCodeUtil.lineRanges(codeWithoutIndicatorMarker) // indicator existed in workspace code, use codeWithoutIndicatorMarker
+
+    // collect all line ranges, they could be in both dependency and workspace code
+    val expectedRanges =
+      dependencyLineRange ++ workspaceCodeRange
+
+    // build a custom dependency from dependency code
+    val downloader =
+      TestDependency.buildDependencyDownloader(
+        depId = dependencyId,
+        depCode = dependencyCodeWithoutRangeMarkers
+      )
+
+    // create a build file
+    val build =
+      TestCommon
+        .genName
+        .flatMap {
+          dependenciesFolderName =>
+            TestBuild
+              .genCompiledOK(
+                // since custom dependencies are being written; always set a dependency folder name,
+                // so dependency files get generated local to the workspace,
+                // otherwise they will get written to `~/.ralph-lsp/*`.
+                config = TestRalphc.genRalphcParsedConfig(dependenciesFolderName = Some(dependenciesFolderName)),
+                dependencyDownloaders = ArraySeq(downloader)
+              )
+        }
+        .sample
+        .get
+
+    // the one dependency is written with custom code.
+    build.dependencies should have size 1
+    build.dependencies.head.sourceCode should have size 1
+    val dependencySourceFile = build.dependencies.head.sourceCode.head
+    dependencySourceFile.code shouldBe dependencyCodeWithoutRangeMarkers
+
+    // generate an on-disk workspace source-file.
+    val sourceCode =
+      TestSourceCode
+        .genOnDiskAndPersist(
+          build = build,
+          code = workspaceCodeWithoutRangeMarkers
+        )
+        .sample
+        .get
+
+    // use the selected fileURI to be the one with @@ indicator.
+    val selectedFileURI =
+      if (isIndicatorInDependency)
+        dependencySourceFile.fileURI
+      else
+        sourceCode.fileURI
+
+    // run test
+    val (searchResult, testWorkspace) =
+      TestCodeProvider[SourceLocation.GoTo](
+        line = indicatorPosition.line,
+        character = indicatorPosition.character,
+        selectedFileURI = selectedFileURI,
+        build = build,
+        workspaceSourceCode = sourceCode
+      )
+
+    testWorkspace.sourceCode should have size 1
+    testWorkspace.build.dependencies should have size 1
+
+    val actualLineRanges = searchResult.value.flatMap(_.toLineRange()).toList
+    actualLineRanges should contain theSameElementsAs expectedRanges
+
+    TestWorkspace delete testWorkspace
+    ()
+  }
+
+  /**
    * Runs go-to definition where @@ is positioned, expecting
    * the resulting go-to definition to be within a dependency workspace.
    *
    * @param code       The code with the search indicator '@@'.
    * @param expected   An optional tuple where the first element is the expected line,
    *                   and the second is the highlighted token in that line.
-   * @param downloader The dependency to download, and to test on.
+   * @param downloader The native dependency to download, and to test on.
+   *                   These must be of type [[DependencyDownloader.Native]]
+   *                   as they can be written to `~/ralph-lsp`.
+   *                   We don't want generated libraries being written to `~/ralph-lsp`.
    */
   private def goToDependency(
       code: String,
       expected: Option[(String, String)],
-      downloader: DependencyDownloader): Assertion = {
+      downloader: DependencyDownloader.Native): Assertion = {
     val (_, codeWithoutGoToSymbols, _, _) =
       TestCodeUtil.lineRanges(code)
 
@@ -201,27 +324,50 @@ object TestCodeProvider {
   }
 
   /**
-   * Runs completion where `@@` is.
+   * Runs code-provider on the given code that contains the selection indicator '@@'.
    *
-   * For example: The following runs completion between the double quotes.
-   * {{{
-   *   TestCompleter(""" import "@@" """)
-   * }}}
+   * @param code                  The code with the search indicator '@@'.
+   * @param dependencyDownloaders The native dependency to download, and to test on.
+   *                              These must be of type [[DependencyDownloader.Native]]
+   *                              as they can be written to `~/ralph-lsp`.
+   *                              We don't want generated libraries being written to `~/ralph-lsp`.
    */
   private def apply[A](
       code: String,
-      dependencyDownloaders: ArraySeq[DependencyDownloader]
+      dependencyDownloaders: ArraySeq[DependencyDownloader.Native]
     )(implicit provider: CodeProvider[A]): (Iterator[A], SourceCodeState.IsCodeAware, WorkspaceState.IsParsedAndCompiled) = {
+    implicit val clientLogger: ClientLogger = TestClientLogger
+    implicit val file: FileAccess           = FileAccess.disk
+    implicit val compiler: CompilerAccess   = CompilerAccess.ralphc
+
     val (linePosition, _, codeWithoutAtSymbol) =
       TestCodeUtil.indicatorPosition(code)
+
+    // create a build file
+    val build =
+      TestBuild
+        .genCompiledOK(dependencyDownloaders = dependencyDownloaders)
+        .sample
+        .get
+
+    // generate source-code for the code
+    val sourceCode =
+      TestSourceCode
+        .genOnDiskAndPersist(
+          build = build,
+          code = codeWithoutAtSymbol
+        )
+        .sample
+        .get
 
     // run completion at that line and character
     val (searchResult, workspace) =
       TestCodeProvider(
         line = linePosition.line,
         character = linePosition.character,
-        code = codeWithoutAtSymbol,
-        dependencyDownloaders = dependencyDownloaders
+        selectedFileURI = sourceCode.fileURI,
+        build = build,
+        workspaceSourceCode = sourceCode
       )
 
     workspace.sourceCode should have size 1
@@ -236,62 +382,40 @@ object TestCodeProvider {
   /**
    * Runs test on the given [[CodeProvider]], at the given line and character number.
    *
-   * @param line      The target line number
-   * @param character The target character within the line
-   * @param code      The code to run completion on.
+   * @param line                The target line number
+   * @param character           The target character within the line
+   * @param selectedFileURI     The URI of the source-file where this search is to be executed.
+   * @param workspaceSourceCode The source to write to the test workspace.
    * @return Suggestions and the created workspace.
    */
   private def apply[A](
       line: Int,
       character: Int,
-      code: Gen[String],
-      dependencyDownloaders: ArraySeq[DependencyDownloader]
-    )(implicit provider: CodeProvider[A]): (Either[CompilerMessage.Error, Iterator[A]], WorkspaceState.IsParsedAndCompiled) = {
-    implicit val clientLogger: ClientLogger = TestClientLogger
-    implicit val file: FileAccess           = FileAccess.disk
-    implicit val compiler: CompilerAccess   = CompilerAccess.ralphc
-
-    // create a build file
-    val build =
-      TestBuild
-        .genCompiledOK(dependencyDownloaders = dependencyDownloaders)
-        .sample
-        .get
-
-    // Generate a source-file name within the contract URI
-    val sourceFile =
-      TestFile
-        .genFileURI(rootFolder = Paths.get(build.contractURI))
-        .sample
-        .get
-
-    // write the source code
-    val (sourceCode, _) =
-      TestSourceCode
-        .genOnDiskAndPersist(
-          fileURI = sourceFile,
-          code = code.sample.get
-        )
-        .sample
-        .get
+      selectedFileURI: URI,
+      build: BuildState.Compiled,
+      workspaceSourceCode: SourceCodeState.OnDisk
+    )(implicit provider: CodeProvider[A],
+      client: ClientLogger,
+      file: FileAccess,
+      compiler: CompilerAccess): (Either[CompilerMessage.Error, Iterator[A]], WorkspaceState.IsParsedAndCompiled) = {
 
     // create a workspace for the build file
     val workspace =
       WorkspaceState.UnCompiled(
         build = build,
-        sourceCode = ArraySeq(sourceCode)
+        sourceCode = ArraySeq(workspaceSourceCode)
       )
 
     // parse and compile workspace
     val compiledWorkspace =
       Workspace.parseAndCompile(workspace)
 
-    // execute completion.
+    // execute code-provider.
     val completionResult =
       CodeProvider.search(
         line = line,
         character = character,
-        fileURI = sourceCode.fileURI,
+        fileURI = selectedFileURI,
         workspace = compiledWorkspace
       )
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
@@ -40,32 +40,15 @@ import scala.collection.immutable.ArraySeq
 object TestCodeProvider {
 
   /**
-   * Runs completion where `@@` is.
+   * Runs code completion where `@@` is positioned.
    *
-   * For example: The following runs completion between the double quotes.
-   * {{{
-   *   TestCompleter(""" import "@@" """)
-   * }}}
+   * @param code The code to run code completion on.
+   * @return A list of code completion suggestions.
    */
-  private def apply[A](code: String)(implicit provider: CodeProvider[A]): (Iterator[A], SourceCodeState.IsCodeAware, WorkspaceState.IsParsedAndCompiled) = {
-    val (linePosition, _, codeWithoutAtSymbol) = TestCodeUtil.indicatorPosition(code)
-
-    // run completion at that line and character
-    val (searchResult, workspace) =
-      TestCodeProvider(
-        line = linePosition.line,
-        character = linePosition.character,
-        code = codeWithoutAtSymbol
-      )
-
-    workspace.sourceCode should have size 1
-
-    // delete the workspace
-    TestWorkspace delete workspace
-
-    (searchResult.value, workspace.sourceCode.head.asInstanceOf[SourceCodeState.IsCodeAware], workspace)
-
-  }
+  def suggest(code: String): List[Suggestion] =
+    TestCodeProvider[Suggestion](code)
+      ._1
+      .toList
 
   /**
    * Runs GoTo definition where `@@` is located
@@ -211,15 +194,32 @@ object TestCodeProvider {
   }
 
   /**
-   * Runs code completion where `@@` is positioned.
+   * Runs completion where `@@` is.
    *
-   * @param code The code to run code completion on.
-   * @return A list of code completion suggestions.
+   * For example: The following runs completion between the double quotes.
+   * {{{
+   *   TestCompleter(""" import "@@" """)
+   * }}}
    */
-  def suggest(code: String): List[Suggestion] =
-    TestCodeProvider[Suggestion](code)
-      ._1
-      .toList
+  private def apply[A](code: String)(implicit provider: CodeProvider[A]): (Iterator[A], SourceCodeState.IsCodeAware, WorkspaceState.IsParsedAndCompiled) = {
+    val (linePosition, _, codeWithoutAtSymbol) = TestCodeUtil.indicatorPosition(code)
+
+    // run completion at that line and character
+    val (searchResult, workspace) =
+      TestCodeProvider(
+        line = linePosition.line,
+        character = linePosition.character,
+        code = codeWithoutAtSymbol
+      )
+
+    workspace.sourceCode should have size 1
+
+    // delete the workspace
+    TestWorkspace delete workspace
+
+    (searchResult.value, workspace.sourceCode.head.asInstanceOf[SourceCodeState.IsCodeAware], workspace)
+
+  }
 
   /**
    * Run test completion.

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
@@ -48,7 +48,7 @@ object TestCodeProvider {
   def suggest(code: String): List[Suggestion] =
     TestCodeProvider[Suggestion](
       code = code,
-      dependencyDownloaders = DependencyDownloader.all()
+      dependencyDownloaders = DependencyDownloader.natives()
     )._1.toList
 
   /**

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToBuiltInFunctionsSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToBuiltInFunctionsSpec.scala
@@ -17,6 +17,7 @@
 package org.alephium.ralph.lsp.pc.search.gotodef
 
 import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -38,17 +39,46 @@ class GoToBuiltInFunctionsSpec extends AnyWordSpec with Matchers {
   }
 
   "return non-empty" when {
-    "assert!" in {
-      goToBuiltIn(
-        code = """
-            |Contract Test() {
-            |  pub fn function() -> () {
-            |    @@assert!()
-            |  }
-            |}
-            |""".stripMargin,
-        expected = Some("""fn assert!(condition:Bool, errorCode:U256) -> ()""")
-      )
+    "assert!" when {
+      "native builtin library" in {
+        // Expect go-to definition to work directly on the native builtin library
+        goToBuiltIn(
+          code = """
+              |Contract Test() {
+              |  pub fn function() -> () {
+              |    @@assert!()
+              |  }
+              |}
+              |""".stripMargin,
+          expected = Some("""fn assert!(condition:Bool, errorCode:U256) -> ()""")
+        )
+      }
+
+      "custom builtin library" in {
+        // Expect go-to definition to work on the following custom builtin code
+        goTo(
+          dependencyId = DependencyID.BuiltIn,
+          // the custom builtin library
+          dependency = """
+              |Interface TestBuiltIn {
+              |  fn hello!() -> ()
+              |
+              |  >>fn assert!() -> ()<<
+              |
+              |  fn blah!() -> ()
+              |}
+              |""".stripMargin,
+          // the developer's workspace code
+          workspace = """
+              |Contract Test() {
+              |  pub fn function() -> () {
+              |    @@assert!()
+              |  }
+              |}
+              |""".stripMargin
+        )
+      }
+
     }
 
     "verifyAbsoluteLocktime!" in {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
@@ -53,6 +53,27 @@ object TestSourceCode {
       (persistedOnDisk, code)
     }
 
+  /** Generates an on-disk source file within the `contractURI` of the given build */
+  def genOnDiskAndPersist(
+      build: BuildState.Compiled,
+      code: Gen[String]): Gen[SourceCodeState.OnDisk] =
+    // Generate a source-file name within the contract URI
+    for {
+      // Generate a source-file name within the contract URI
+      sourceFile <-
+        TestFile.genFileURI(
+          rootFolder = Paths.get(build.contractURI)
+        )
+
+      // write the source code
+      (sourceCode, _) <-
+        TestSourceCode
+          .genOnDiskAndPersist(
+            fileURI = sourceFile,
+            code = code.sample.get
+          )
+    } yield sourceCode
+
   /**
    */
   def genOnDiskForRoot(rootURI: Gen[URI] = genFolderURI()): Gen[SourceCodeState.OnDisk] =

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
@@ -67,11 +67,10 @@ object TestSourceCode {
 
       // write the source code
       (sourceCode, _) <-
-        TestSourceCode
-          .genOnDiskAndPersist(
-            fileURI = sourceFile,
-            code = code.sample.get
-          )
+        genOnDiskAndPersist(
+          fileURI = sourceFile,
+          code = code.sample.get
+        )
     } yield sourceCode
 
   /**
@@ -81,7 +80,7 @@ object TestSourceCode {
       rootURI <- rootURI
       workspacePath = Gen.const(Paths.get(rootURI))
       fileURI       = genFileURI(rootFolder = workspacePath)
-      sourceCode <- TestSourceCode.genOnDisk(fileURI)
+      sourceCode <- genOnDisk(fileURI)
     } yield {
       // assert that SourceCode URI is a child of rootURI
       URIUtil.contains(rootURI, sourceCode.fileURI) shouldBe true
@@ -94,7 +93,7 @@ object TestSourceCode {
       build <- build
       workspacePath = Paths.get(build.workspaceURI).resolve(build.config.contractPath)
       fileURI       = genFileURI(rootFolder = workspacePath)
-      sourceCode <- TestSourceCode.genOnDisk(fileURI)
+      sourceCode <- genOnDisk(fileURI)
     } yield sourceCode
 
   /**

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuild1Spec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuild1Spec.scala
@@ -23,6 +23,7 @@ import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.sourcecode.TestSourceCode
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader.DependencyDownloader
 import org.alephium.ralph.lsp.pc.workspace.build.error.{ErrorBuildFileNotFound, ErrorInvalidBuildSyntax}
 import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState, TestBuild}
 import org.scalacheck.Gen
@@ -196,7 +197,8 @@ class WorkspaceBuild1Spec extends AnyWordSpec with Matchers with ScalaCheckDrive
                 Build
                   .compile(
                     parsed = build,
-                    currentBuild = None
+                    currentBuild = None,
+                    dependencyDownloaders = DependencyDownloader.all()
                   )
                   .asInstanceOf[BuildState.Compiled]
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuild1Spec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuild1Spec.scala
@@ -198,7 +198,7 @@ class WorkspaceBuild1Spec extends AnyWordSpec with Matchers with ScalaCheckDrive
                   .compile(
                     parsed = build,
                     currentBuild = None,
-                    dependencyDownloaders = DependencyDownloader.all()
+                    dependencyDownloaders = DependencyDownloader.natives()
                   )
                   .asInstanceOf[BuildState.Compiled]
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuild2Spec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuild2Spec.scala
@@ -21,6 +21,7 @@ import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.alephium.ralph.lsp.pc.log.ClientLogger
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader.DependencyDownloader
 import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState, TestBuild}
 import org.scalatest.EitherValues._
 import org.scalatest.matchers.should.Matchers
@@ -57,7 +58,8 @@ class WorkspaceBuild2Spec extends AnyWordSpec with Matchers with ScalaCheckDrive
           Build
             .compile(
               parsed = build,
-              currentBuild = None
+              currentBuild = None,
+              dependencyDownloaders = DependencyDownloader.all()
             )
             .asInstanceOf[BuildState.Compiled]
 
@@ -149,7 +151,8 @@ class WorkspaceBuild2Spec extends AnyWordSpec with Matchers with ScalaCheckDrive
           Build
             .compile(
               parsed = build,
-              currentBuild = None
+              currentBuild = None,
+              dependencyDownloaders = DependencyDownloader.all()
             )
             .asInstanceOf[BuildState.Compiled]
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuild2Spec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuild2Spec.scala
@@ -59,7 +59,7 @@ class WorkspaceBuild2Spec extends AnyWordSpec with Matchers with ScalaCheckDrive
             .compile(
               parsed = build,
               currentBuild = None,
-              dependencyDownloaders = DependencyDownloader.all()
+              dependencyDownloaders = DependencyDownloader.natives()
             )
             .asInstanceOf[BuildState.Compiled]
 
@@ -152,7 +152,7 @@ class WorkspaceBuild2Spec extends AnyWordSpec with Matchers with ScalaCheckDrive
             .compile(
               parsed = build,
               currentBuild = None,
-              dependencyDownloaders = DependencyDownloader.all()
+              dependencyDownloaders = DependencyDownloader.natives()
             )
             .asInstanceOf[BuildState.Compiled]
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceInitialiseSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceInitialiseSpec.scala
@@ -53,7 +53,8 @@ class WorkspaceInitialiseSpec extends AnyWordSpec with Matchers with ScalaCheckD
               val errored =
                 Build.compile(
                   parsed = parsed,
-                  currentBuild = None
+                  currentBuild = None,
+                  dependencyDownloaders = ArraySeq.empty
                 )(FileAccess.disk, compiler, clientLogger)
 
               // errored because contractsURI is not a persisted folder

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/BuildSpec.scala
@@ -50,7 +50,7 @@ class BuildSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyC
           TestBuild
             .genParsed()
             .map(persist)
-            .map(Build.compile(_, None)(FileAccess.disk, CompilerAccess.ralphc, clientLogger))
+            .map(Build.compile(_, None, ArraySeq.empty)(FileAccess.disk, CompilerAccess.ralphc, clientLogger))
             .map(_.asInstanceOf[BuildState.Compiled])
 
         forAll(outSideBuildGen, insideBuildGen) {
@@ -72,7 +72,8 @@ class BuildSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyC
                 .parseAndCompile(
                   buildURI = outsideBuild.buildURI,
                   code = buildCode,
-                  currentBuild = insideBuild
+                  currentBuild = insideBuild,
+                  dependencyDownloaders = ArraySeq.empty
                 )
                 .value
 
@@ -103,7 +104,7 @@ class BuildSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyC
           TestBuild
             .genParsed()
             .map(persist)
-            .map(Build.compile(_, None)(FileAccess.disk, CompilerAccess.ralphc, clientLogger))
+            .map(Build.compile(_, None, ArraySeq.empty)(FileAccess.disk, CompilerAccess.ralphc, clientLogger))
             .map(_.asInstanceOf[BuildState.Compiled])
 
         val generator =
@@ -144,7 +145,8 @@ class BuildSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyC
                 .parseAndCompile(
                   buildURI = build.buildURI,
                   code = buildCode,
-                  currentBuild = currentBuild
+                  currentBuild = currentBuild,
+                  dependencyDownloaders = ArraySeq.empty
                 )
                 .value
 
@@ -190,7 +192,8 @@ class BuildSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyC
           val actual =
             Build.parseAndCompile(
               buildURI = buildURI,
-              currentBuild = None
+              currentBuild = None,
+              dependencyDownloaders = ArraySeq.empty
             )
 
           val expected =

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestBuild.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestBuild.scala
@@ -24,12 +24,14 @@ import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.sourcecode.{TestSourceCode, SourceCodeState}
 import org.alephium.ralph.lsp.pc.workspace.build.TestRalphc.genRalphcParsedConfig
 import org.alephium.ralph.lsp.pc.workspace.build.config.{RalphcConfigState, RalphcConfig}
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader.DependencyDownloader
 import org.alephium.ralph.lsp.{TestCode, TestFile}
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers._
 
 import java.net.URI
 import java.nio.file.Paths
+import scala.collection.immutable.ArraySeq
 
 /** Build specific generators */
 object TestBuild {
@@ -58,18 +60,21 @@ object TestBuild {
   /** Generate a successfully compiled BuildState */
   def genCompiledOK(
       workspaceURI: Gen[URI] = genFolderURI(),
-      config: Gen[RalphcConfigState.Parsed] = genRalphcParsedConfig()
+      config: Gen[RalphcConfigState.Parsed] = genRalphcParsedConfig(),
+      dependencyDownloaders: ArraySeq[DependencyDownloader] = DependencyDownloader.all()
     )(implicit file: FileAccess,
       compiler: CompilerAccess,
       logger: ClientLogger): Gen[BuildState.Compiled] =
     genCompiled(
       workspaceURI = workspaceURI,
-      config = config
+      config = config,
+      dependencyDownloaders = dependencyDownloaders
     ).map(_.asInstanceOf[BuildState.Compiled])
 
   def genCompiled(
       workspaceURI: Gen[URI] = genFolderURI(),
-      config: Gen[RalphcConfigState.Parsed] = genRalphcParsedConfig()
+      config: Gen[RalphcConfigState.Parsed] = genRalphcParsedConfig(),
+      dependencyDownloaders: ArraySeq[DependencyDownloader] = DependencyDownloader.all()
     )(implicit file: FileAccess,
       compiler: CompilerAccess,
       logger: ClientLogger): Gen[BuildState.IsCompiled] =
@@ -80,7 +85,8 @@ object TestBuild {
       parsed =>
         Build.compile(
           parsed = persist(parsed),
-          currentBuild = None
+          currentBuild = None,
+          dependencyDownloaders = dependencyDownloaders
         )
     }
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestBuild.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestBuild.scala
@@ -61,7 +61,7 @@ object TestBuild {
   def genCompiledOK(
       workspaceURI: Gen[URI] = genFolderURI(),
       config: Gen[RalphcConfigState.Parsed] = genRalphcParsedConfig(),
-      dependencyDownloaders: ArraySeq[DependencyDownloader] = DependencyDownloader.all()
+      dependencyDownloaders: ArraySeq[DependencyDownloader] = DependencyDownloader.natives()
     )(implicit file: FileAccess,
       compiler: CompilerAccess,
       logger: ClientLogger): Gen[BuildState.Compiled] =
@@ -74,7 +74,7 @@ object TestBuild {
   def genCompiled(
       workspaceURI: Gen[URI] = genFolderURI(),
       config: Gen[RalphcConfigState.Parsed] = genRalphcParsedConfig(),
-      dependencyDownloaders: ArraySeq[DependencyDownloader] = DependencyDownloader.all()
+      dependencyDownloaders: ArraySeq[DependencyDownloader] = DependencyDownloader.natives()
     )(implicit file: FileAccess,
       compiler: CompilerAccess,
       logger: ClientLogger): Gen[BuildState.IsCompiled] =

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/config/RalphcConfigSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/config/RalphcConfigSpec.scala
@@ -205,7 +205,7 @@ class RalphcConfigSpec extends AnyWordSpec with Matchers {
         Build.parseAndCompile(
           buildURI = expectedBuildPath.toUri,
           currentBuild = None,
-          dependencyDownloaders = DependencyDownloader.all()
+          dependencyDownloaders = DependencyDownloader.natives()
         )
 
       // The code of the parsed config (user inputted) is expected, not the compiled config's code.
@@ -236,7 +236,7 @@ class RalphcConfigSpec extends AnyWordSpec with Matchers {
           .compile(
             parsed = parsedBuild,
             currentBuild = None,
-            downloaders = DependencyDownloader.all()
+            downloaders = DependencyDownloader.natives()
           )
           .asInstanceOf[BuildState.Compiled]
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/config/RalphcConfigSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/config/RalphcConfigSpec.scala
@@ -22,6 +22,7 @@ import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState}
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.Dependency
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader.DependencyDownloader
 import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorEmptyBuildFile
 import org.alephium.ralph.lsp.pc.workspace.{WorkspaceState, TestWorkspace}
 import org.alephium.ralphc.Config
@@ -160,7 +161,7 @@ class RalphcConfigSpec extends AnyWordSpec with Matchers {
     implicit val compiler: CompilerAccess =
       CompilerAccess.ralphc
 
-    // create workspace structure with config file
+    // create workspace structure with a config file
     def doTest(
         dependencyPath: Option[String],
         artifactPath: Option[String]) = {
@@ -203,7 +204,8 @@ class RalphcConfigSpec extends AnyWordSpec with Matchers {
       val readConfig =
         Build.parseAndCompile(
           buildURI = expectedBuildPath.toUri,
-          currentBuild = None
+          currentBuild = None,
+          dependencyDownloaders = DependencyDownloader.all()
         )
 
       // The code of the parsed config (user inputted) is expected, not the compiled config's code.
@@ -233,7 +235,8 @@ class RalphcConfigSpec extends AnyWordSpec with Matchers {
         Dependency
           .compile(
             parsed = parsedBuild,
-            currentBuild = None
+            currentBuild = None,
+            downloaders = DependencyDownloader.all()
           )
           .asInstanceOf[BuildState.Compiled]
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/TestDependency.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/TestDependency.scala
@@ -16,17 +16,21 @@
 
 package org.alephium.ralph.lsp.pc.workspace.build.dependency
 
+import org.alephium.ralph.SourceIndex
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
+import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.alephium.ralph.lsp.pc.log.ClientLogger
 import org.alephium.ralph.lsp.pc.util.URIUtil
+import org.alephium.ralph.lsp.pc.workspace.{WorkspaceState, TestWorkspace}
 import org.alephium.ralph.lsp.pc.workspace.build.config.{RalphcConfigState, RalphcConfig}
-import org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader.StdInterfaceDownloader
-import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState}
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader.{StdInterfaceDownloader, DependencyDownloader}
+import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState, TestBuild}
 import org.scalatest.matchers.should.Matchers._
+import org.scalatest.OptionValues._
 
-import java.nio.file.Paths
+import java.nio.file.{Path, Paths}
 import scala.collection.immutable.ArraySeq
 
 object TestDependency {
@@ -68,5 +72,51 @@ object TestDependency {
     // return the build (the build contains the std workspace)
     dependencyBuild
   }
+
+  /**
+   * Builds a custom dependency downloader for the given code.
+   *
+   * @param depId   The ID to assign to the dependency.
+   * @param depCode The code to include within the dependency.
+   * @return A downloader that generates an uncompiled dependency workspace.
+   */
+  def buildDependencyDownloader(
+      depId: DependencyID,
+      depCode: String
+    )(implicit file: FileAccess,
+      compiler: CompilerAccess): DependencyDownloader =
+    new DependencyDownloader {
+      override def dependencyID: DependencyID =
+        depId
+
+      protected override def _download(
+          dependencyPath: Path,
+          errorIndex: SourceIndex
+        )(implicit logger: ClientLogger): Either[ArraySeq[CompilerMessage.AnyError], WorkspaceState.UnCompiled] = {
+        // Generate a build file for this dependency
+        val build =
+          TestBuild
+            .genCompiledOK(
+              // the dependency's folder name should be the ID's name
+              workspaceURI = dependencyPath.resolve(depId.dirName).toUri,
+              // the dependency itself does not have other dependencies
+              dependencyDownloaders = ArraySeq.empty
+            )
+            .sample
+            .value
+
+        // Generate a workspace from the build file.
+        val dependencyWorkspace =
+          TestWorkspace
+            .genUnCompiled(
+              build = build,
+              code = Seq(depCode)
+            )
+            .sample
+            .value
+
+        Right(dependencyWorkspace)
+      }
+    }
 
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/TestDependency.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/TestDependency.scala
@@ -20,11 +20,14 @@ import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.alephium.ralph.lsp.pc.log.ClientLogger
-import org.alephium.ralph.lsp.pc.workspace.build.config.{RalphcConfig, RalphcConfigState}
+import org.alephium.ralph.lsp.pc.util.URIUtil
+import org.alephium.ralph.lsp.pc.workspace.build.config.{RalphcConfigState, RalphcConfig}
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader.StdInterfaceDownloader
 import org.alephium.ralph.lsp.pc.workspace.build.{Build, BuildState}
 import org.scalatest.matchers.should.Matchers._
 
 import java.nio.file.Paths
+import scala.collection.immutable.ArraySeq
 
 object TestDependency {
 
@@ -52,12 +55,15 @@ object TestDependency {
       Dependency
         .compile(
           parsed = parsed,
-          currentBuild = None
+          currentBuild = None,
+          downloaders = ArraySeq(StdInterfaceDownloader)
         )
         .asInstanceOf[BuildState.Compiled]
 
-    // dependency should exists in the build
-    dependencyBuild.dependencies should have size 2
+    // only the `std` dependency should exist in the build
+    dependencyBuild.dependencies should have size 1
+    dependencyBuild.findDependency(DependencyID.Std) shouldBe defined
+    URIUtil.getFileName(dependencyBuild.dependencies.head.workspaceURI) shouldBe DependencyID.Std.dirName
 
     // return the build (the build contains the std workspace)
     dependencyBuild


### PR DESCRIPTION
- Allows `DependencyDownloader` to be passed as a parameter, so test-cases can provide testable dependency code, to test go-to jumps between `dependency` code  and the dev's `workspace` code, and also among dependencies itself. Example test:
  ```scala
        goTo(
          dependencyId = DependencyID.BuiltIn,
          // the custom builtin library
          dependency = """
              |Interface TestBuiltIn {
              |  fn hello!() -> ()
              |
              |  >>fn assert!() -> ()<<
              |
              |  fn blah!() -> ()
              |}
              |""".stripMargin,
          // the developer's workspace code
          workspace = """
              |Contract Test() {
              |  pub fn function() -> () {
              |    @@assert!()
              |  }
              |}
              |""".stripMargin
        )
      }
  ```
- These tests are used in the following PR #276.
- Towards #274 & #105