### PR TITLE
Prioritise default configurations from `alephium.config.ts`

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/config/CompilerOptionsParsed.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/config/CompilerOptionsParsed.scala
@@ -17,6 +17,7 @@
 package org.alephium.ralph.lsp.pc.workspace.build.config
 
 import org.alephium.ralph.CompilerOptions
+import org.alephium.ralph.lsp.pc.workspace.build.typescript.TSConfig
 
 object CompilerOptionsParsed {
 
@@ -35,6 +36,23 @@ object CompilerOptionsParsed {
       ignoreUpdateFieldsCheckWarnings = Some(options.ignoreUpdateFieldsCheckWarnings),
       ignoreCheckExternalCallerWarnings = Some(options.ignoreCheckExternalCallerWarnings),
       ignoreUnusedFunctionReturnWarnings = Some(options.ignoreUnusedFunctionReturnWarnings)
+    )
+
+  /**
+   * Converts TypeScript compiler options defined in `alephium.config.ts` to `ralph.json`'s [[CompilerOptionsParsed]].
+   *
+   * @param options The [[TSConfig.CompilerOptions]] instance to be converted.
+   * @return A [[CompilerOptionsParsed]] instance containing the corresponding values.
+   */
+  def from(options: TSConfig.CompilerOptions): CompilerOptionsParsed =
+    CompilerOptionsParsed(
+      ignoreUnusedConstantsWarnings = options.ignoreUnusedConstantsWarnings,
+      ignoreUnusedVariablesWarnings = options.ignoreUnusedVariablesWarnings,
+      ignoreUnusedFieldsWarnings = options.ignoreUnusedFieldsWarnings,
+      ignoreUnusedPrivateFunctionsWarnings = options.ignoreUnusedPrivateFunctionsWarnings,
+      ignoreUpdateFieldsCheckWarnings = options.ignoreUpdateFieldsCheckWarnings,
+      ignoreCheckExternalCallerWarnings = options.ignoreCheckExternalCallerWarnings,
+      ignoreUnusedFunctionReturnWarnings = options.ignoreUnusedFunctionReturnWarnings
     )
 
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuildChangedSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceBuildChangedSpec.scala
@@ -93,7 +93,8 @@ class WorkspaceBuildChangedSpec extends AnyWordSpec with Matchers {
       val ralph_json_parsed = RalphcConfig.parse(goodWorkspace.buildURI, ralph_json).value
       // values from `alephium.config.ts` are copied into `ralph.json`
       ralph_json_parsed.contractPath shouldBe ""
-      ralph_json_parsed.artifactPath.value shouldBe ""
+      // Currently, artifactPath is not used until #84 is implemented, so its is always defaulted to None
+      ralph_json_parsed.artifactPath shouldBe empty
 
       TestWorkspace delete goodWorkspace
     }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/typescript/TSBuildBuildSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/typescript/TSBuildBuildSpec.scala
@@ -78,7 +78,16 @@ class TSBuildBuildSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPr
 
   "not update `ralph.json`" when {
     "both build files have identical settings" in {
-      forAll(TestBuild.genCompiledOK(config = TestRalphc.genRalphcParsedConfig(dependenciesFolderName = Some("some_deps")))) {
+      val generator =
+        TestBuild.genCompiledOK(
+          config = TestRalphc.genRalphcParsedConfig(
+            dependenciesFolderName = Some("some_deps"),
+            // Currently, artifactPath is not used until #84 is implemented, so its is always defaulted to None
+            artifactsFolderName = None
+          )
+        )
+
+      forAll(generator) {
         jsonBuild =>
           // the JSON on disk before the build
           val preBuildJSON = TestFile readAll jsonBuild.buildURI
@@ -195,7 +204,8 @@ class TSBuildBuildSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPr
                 )
               ),
               contractPath = tsBuild.sourceDir.value,
-              artifactPath = Some(tsBuild.artifactDir.value),
+              // Currently, artifactPath is not used until #84 is implemented, so its is always defaulted to None
+              artifactPath = None,
               // dependency path is not configured in `alephium.config.ts`, so it should remain the same as the existing `ralph.json` configured value
               // tests that it does not get overwritten.
               dependencyPath = Some(jsonBuild.parsed.config.dependencyPath.value)


### PR DESCRIPTION
Towards resolving `Default Settings` in #291.

This PR ensures that when a build [configuration](https://docs.alephium.org/sdk/cli/#configuration) is missing from `alephium.config.ts`, its default value mentioned in the documentation is used:

- `sourceDir` will be defaulted to `contracts`.
- `artifactDir` is always set to `None` because currently we do not make any use of it. Issue #84 will decide its fate.
- All `compilerOptions` are defaulted to `false`. Although the documentation does not mention this, I'm assuming this is what's expected. 

 The function that merged `compilerOptions` from `ralph.json` and `alephium.config.ts` is removed. If the file `alephium.config.ts` is available, the defaults `compilerOptions` (all `false`) from `alephium.config.ts`, defined or not, are used and the ones in `ralph.json` are overwritten. 

This ensures that `alephium.config.ts` and its defaults are always prioritised over any configuration defined in `ralph.json`.

A new project containing a `*.ral` file will still start compilation. But when an empty `alephium.config.ts` is created, that `*.ral` file will have to be moved to the `contracts` directory (`alephium.config.ts`'s default) for compilation. 