### PR TITLE
Standardise `Warning`  management

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,7 @@ lazy val `compiler-access` =
           Dependencies.ralphc,
           Dependencies.scalaTest,
           Dependencies.scalaCheck,
+          Dependencies.scalaMock,
           Dependencies.logback,
           Dependencies.scalaLogging
         )

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/CompiledCodeWrapper.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/CompiledCodeWrapper.scala
@@ -1,0 +1,61 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler
+
+import org.alephium.ralph.{CompiledScript, Warning, CompiledContract, Ast}
+import org.alephium.util.AVector
+
+object CompiledCodeWrapper {
+
+  def apply(contract: CompiledContract): CompiledCodeWrapper =
+    CompiledCodeWrapper(Left(contract))
+
+  def apply(contract: CompiledScript): CompiledCodeWrapper =
+    CompiledCodeWrapper(Right(contract))
+
+}
+
+/**
+ * A wrapper class for compilation result types returned by ralphc.
+ *
+ * This is needed because the types [[CompiledContract]] and [[CompiledScript]] do not have a subtype.
+ *
+ * TODO: Remove this class when a subtype is available.
+ *
+ * @param either Either a contract or a script.
+ */
+case class CompiledCodeWrapper(either: Either[CompiledContract, CompiledScript]) extends AnyVal {
+
+  def warnings: AVector[Warning] =
+    either match {
+      case Left(contract) =>
+        contract.warnings
+
+      case Right(script) =>
+        script.warnings
+    }
+
+  def ast: Ast.ContractWithState =
+    either match {
+      case Left(contract) =>
+        contract.ast
+
+      case Right(script) =>
+        script.ast
+    }
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/CompilerAccess.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/CompilerAccess.scala
@@ -18,7 +18,8 @@ package org.alephium.ralph.lsp.access.compiler
 
 import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
-import org.alephium.ralph.{CompilerOptions, Warning, CompiledScript, Ast, CompiledContract}
+import org.alephium.ralph.lsp.utils.log.ClientLogger
+import org.alephium.ralph._
 
 import java.net.URI
 
@@ -58,6 +59,7 @@ trait CompilerAccess {
   def compileContracts(
       parsedSource: Seq[Ast.GlobalDefinition],
       options: CompilerOptions,
-      workspaceErrorURI: URI): Either[CompilerMessage.AnyError, (Array[CompiledContract], Array[CompiledScript], Array[Warning])]
+      workspaceErrorURI: URI
+    )(implicit logger: ClientLogger): Either[CompilerMessage.AnyError, (Array[CompiledContract], Array[CompiledScript], Array[Warning])]
 
 }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/CompilerLogMessage.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/CompilerLogMessage.scala
@@ -1,0 +1,70 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler
+
+import org.alephium.ralph.Warning
+import org.alephium.ralph.lsp.utils.log.LogMessage
+
+/**
+ * Log messages used by [[RalphCompilerAccess]].
+ */
+sealed trait CompilerLogMessage extends LogMessage {
+
+  def message: String
+
+}
+
+object CompilerLogMessage {
+
+  case class UnassignedWarningNoneFileURI(
+      warning: Warning,
+      contractName: String)
+    extends CompilerLogMessage {
+
+    def message =
+      s"Unassigned Warning: `Warning.SourceIndex.fileURI` & `Contract.SourceIndex.fileURI` are `None`. Contract: $contractName. Warning: $warning"
+
+  }
+
+  case class UnassignedWarningNoneFileInfo(
+      warning: Warning,
+      contractName: String)
+    extends CompilerLogMessage {
+
+    def message =
+      s"Unassigned Warning: `Warning.SourceIndex`, `Contract.Ident.SourceIndex` & `Contract.SourceIndex` are `None`. Contract: $contractName. Warning: $warning"
+
+  }
+
+  case class NoneIdentSourceIndex(
+      warning: Warning,
+      contractName: String)
+    extends CompilerLogMessage {
+
+    def message =
+      s"Contract '$contractName' has undefined SourceIndex for its Ident. Reporting warning at Contract's SourceIndex. Warning: $warning"
+
+  }
+
+  case class UnassignedWarning(warning: Warning) extends CompilerLogMessage {
+
+    def message =
+      s"Unassigned Warning: Missing file information. Warning: $warning"
+
+  }
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/RalphCompilerAccess.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/RalphCompilerAccess.scala
@@ -23,6 +23,7 @@ import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.access.compiler.message.error._
 import org.alephium.ralph.lsp.access.util.TryUtil
+import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
 
 import java.net.URI
 
@@ -30,10 +31,10 @@ import java.net.URI
  * Implements ralph parsing and compilation functions accessing the `ralphc`.
  *
  * @note Access to this object is private.
- *       PresentationCompiler does not directly accesses this code.
+ *       PresentationCompiler does not directly access this code.
  */
 
-private object RalphCompilerAccess extends CompilerAccess {
+private object RalphCompilerAccess extends CompilerAccess with StrictImplicitLogging {
 
   /** @inheritdoc */
   def parseContracts(
@@ -53,7 +54,8 @@ private object RalphCompilerAccess extends CompilerAccess {
   def compileContracts(
       parsedSource: Seq[Ast.GlobalDefinition],
       options: CompilerOptions,
-      workspaceErrorURI: URI): Either[CompilerMessage.AnyError, (Array[CompiledContract], Array[CompiledScript], Array[Warning])] =
+      workspaceErrorURI: URI
+    )(implicit logger: ClientLogger): Either[CompilerMessage.AnyError, (Array[CompiledContract], Array[CompiledScript], Array[Warning])] =
     try {
       val allContracts     = Seq.newBuilder[Ast.ContractWithState]
       val otherDefinitions = Seq.newBuilder[Ast.GlobalDefinition]
@@ -93,13 +95,93 @@ private object RalphCompilerAccess extends CompilerAccess {
       val (warnings, statefulContractsAndIndex) =
         extendedContracts.genStatefulContracts()(options)
 
+      // Ensure warnings with empty file information are logged so they can be resolved in Node.
+      warnings foreach {
+        warning =>
+          if (warning.sourceIndex.flatMap(_.fileURI).isEmpty)
+            logger.error(CompilerLogMessage.UnassignedWarning(warning))
+      }
+
       val statefulContracts =
-        statefulContractsAndIndex.map(_._1)
+        statefulContractsAndIndex.map(_._1).toArray
 
       val statefulScripts =
-        extendedContracts.genStatefulScripts()(options)
+        extendedContracts.genStatefulScripts()(options).toArray
 
-      Right((statefulContracts.toArray, statefulScripts.toArray, warnings.toArray))
+      val extractedContractWarnings =
+        extractWarnings(statefulContracts.map(CompiledCodeWrapper(_)))
+
+      val extractedScriptWarnings =
+        extractWarnings(statefulScripts.map(CompiledCodeWrapper(_)))
+
+      // Combine all warnings into a single collection so there is only one way to handle Warnings by presentation-compiler.
+      // This list contains all Warnings with SourceIndex and fileURI populated.
+      // If there are cases where SourceIndex or fileURI is None, they can be ignored by presentation-compiler,
+      // because they are logged.
+      val allWarnings =
+        extractedContractWarnings ++ extractedScriptWarnings ++ warnings
+
+      Right((statefulContracts, statefulScripts, allWarnings))
     } catch TryUtil.catchAllThrows(workspaceErrorURI)
+
+  private def extractWarnings(contracts: Array[CompiledCodeWrapper])(implicit logger: ClientLogger): Array[Warning] =
+    contracts flatMap extractWarnings
+
+  /**
+   * Ensures all [[Warning]]s are assigned a [[SourceIndex]] and file URI.
+   * Warnings that cannot be assigned are logged.
+   *
+   * Warnings returned by ralphc may or may not contain a [[SourceIndex]] or file URI.
+   *
+   * There multiple conditions for handling [[Warning]]s returned by ralphc
+   *  - When a warning contained in a [[CompiledContract]] or [[CompiledScript]]
+   *    has an empty [[SourceIndex]] or [[SourceIndex.fileURI]], the file information
+   *    for the contract or script must be applied to the [[Warning]].
+   *  - When a [[CompiledContract]] or [[CompiledScript]] contains a [[Warning]] for different file URI,
+   *    that [[Warning]] must be reported at the file information contained with the [[Warning]] and not
+   *    at the [[CompiledContract]]'s or [[CompiledScript]]'s file information.
+   *  - Since [[Warning.sourceIndex]] is of type [[Option]], [[None]] cases must be reported
+   *    so they can be resolved in Node.
+   *  - Since [[SourceIndex.fileURI]] is of type [[Option]], [[None]] cases must be reported
+   *    so they can be resolved in Node.
+   *
+   * @param contract The contract containing warnings.
+   * @param logger   Message logger
+   * @return Warnings with [[SourceIndex]] populated.
+   */
+  def extractWarnings(contract: CompiledCodeWrapper)(implicit logger: ClientLogger): Array[Warning] =
+    contract.warnings.toArray flatMap {
+      warning =>
+        warning.sourceIndex match {
+          case Some(warningSourceIndex) => // Warning has SourceIndex!
+            if (warningSourceIndex.fileURI.isEmpty)               // Is the Warning's fileURI empty?
+              contract.ast.sourceIndex.flatMap(_.fileURI) match { // It's empty! Assign it from Contract's fileURI.
+                case Some(contractFileURI) =>
+                  // update the Warning's fileURI
+                  Some(warning.copy(sourceIndex = Some(warningSourceIndex.copy(fileURI = Some(contractFileURI)))))
+
+                case None =>
+                  // Contract also does not have a fileURI. Report this as an error so it can be resolved in Node.
+                  logger.error(CompilerLogMessage.UnassignedWarningNoneFileURI(warning, contract.ast.name))
+                  None
+              }
+            else
+              Some(warning) // Warning is good. It contains all file information.
+
+          case None => // Warning's SourceIndex is None. Assign it one, either `Contract.Ident.SourceIndex` or `Contract.SourceIndex`.
+            if (contract.ast.ident.sourceIndex.isDefined) {
+              // assign the Contract.Ident.SourceIndex
+              Some(warning.copy(sourceIndex = contract.ast.ident.sourceIndex))
+            } else if (contract.ast.sourceIndex.isDefined) {
+              logger.error(CompilerLogMessage.NoneIdentSourceIndex(warning, contract.ast.name))
+              // assign the Contract.SourceIndex
+              Some(warning.copy(sourceIndex = contract.ast.sourceIndex))
+            } else {
+              // SourceIndex not set anywhere. Report this as an error so it can be resolved in Node.
+              logger.error(CompilerLogMessage.UnassignedWarningNoneFileInfo(warning, contract.ast.name))
+              None
+            }
+        }
+    }
 
 }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/ExtractWarningsSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/ExtractWarningsSpec.scala
@@ -1,0 +1,232 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler
+
+import com.typesafe.scalalogging.Logger
+import org.alephium.ralph.{Warning, SourceIndex, Ast}
+import org.alephium.ralph.lsp.utils.log.{ClientLogger, LogMessage}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.OptionValues._
+
+import java.net.URI
+
+class ExtractWarningsSpec extends AnyWordSpec with Matchers with MockFactory {
+
+  "return empty" when {
+    "warnings are empty" in {
+      implicit val logger: ClientLogger =
+        null // nothing should get logged
+
+      val code =
+        CompiledCodeWrapper(TestRalphc.createCompiledContract(Ast.TypeId("MyContract")))
+
+      RalphCompilerAccess.extractWarnings(code) shouldBe empty
+    }
+
+    "the warning and Contract have no SourceIndex" in {
+      val contractTypeId =
+        Ast.TypeId("MyContract")
+
+      val warning =
+        Warning(message = "Wassup!", sourceIndex = None)
+
+      val code =
+        CompiledCodeWrapper(TestRalphc.createCompiledContract(contractTypeId, warning))
+
+      implicit val logger: ClientLogger =
+        mock[ClientLogger]
+
+      (logger
+        .error(_: LogMessage)(_: Logger))
+        .expects(CompilerLogMessage.UnassignedWarningNoneFileInfo(warning, contractTypeId.name), *)
+        .returns(())
+        .once()
+
+      RalphCompilerAccess.extractWarnings(code) shouldBe empty
+    }
+
+    "the warning and Contract have SourceIndex, but fileURI is not provided" in {
+      val contractTypeId =
+        Ast.TypeId("MyContract")
+
+      val warning =
+        Warning(message = "Wassup!", sourceIndex = Some(SourceIndex(1, 2, None)))
+
+      val code =
+        CompiledCodeWrapper(TestRalphc.createCompiledContract(contractTypeId, warning))
+
+      implicit val logger: ClientLogger =
+        mock[ClientLogger]
+
+      (logger
+        .error(_: LogMessage)(_: Logger))
+        .expects(CompilerLogMessage.UnassignedWarningNoneFileURI(warning, contractTypeId.name), *)
+        .returns(())
+        .once()
+
+      RalphCompilerAccess.extractWarnings(code) shouldBe empty
+    }
+
+  }
+
+  "return nonempty" when {
+    "Contract has SourceIndex but the warning and Contract.Ident has no SourceIndex" in {
+      val contractTypeId =
+        Ast.TypeId("MyContract")
+
+      val ast =
+        TestRalphc.createTestContract(contractTypeId)
+
+      val contractSourceIndex =
+        SourceIndex(1, 2, Some(URI.create("file://blah.txt")))
+
+      ast.sourceIndex = Some(contractSourceIndex)
+
+      val warning =
+        Warning(message = "Wassup!", sourceIndex = None)
+
+      val code =
+        CompiledCodeWrapper(TestRalphc.createCompiledContract(ast, warning))
+
+      implicit val logger: ClientLogger =
+        mock[ClientLogger]
+
+      (logger
+        .error(_: LogMessage)(_: Logger))
+        .expects(CompilerLogMessage.NoneIdentSourceIndex(warning, contractTypeId.name), *)
+        .returns(())
+        .once()
+
+      // Warning and Ast.Contract.Ident has no SourceIndex, therefore, the SourceIndex of Ast.Contract should be used.
+      val expected =
+        warning.copy(sourceIndex = Some(contractSourceIndex))
+
+      val actual =
+        RalphCompilerAccess.extractWarnings(code)
+
+      actual should contain only expected
+    }
+
+    "Warning does not have a SourceIndex, but Contract.Ident does" in {
+      val typeIdSourceIndex =
+        SourceIndex(1, 2, Some(URI.create("file://blah.txt")))
+
+      val contractTypeId =
+        Ast.TypeId("MyContract")
+
+      contractTypeId.sourceIndex = Some(typeIdSourceIndex)
+
+      val ast =
+        TestRalphc.createTestContract(contractTypeId)
+
+      ast.sourceIndex shouldBe empty
+
+      val warning =
+        Warning(message = "Wassup!", sourceIndex = None)
+
+      val code =
+        CompiledCodeWrapper(TestRalphc.createCompiledContract(ast, warning))
+
+      implicit val logger: ClientLogger =
+        null // nothing should get logged
+
+      // Warning does not have a SourceIndex but the Contract's TypeId does
+      val expected =
+        warning.copy(sourceIndex = Some(typeIdSourceIndex))
+
+      val actual =
+        RalphCompilerAccess.extractWarnings(code)
+
+      actual should contain only expected
+    }
+
+    "Warning has SourceIndex but its fileURI is None, but Contract has a fileURI" in {
+      val contractTypeId =
+        Ast.TypeId("MyContract")
+
+      val ast =
+        TestRalphc.createTestContract(contractTypeId)
+
+      val astSourceIndex =
+        SourceIndex(1, 2, Some(URI.create("file://blah.txt")))
+
+      ast.sourceIndex = Some(astSourceIndex)
+
+      val warningSourceIndex =
+        SourceIndex(4, 5, None)
+
+      val warning =
+        Warning(message = "Wassup!", sourceIndex = Some(warningSourceIndex))
+
+      val code =
+        CompiledCodeWrapper(TestRalphc.createCompiledContract(ast, warning))
+
+      implicit val logger: ClientLogger =
+        null // nothing should get logged
+
+      // Warning.SourceIndex.fileURI is None, therefore, Contract's fileURI should be used
+      val expected =
+        warning.copy(sourceIndex = warning.sourceIndex.map(_.copy(fileURI = Some(astSourceIndex.fileURI.value))))
+
+      val actual =
+        RalphCompilerAccess.extractWarnings(code)
+
+      actual should contain only expected
+    }
+
+    "Warning has SourceIndex" when {
+      def doTest(astSourceIndex: Option[SourceIndex]) = {
+        val ast =
+          TestRalphc.createTestContract(Ast.TypeId("MyContract"))
+
+        ast.sourceIndex = astSourceIndex
+
+        val warning =
+          Warning(
+            message = "Wassup!",
+            sourceIndex = Some(SourceIndex(4, 5, Some(URI.create("file://warning.txt"))))
+          )
+
+        val code =
+          CompiledCodeWrapper(TestRalphc.createCompiledContract(ast, warning))
+
+        implicit val logger: ClientLogger =
+          null // nothing should get logged
+
+        val actual =
+          RalphCompilerAccess.extractWarnings(code)
+
+        actual should contain only warning
+      }
+
+      "ast SourceIndex is also defined" in {
+        doTest(astSourceIndex = Some(SourceIndex(1, 2, Some(URI.create("file://blah.txt")))))
+      }
+
+      "ast SourceIndex is partially defined" in {
+        doTest(astSourceIndex = Some(SourceIndex(1, 2, None)))
+      }
+
+      "ast SourceIndex is empty" in {
+        doTest(astSourceIndex = None)
+      }
+    }
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/TestRalphc.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/TestRalphc.scala
@@ -1,0 +1,64 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler
+
+import org.alephium.protocol.vm.StatefulContract
+import org.alephium.ralph.{Warning, Ast, CompiledContract}
+import org.alephium.util.AVector
+
+/**
+ * Test functions for generating data types returned by ralphc.
+ */
+object TestRalphc {
+
+  def createTestContract(typeId: Ast.TypeId): Ast.Contract =
+    Ast.Contract(
+      stdIdEnabled = None,
+      stdInterfaceId = None,
+      isAbstract = false,
+      ident = typeId,
+      templateVars = Seq.empty,
+      fields = Seq.empty,
+      funcs = Seq.empty,
+      maps = Seq.empty,
+      events = Seq.empty,
+      constantVars = Seq.empty,
+      enums = Seq.empty,
+      inheritances = Seq.empty
+    )
+
+  def createCompiledContract(
+      typeId: Ast.TypeId,
+      warnings: Warning*): CompiledContract =
+    CompiledContract(
+      code = StatefulContract(0, AVector.empty),
+      ast = createTestContract(typeId),
+      warnings = AVector.from(warnings),
+      debugCode = StatefulContract(0, AVector.empty)
+    )
+
+  def createCompiledContract(
+      ast: Ast.Contract,
+      warnings: Warning*): CompiledContract =
+    CompiledContract(
+      code = StatefulContract(0, AVector.empty),
+      ast = ast,
+      warnings = AVector.from(warnings),
+      debugCode = StatefulContract(0, AVector.empty)
+    )
+
+}

--- a/utils/src/main/scala/org/alephium/ralph/lsp/utils/log/LogMessage.scala
+++ b/utils/src/main/scala/org/alephium/ralph/lsp/utils/log/LogMessage.scala
@@ -16,27 +16,9 @@
 
 package org.alephium.ralph.lsp.utils.log
 
-import com.typesafe.scalalogging.Logger
+/** Type log message */
+trait LogMessage {
 
-/** Defines APIs for publishing logs to an LSP client */
-trait ClientLogger {
-
-  def info(message: String)(implicit logger: Logger): Unit
-
-  def warning(message: String)(implicit logger: Logger): Unit
-
-  def error(message: String)(implicit logger: Logger): Unit
-
-  def error(message: LogMessage)(implicit logger: Logger): Unit =
-    this.error(message.message)
-
-  def error(
-      message: String,
-      cause: Throwable
-    )(implicit logger: Logger): Unit
-
-  def debug(message: String)(implicit logger: Logger): Unit
-
-  def trace(message: String)(implicit logger: Logger): Unit
+  def message: String
 
 }


### PR DESCRIPTION
- Resolves #313
- Resolves #267

## Issue 

`Warning`s returned by ralphc have multiple conditions (see the following referenced issue): 

- When a `Warning` in a `CompiledContract` or `CompiledScript` has an empty `SourceIndex` or an empty `SourceIndex.fileURI`, it must be reported using the file information of the `CompiledContract` or `CompiledScript` containing the `Warning`.
- A `CompiledContract` or `CompiledScript` can also contain `Warning`s for a file URI that is different from the `CompiledContract`'s or `CompiledScript`'s file information. In this case, the `Warning` must be reported using the file information set in the `Warning` itself, not the `CompiledContract`'s or `CompiledScript`'s file information.
- `Warning`s can also be returned by `genStatefulScripts()`.
- Both `Warning.SourceIndex` and `SourceIndex.fileURI` are of type `Option`. When they are `None` and the `Warning` is contained within a `CompiledContract` or `CompiledScript`, they are resolved using the file information of the `CompiledContract` or `CompiledScript`.
    - If no file information is available for a `Warning`, those `Warning`s are logged for debugging purposes so they can be resolved in Node.

## Solution

The above conditions are not as simple to manage. Therefore, this PR changes compiler output so that the above conditions are applied in the compiler module within `RalphCompilerAccess`. In `presentation-compiler`, there will only be one way to process `Warning`s i.e., every `Warning` returned must have a `SourceIndex` populated, and **all** `Warning`s must be returned as a single output by the compiler function `compileContracts`.