### PR TITLE
Handle end-of-file `LineRange`

### DIFF
--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/util/StringUtilSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/util/StringUtilSpec.scala
@@ -66,12 +66,23 @@ class StringUtilSpec extends AnyWordSpec with Matchers {
 
     "fail to build time range with invalid arguments" in {
       val code = "line1\nline2\r\nline3\rline4"
-      buildLineRange(code, 0, code.length) shouldBe LineRange.zero
       buildLineRange(code, 1, 0) shouldBe LineRange.zero
       buildLineRange(code, -1, 1) shouldBe LineRange.zero
       buildLineRange(code, 1, -1) shouldBe LineRange.zero
       buildLineRange(code, code.length, code.length) shouldBe LineRange.zero
       buildLineRange(code, code.length + 1, code.length + 1) shouldBe LineRange.zero
+    }
+
+    "end-of-file" should {
+      "succeed" when {
+        "range spans the entire file" in {
+          testLineRange(">>line1\nline2\r\nline3\rline4<<")
+        }
+
+        "range spans only the last character" in {
+          testLineRange("line1\nline2\r\nline3\rline>>4<<")
+        }
+      }
     }
   }
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToConstantSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToConstantSpec.scala
@@ -182,6 +182,20 @@ class GoToConstantSpec extends AnyWordSpec with Matchers {
         }
       }
     }
+
+    "Issue #254: Global constant has no tail newline" in {
+      // https://github.com/alephium/ralph-lsp/issues/254
+      goTo {
+        """
+          |Contract Test() {
+          |  pub fn main() -> () {
+          |     let one = ONE@@
+          |  }
+          |}
+          |
+          |>>const ONE = 1<<""".stripMargin
+      }
+    }
   }
 
 }


### PR DESCRIPTION
- Resolves #254.
- The issue occurs because FastParse returns an `endIndex` that exceeds the index of the last character. For example, in the following test `code(endIndex)` results in `IndexOutOfBoundsException` because `endIndex == code.length`.  

  In the following case, both `endIndex` and `code.length` are equal to `4`. But this condition indicates that `endIndex` spans to the end of the file, which should be handled.

  ```scala
  import fastparse.ScalaWhitespace.whitespace
  import fastparse._
  
  def parser[_: P] =
    P(Index ~~ CharIn("A", "B", "C", "D", "\n").rep(1) ~~ Index)
  
  val code =
    "ABCD" // no newline
  
  val Parsed.Success((startIndex, endIndex), _) =
    fastparse.parse(code, parser(_))
  
  println("startIndex: " + startIndex) // = 0
  println("endIndex: " + endIndex)     // = 4
  println("length: " + code.length)    // = 4
  
  val endIndexChar = code(endIndex) // throws IndexOutOfBoundsException
  ```

