### PR TITLE
Soft Parser: Initial implementation of `SoftParser`

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/CompilerAccess.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/CompilerAccess.scala
@@ -19,6 +19,8 @@ package org.alephium.ralph.lsp.access.compiler
 import org.alephium.ralph._
 import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
+import org.alephium.ralph.lsp.access.compiler.message.error.FastParseError
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
 import org.alephium.ralph.lsp.utils.log.ClientLogger
 import org.alephium.ralph.lsp.utils.URIUtil
 
@@ -45,6 +47,14 @@ object CompilerAccess {
  * @see [[org.alephium.ralph.lsp.access.file.FileAccess]] for file-io.
  */
 trait CompilerAccess {
+
+  /**
+   * Runs the soft parser.
+   *
+   * @param code Code to parse.
+   * @return Parsing error or successfully parsed [[SoftAST]].
+   */
+  def parseSoft(code: String): Either[FastParseError, SoftAST.BlockBody]
 
   /**
    * Runs the parser phase.

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/RalphCompilerAccess.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/RalphCompilerAccess.scala
@@ -21,7 +21,9 @@ import org.alephium.protocol.vm.StatefulContext
 import org.alephium.ralph._
 import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
-import org.alephium.ralph.lsp.access.compiler.message.error._
+import org.alephium.ralph.lsp.access.compiler.message.error.FastParseError
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.SoftParser
 import org.alephium.ralph.lsp.access.util.TryUtil
 import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
 
@@ -35,6 +37,16 @@ import java.net.URI
  */
 
 private object RalphCompilerAccess extends CompilerAccess with StrictImplicitLogging {
+
+  /** @inheritdoc */
+  override def parseSoft(code: String): Either[FastParseError, SoftAST.BlockBody] =
+    fastparse.parse(code, SoftParser.parse(_)) match {
+      case Parsed.Success(ast: SoftAST.BlockBody, _) =>
+        Right(ast)
+
+      case failure: Parsed.Failure =>
+        Left(FastParseError(failure))
+    }
 
   /** @inheritdoc */
   def parseContracts(

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
@@ -31,6 +31,21 @@ object SourceIndexExtra {
     )
 
   /**
+   * Creates a [[SourceIndex]] when the start and end indexes are known.
+   *
+   * @param from the starting index of the range (inclusive)
+   * @param to   the ending index of the range (exclusive)
+   */
+  @inline def range(
+      from: Int,
+      to: Int): SourceIndex =
+    SourceIndex(
+      index = from,
+      width = to - from,
+      fileURI = None
+    )
+
+  /**
    * Sending negative index to the client would be incorrect.
    * This set the index to be an empty range.
    *

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
@@ -1,0 +1,71 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse._
+import fastparse.NoWhitespace.noWhitespaceImplicit
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
+import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+
+private object BlockParser {
+
+  def clause[Unknown: P](mandatory: Boolean): P[SoftAST.BlockClause] =
+    P(Index ~ TokenParser.openCurly(mandatory) ~ spaceOrFail.? ~ body(Some('}')) ~ spaceOrFail.? ~ TokenParser.closeCurly ~ Index) map {
+      case (from, openCurly, preBodySpace, body, postBodySpace, closeCurly, to) =>
+        SoftAST.BlockClause(
+          index = range(from, to),
+          openCurly = openCurly,
+          preBodySpace = preBodySpace,
+          body = body,
+          postBodySpace = postBodySpace,
+          closeCurly = closeCurly
+        )
+    }
+
+  def body[Unknown: P]: P[SoftAST.BlockBody] =
+    body(stopChar = None)
+
+  private def body[Unknown: P](stopChar: Option[Char]): P[SoftAST.BlockBody] =
+    P(Index ~ spaceOrFail.? ~ bodyPart(stopChar).rep ~ Index) map {
+      case (from, headSpace, parts, to) =>
+        SoftAST.BlockBody(
+          index = range(from, to),
+          prePartsSpace = headSpace,
+          parts = parts
+        )
+    }
+
+  private def bodyPart[Unknown: P](stopChar: Option[Char]): P[SoftAST.BlockBodyPart] =
+    P(Index ~ part(stopChar) ~ spaceOrFail.? ~ Index) map {
+      case (from, ast, space, to) =>
+        SoftAST.BlockBodyPart(
+          index = range(from, to),
+          part = ast,
+          postPartSpace = space
+        )
+    }
+
+  private def part[Unknown: P](stopChar: Option[Char]): P[SoftAST.BodyPartAST] =
+    P {
+      TemplateParser.parse |
+        FunctionParser.parse |
+        CommentParser.parse |
+        unresolved(stopChar)
+    }
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
@@ -20,12 +20,12 @@ import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object BlockParser {
 
   def clause[Unknown: P](mandatory: Boolean): P[SoftAST.BlockClause] =
-    P(Index ~ TokenParser.openCurly(mandatory) ~ spaceOrFail.? ~ body(Some('}')) ~ spaceOrFail.? ~ TokenParser.closeCurly ~ Index) map {
+    P(Index ~ TokenParser.openCurly(mandatory) ~ spaceOrFail.? ~ body(Some(Token.CloseCurly.lexeme.head)) ~ spaceOrFail.? ~ TokenParser.closeCurly ~ Index) map {
       case (from, openCurly, preBodySpace, body, postBodySpace, closeCurly, to) =>
         SoftAST.BlockClause(
           index = range(from, to),

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommentParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommentParser.scala
@@ -1,0 +1,38 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse._
+import fastparse.NoWhitespace.noWhitespaceImplicit
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
+import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+
+private object CommentParser {
+
+  def parse[Unknown: P]: P[SoftAST.Comment] =
+    P(Index ~ TokenParser.doubleForwardSlash ~ spaceOrFail.? ~ text.? ~ Index) map {
+      case (from, doubleForwardSlash, space, text, to) =>
+        SoftAST.Comment(
+          index = range(from, to),
+          doubleForwardSlash = doubleForwardSlash,
+          space = space,
+          text = text
+        )
+    }
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommonParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommonParser.scala
@@ -1,0 +1,98 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse._
+import fastparse.NoWhitespace.noWhitespaceImplicit
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+
+private object CommonParser {
+
+  def spaceOrFail[Unknown: P]: P[SoftAST.Space] =
+    P(Index ~ CharsWhileIn(" \t\r\n").! ~ Index) map {
+      case (from, text, to) =>
+        SoftAST.Space(
+          code = text,
+          index = range(from, to)
+        )
+    }
+
+  def space[Unknown: P]: P[SoftAST.SpaceAST] =
+    P(Index ~ spaceOrFail.?) map {
+      case (_, Some(space)) =>
+        space
+
+      case (from, None) =>
+        SoftAST.SpaceExpected(range(from, from))
+    }
+
+  def text[Unknown: P]: P[SoftAST.Text] =
+    P(Index ~ CharsWhile(_ != '\n').! ~ Index) map {
+      case (from, text, to) =>
+        SoftAST.Text(
+          code = text,
+          index = range(from, to)
+        )
+    }
+
+  def unresolved[Unknown: P](stopChar: Option[Char]): P[SoftAST.Unresolved] =
+    P(Index ~ CharsWhileNot(Seq(' ', '\n') ++ stopChar: _*).! ~ Index) map {
+      case (from, text, to) =>
+        SoftAST.Unresolved(
+          code = text,
+          index = range(from, to)
+        )
+    }
+
+  def identifier[Unknown: P]: P[SoftAST.IdentifierAST] =
+    P(Index ~ isLetterDigitOrUnderscore.!.? ~ Index) map {
+      case (from, Some(identifier), to) =>
+        SoftAST.Identifier(
+          code = identifier,
+          index = range(from, to)
+        )
+
+      case (from, None, to) =>
+        SoftAST.IdentifierExpected(range(from, to))
+    }
+
+  def typeName[Unknown: P]: P[SoftAST.SingleTypeAST] =
+    P(Index ~ isLetterDigitOrUnderscore.!.? ~ Index) map {
+      case (from, Some(typeName), to) =>
+        SoftAST.Type(
+          code = typeName,
+          index = range(from, to)
+        )
+
+      case (from, None, to) =>
+        SoftAST.TypeExpected(range(from, to))
+    }
+
+  private def CharsWhileNot[Unknown: P](chars: Char*): P[Unit] =
+    CharsWhile {
+      char =>
+        !(chars contains char)
+    }
+
+  private def isLetterDigitOrUnderscore[Unknown: P]: P[Unit] =
+    CharsWhile {
+      char =>
+        char.isLetterOrDigit || char == '_'
+    }
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommonParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommonParser.scala
@@ -19,7 +19,7 @@ package org.alephium.ralph.lsp.access.compiler.parser.soft
 import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object CommonParser {
 
@@ -42,7 +42,7 @@ private object CommonParser {
     }
 
   def text[Unknown: P]: P[SoftAST.Text] =
-    P(Index ~ CharsWhile(_ != '\n').! ~ Index) map {
+    P(Index ~ CharsWhile(_ != Token.Newline.lexeme.head).! ~ Index) map {
       case (from, text, to) =>
         SoftAST.Text(
           code = text,
@@ -51,7 +51,7 @@ private object CommonParser {
     }
 
   def unresolved[Unknown: P](stopChar: Option[Char]): P[SoftAST.Unresolved] =
-    P(Index ~ CharsWhileNot(Seq(' ', '\n') ++ stopChar: _*).! ~ Index) map {
+    P(Index ~ CharsWhileNot(Seq(Token.Space.lexeme.head, Token.Newline.lexeme.head) ++ stopChar: _*).! ~ Index) map {
       case (from, text, to) =>
         SoftAST.Unresolved(
           code = text,
@@ -92,7 +92,7 @@ private object CommonParser {
   private def isLetterDigitOrUnderscore[Unknown: P]: P[Unit] =
     CharsWhile {
       char =>
-        char.isLetterOrDigit || char == '_'
+        char.isLetterOrDigit || char == Token.Underscore.lexeme.head
     }
 
 }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommonParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommonParser.scala
@@ -42,7 +42,7 @@ private object CommonParser {
     }
 
   def text[Unknown: P]: P[SoftAST.Text] =
-    P(Index ~ CharsWhile(_ != Token.Newline.lexeme.head).! ~ Index) map {
+    P(Index ~ CharsWhileNot(Token.Newline.lexeme).! ~ Index) map {
       case (from, text, to) =>
         SoftAST.Text(
           code = text,
@@ -51,7 +51,7 @@ private object CommonParser {
     }
 
   def unresolved[Unknown: P](stopChar: Option[Char]): P[SoftAST.Unresolved] =
-    P(Index ~ CharsWhileNot(Seq(Token.Space.lexeme.head, Token.Newline.lexeme.head) ++ stopChar: _*).! ~ Index) map {
+    P(Index ~ CharsWhileNot(Token.Space.lexeme ++ Token.Newline.lexeme ++ stopChar).! ~ Index) map {
       case (from, text, to) =>
         SoftAST.Unresolved(
           code = text,
@@ -83,7 +83,7 @@ private object CommonParser {
         SoftAST.TypeExpected(range(from, to))
     }
 
-  private def CharsWhileNot[Unknown: P](chars: Char*): P[Unit] =
+  private def CharsWhileNot[Unknown: P](chars: String): P[Unit] =
     CharsWhile {
       char =>
         !(chars contains char)

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala
@@ -1,0 +1,42 @@
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.CompilerAccess
+
+object Demo extends App {
+
+  val compiler =
+    CompilerAccess.ralphc
+
+  val ast =
+    compiler.parseSoft {
+      """
+        |Contract HelloWorld(type: SomeType, tuple: (A, B)) {
+        |
+        |  fn function(nested_tuple: (A, (B, C))) -> ABC {
+        |
+        |  }
+        |
+        |  🚀
+        |}
+        |""".stripMargin
+    } match {
+      case Right(softAST) =>
+        softAST
+
+      case Left(parseError) =>
+        // Format and print the FastParse error.
+        // The goal here is to ensure that the parser always succeeds, regardless of the input.
+        // Therefore, this error should never occur. If an error does occur, the parser should be updated to handle those cases.
+        println(parseError.error.toFormatter().format(Some(Console.RED)))
+        throw parseError.error
+    }
+
+  // Emit code generated from AST
+  println("Parsed code:")
+  println(ast.toCode())
+
+  // Emit parsed AST
+  println("SoftAST:")
+  println(ast.toNode().toStringTree(_.toStringPretty()))
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala
@@ -37,6 +37,6 @@ object Demo extends App {
 
   // Emit parsed AST
   println("SoftAST:")
-  println(ast.toNode().toStringTree(_.toStringPretty()))
+  println(ast.toStringTree())
 
 }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala
@@ -13,7 +13,7 @@ object Demo extends App {
         |Contract HelloWorld(type: SomeType, tuple: (A, B)) {
         |
         |  fn function(nested_tuple: (A, (B, C))) -> ABC {
-        |
+        |    // comment
         |  }
         |
         |  🚀

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionParser.scala
@@ -1,0 +1,67 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse._
+import fastparse.NoWhitespace.noWhitespaceImplicit
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.{range, SourceIndexExtension}
+import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+
+private object FunctionParser {
+
+  def parse[Unknown: P]: P[SoftAST.Function] =
+    P(TokenParser.fn ~ space ~ signature ~ spaceOrFail.? ~ BlockParser.clause(mandatory = false).?) map {
+      case (fnDeceleration, headSpace, signature, tailSpace, block) =>
+        SoftAST.Function(
+          index = range(fnDeceleration.index.from, signature.index.to),
+          fn = fnDeceleration,
+          preSignatureSpace = headSpace,
+          signature = signature,
+          postSignatureSpace = tailSpace,
+          block = block
+        )
+    }
+
+  private def signature[Unknown: P]: P[SoftAST.FunctionSignature] =
+    P(Index ~ identifier ~ spaceOrFail.? ~ ParameterParser.parse ~ spaceOrFail.? ~ returnSignature ~ Index) map {
+      case (from, fnName, headSpace, params, tailSpace, returns, to) =>
+        SoftAST.FunctionSignature(
+          index = range(from, to),
+          fnName = fnName,
+          preParamSpace = headSpace,
+          params = params,
+          postParamSpace = tailSpace,
+          returned = returns
+        )
+    }
+
+  private def returnSignature[Unknown: P]: P[SoftAST.FunctionReturnAST] =
+    P(Index ~ (TokenParser.forwardArrow ~ spaceOrFail.? ~ TypeParser.parse).? ~ Index) map {
+      case (from, Some((forwardArrow, space, tpe)), to) =>
+        SoftAST.FunctionReturn(
+          index = range(from, to),
+          forwardArrow = forwardArrow,
+          space = space,
+          tpe = tpe
+        )
+
+      case (from, None, to) =>
+        SoftAST.FunctionReturnExpected(range(from, to))
+    }
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ParameterParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ParameterParser.scala
@@ -1,0 +1,80 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse._
+import fastparse.NoWhitespace.noWhitespaceImplicit
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
+import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+
+private object ParameterParser {
+
+  def parse[Unknown: P]: P[SoftAST.ParameterClauseAST] =
+    P(emptyParams | atLeastOneParam)
+
+  private def emptyParams[Unknown: P]: P[SoftAST.EmptyParameterClause] =
+    P(Index ~ TokenParser.openParenOrFail ~ spaceOrFail.? ~ TokenParser.closeParenOrFail ~ Index) map {
+      case (from, openParen, space, closeParen, to) =>
+        SoftAST.EmptyParameterClause(
+          index = range(from, to),
+          openParen = openParen,
+          preCloseParenSpace = space,
+          closeParen = closeParen
+        )
+    }
+
+  private def atLeastOneParam[Unknown: P]: P[SoftAST.NonEmptyParameterClause] =
+    P(Index ~ TokenParser.openParen ~ spaceOrFail.? ~ oneParameter ~ tailParam.rep ~ spaceOrFail.? ~ TokenParser.closeParen ~ Index) map {
+      case (from, openParen, headSpace, headParam, tailParams, tailSpace, closeParen, to) =>
+        SoftAST.NonEmptyParameterClause(
+          index = range(from, to),
+          openParen = openParen,
+          preParamsSpace = headSpace,
+          headParam = headParam,
+          tailParams = tailParams,
+          postParamSpace = tailSpace,
+          closeParen = closeParen
+        )
+    }
+
+  private def oneParameter[Unknown: P]: P[SoftAST.Parameter] =
+    P(Index ~ identifier ~ spaceOrFail.? ~ TokenParser.colon ~ spaceOrFail.? ~ TypeParser.parse ~ Index) map {
+      case (from, paramName, headSpace, colon, tailSpace, typeName, to) =>
+        SoftAST.Parameter(
+          index = range(from, to),
+          paramName = paramName,
+          preColonSpace = headSpace,
+          colon = colon,
+          postColonSpace = tailSpace,
+          paramType = typeName
+        )
+    }
+
+  private def tailParam[Unknown: P]: P[SoftAST.TailParameter] =
+    P(Index ~ spaceOrFail.? ~ TokenParser.comma ~ spaceOrFail.? ~ oneParameter ~ Index) map {
+      case (from, headSpace, comma, tailSpace, param, to) =>
+        SoftAST.TailParameter(
+          index = range(from, to),
+          preCommaSpace = headSpace,
+          comma = comma,
+          postCommaSpace = tailSpace,
+          parameter = param
+        )
+    }
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/SoftParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/SoftParser.scala
@@ -1,0 +1,28 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse._
+import fastparse.NoWhitespace.noWhitespaceImplicit
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+
+object SoftParser {
+
+  def parse[Unknown: P]: P[SoftAST.BlockBody] =
+    P(Start ~ BlockParser.body ~ End)
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateParser.scala
@@ -1,0 +1,29 @@
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse._
+import fastparse.NoWhitespace.noWhitespaceImplicit
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
+import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+
+private object TemplateParser {
+
+  def parse[Unknown: P] =
+    P(Index ~ templateType ~ space ~ identifier ~ spaceOrFail.? ~ ParameterParser.parse ~ spaceOrFail.? ~ BlockParser.clause(mandatory = true) ~ Index) map {
+      case (from, templateType, preIdentifierSpace, identifier, preParamSpace, params, postParamSpace, block, to) =>
+        SoftAST.Template(
+          index = range(from, to),
+          templateType = templateType,
+          preIdentifierSpace = preIdentifierSpace,
+          identifier = identifier,
+          preParamSpace = preParamSpace,
+          params = params,
+          postParamSpace = postParamSpace,
+          block = block
+        )
+    }
+
+  private def templateType[Unknown: P]: P[SoftAST.TemplateToken] =
+    P(TokenParser.Contract | TokenParser.TxScript)
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -1,0 +1,134 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse._
+import fastparse.NoWhitespace.noWhitespaceImplicit
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
+
+private object TokenParser {
+
+  def colon[Unknown: P]: P[SoftAST.ColonAST] =
+    P(Index ~ Token.Colon.lexeme.!.? ~ Index) map {
+      case (from, Some(_), to) =>
+        SoftAST.Colon(range(from, to))
+
+      case (from, None, to) =>
+        SoftAST.ColonExpected(range(from, to))
+    }
+
+  def openParen[Unknown: P]: P[SoftAST.OpenParenAST] =
+    P(Index ~ Token.OpenParen.lexeme.!.? ~ Index) map {
+      case (from, Some(_), to) =>
+        SoftAST.OpenParen(range(from, to))
+
+      case (from, None, to) =>
+        SoftAST.OpenParenExpected(range(from, to))
+    }
+
+  def openParenOrFail[Unknown: P]: P[SoftAST.OpenParen] =
+    P(Index ~ Token.OpenParen.lexeme ~ Index) map {
+      case (from, to) =>
+        SoftAST.OpenParen(range(from, to))
+    }
+
+  def closeParen[Unknown: P]: P[SoftAST.CloseParenAST] =
+    P(Index ~ Token.CloseParen.lexeme.!.? ~ Index) map {
+      case (from, Some(_), to) =>
+        SoftAST.CloseParen(range(from, to))
+
+      case (from, None, to) =>
+        SoftAST.CloseParenExpected(range(from, to))
+    }
+
+  def closeParenOrFail[Unknown: P]: P[SoftAST.CloseParenAST] =
+    P(Index ~ Token.CloseParen.lexeme ~ Index) map {
+      case (from, to) =>
+        SoftAST.CloseParen(range(from, to))
+    }
+
+  def openCurly[Unknown: P](mandatory: Boolean): P[SoftAST.OpenCurlyAST] =
+    if (mandatory)
+      openCurly
+    else
+      openCurlyOrFail
+
+  def openCurly[Unknown: P]: P[SoftAST.OpenCurlyAST] =
+    P(Index ~ Token.OpenCurly.lexeme.!.? ~ Index) map {
+      case (from, Some(_), to) =>
+        SoftAST.OpenCurly(range(from, to))
+
+      case (from, None, to) =>
+        SoftAST.OpenCurlyExpected(range(from, to))
+    }
+
+  def openCurlyOrFail[Unknown: P]: P[SoftAST.OpenCurly] =
+    P(Index ~ Token.OpenCurly.lexeme.! ~ Index) map {
+      case (from, _, to) =>
+        SoftAST.OpenCurly(range(from, to))
+    }
+
+  def closeCurly[Unknown: P]: P[SoftAST.CloseCurlyAST] =
+    P(Index ~ Token.CloseCurly.lexeme.!.? ~ Index) map {
+      case (from, Some(_), to) =>
+        SoftAST.CloseCurly(range(from, to))
+
+      case (from, None, to) =>
+        SoftAST.CloseCurlyExpected(range(from, to))
+    }
+
+  def comma[Unknown: P]: P[SoftAST.Comma] =
+    P(Index ~ Token.Comma.lexeme ~ Index) map {
+      case (from, to) =>
+        SoftAST.Comma(range(from, to))
+    }
+
+  def forwardArrow[Unknown: P]: P[SoftAST.ForwardArrowAST] =
+    P(Index ~ Token.ForwardArrow.lexeme.!.? ~ Index) map {
+      case (from, Some(_), to) =>
+        SoftAST.ForwardArrow(range(from, to))
+
+      case (from, None, to) =>
+        SoftAST.ForwardArrowExpected(range(from, to))
+    }
+
+  def doubleForwardSlash[Unknown: P]: P[SoftAST.DoubleForwardSlash] =
+    P(Index ~ Token.DoubleForwardSlash.lexeme ~ Index) map {
+      case (from, to) =>
+        SoftAST.DoubleForwardSlash(range(from, to))
+    }
+
+  def Contract[Unknown: P]: P[SoftAST.Contract] =
+    P(Index ~ Token.Contract.lexeme ~ Index) map {
+      case (from, to) =>
+        SoftAST.Contract(range(from, to))
+    }
+
+  def TxScript[Unknown: P]: P[SoftAST.TxScript] =
+    P(Index ~ Token.TxScript.lexeme ~ Index) map {
+      case (from, to) =>
+        SoftAST.TxScript(range(from, to))
+    }
+
+  def fn[Unknown: P]: P[SoftAST.Fn] =
+    P(Index ~ Token.Fn.lexeme ~ Index) map {
+      case (from, to) =>
+        SoftAST.Fn(range(from, to))
+    }
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeParser.scala
@@ -1,0 +1,55 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse._
+import fastparse.NoWhitespace.noWhitespaceImplicit
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
+import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+
+private object TypeParser {
+
+  def parse[Unknown: P]: P[SoftAST.TypeAST] =
+    P(tupledTypeNames | typeName)
+
+  private def tupledTypeNames[Unknown: P]: P[SoftAST.TupledType] =
+    P(Index ~ TokenParser.openParenOrFail ~ spaceOrFail.? ~ parse ~ commaTypeName.rep ~ TokenParser.closeParen ~ Index) map {
+      case (from, openParen, preHeadTypeSpace, headType, tailTypes, closeParen, to) =>
+        SoftAST.TupledType(
+          index = range(from, to),
+          openParen = openParen,
+          preHeadTypeSpace = preHeadTypeSpace,
+          headType = headType,
+          tailTypes = tailTypes,
+          closeParen = closeParen
+        )
+    }
+
+  private def commaTypeName[Unknown: P]: P[SoftAST.TailType] =
+    P(Index ~ TokenParser.comma ~ spaceOrFail.? ~ parse ~ spaceOrFail.? ~ Index) map {
+      case (from, comma, preTypeNameSpace, typeName, postTypeNameSpace, to) =>
+        SoftAST.TailType(
+          index = range(from, to),
+          comma = comma,
+          preTypeNameSpace = preTypeNameSpace,
+          tpe = typeName,
+          postTypeNameSpace = postTypeNameSpace
+        )
+    }
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -36,6 +36,9 @@ sealed trait SoftAST extends Product { self =>
   final def toCode(): String =
     toNode().toCode()
 
+  final def toStringTree(): String =
+    toNode().toStringTree(_.toStringPretty())
+
   def toStringPretty(): String =
     if (self.children().nonEmpty)
       s"${self.getClass.getSimpleName}: ${self.index}"

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -291,6 +291,7 @@ object SoftAST {
       this
         .copy(
           code = code
+            .replaceAll("\r", "\\\\r") // Replace carriage with \\r
             .replaceAll("\n", "\\\\n") // Replace newline with \\n
             .replaceAll("\t", "\\\\t") // Replace tab with \\t
         )

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -37,7 +37,7 @@ sealed trait SoftAST extends Product { self =>
     toNode().toCode()
 
   final def toStringTree(): String =
-    toNode().toStringTree(_.toStringPretty())
+    toNode().toStringTree()
 
   def toStringPretty(): String =
     if (self.children().nonEmpty)
@@ -59,6 +59,9 @@ object SoftAST {
         case (code, _) =>
           code
       }
+
+    def toStringTree(): String =
+      node.toStringTree(_.toStringPretty())
 
   }
 

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -1,0 +1,314 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft.ast
+
+import org.alephium.ralph.SourceIndex
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST.collectASTs
+import org.alephium.ralph.lsp.utils.Node
+
+sealed trait SoftAST extends Product { self =>
+
+  def index: SourceIndex
+
+  final def children(): Iterator[SoftAST] =
+    productIterator flatMap collectASTs
+
+  final def toNode(): Node[this.type, SoftAST] =
+    Node(
+      data = self,
+      children = children().map(_.toNode()).toSeq
+    )
+
+  final def toCode(): String =
+    toNode().toCode()
+
+  def toStringPretty(): String =
+    if (self.children().nonEmpty)
+      s"${self.getClass.getSimpleName}: ${self.index}"
+    else
+      self.toString
+
+}
+
+object SoftAST {
+
+  implicit class NodeSoftASTExtensions(val node: Node[SoftAST, SoftAST]) extends AnyVal {
+
+    def toCode(): String =
+      node.walkDown.foldLeft("") {
+        case (code, Node(ast: CodeAST, _)) =>
+          code + ast.code
+
+        case (code, _) =>
+          code
+      }
+
+  }
+
+  sealed trait BodyPartAST extends SoftAST
+
+  sealed trait CodeAST extends SoftAST {
+
+    def code: String
+
+  }
+
+  abstract class TokenAST(token: Token) extends CodeAST {
+
+    final override def code: String =
+      token.lexeme
+
+  }
+
+  abstract class ErrorAST(val message: String)       extends SoftAST
+  abstract class ExpectedErrorAST(element: String)   extends ErrorAST(s"$element expected")
+  abstract class TokenExpectedErrorAST(token: Token) extends ExpectedErrorAST(s"'${token.lexeme}'")
+
+  case class Fn(index: SourceIndex)                 extends TokenAST(Token.Fn)
+  case class Comma(index: SourceIndex)              extends TokenAST(Token.Comma)
+  case class DoubleForwardSlash(index: SourceIndex) extends TokenAST(Token.DoubleForwardSlash)
+
+  sealed abstract class TemplateToken(token: Token) extends TokenAST(token)
+  case class Contract(index: SourceIndex)           extends TemplateToken(Token.Contract)
+  case class TxScript(index: SourceIndex)           extends TemplateToken(Token.TxScript)
+
+  sealed trait ColonAST                        extends SoftAST
+  case class Colon(index: SourceIndex)         extends TokenAST(Token.Colon) with ColonAST
+  case class ColonExpected(index: SourceIndex) extends TokenExpectedErrorAST(Token.Colon) with ColonAST
+
+  sealed trait ForwardArrowAST                        extends SoftAST
+  case class ForwardArrow(index: SourceIndex)         extends TokenAST(Token.ForwardArrow) with ForwardArrowAST
+  case class ForwardArrowExpected(index: SourceIndex) extends TokenExpectedErrorAST(Token.ForwardArrow) with ForwardArrowAST
+
+  sealed trait OpenParenAST                        extends SoftAST
+  case class OpenParen(index: SourceIndex)         extends TokenAST(Token.OpenParen) with OpenParenAST
+  case class OpenParenExpected(index: SourceIndex) extends TokenExpectedErrorAST(Token.OpenParen) with OpenParenAST
+
+  sealed trait CloseParenAST                        extends SoftAST
+  case class CloseParen(index: SourceIndex)         extends TokenAST(Token.CloseParen) with CloseParenAST
+  case class CloseParenExpected(index: SourceIndex) extends TokenExpectedErrorAST(Token.CloseParen) with CloseParenAST
+
+  sealed trait OpenCurlyAST                        extends SoftAST
+  case class OpenCurly(index: SourceIndex)         extends TokenAST(Token.OpenCurly) with OpenCurlyAST
+  case class OpenCurlyExpected(index: SourceIndex) extends TokenExpectedErrorAST(Token.OpenCurly) with OpenCurlyAST
+
+  sealed trait CloseCurlyAST                        extends SoftAST
+  case class CloseCurly(index: SourceIndex)         extends TokenAST(Token.CloseCurly) with CloseCurlyAST
+  case class CloseCurlyExpected(index: SourceIndex) extends TokenExpectedErrorAST(Token.CloseCurly) with CloseCurlyAST
+
+  case class Template(
+      index: SourceIndex,
+      templateType: TemplateToken,
+      preIdentifierSpace: SpaceAST,
+      identifier: SoftAST.IdentifierAST,
+      preParamSpace: Option[Space],
+      params: ParameterClauseAST,
+      postParamSpace: Option[Space],
+      block: BlockClause)
+    extends BodyPartAST
+
+  case class BlockClause(
+      index: SourceIndex,
+      openCurly: OpenCurlyAST,
+      preBodySpace: Option[Space],
+      body: BlockBody,
+      postBodySpace: Option[Space],
+      closeCurly: CloseCurlyAST)
+    extends SoftAST
+
+  case class BlockBody(
+      index: SourceIndex,
+      prePartsSpace: Option[Space],
+      parts: Seq[BlockBodyPart])
+    extends SoftAST
+
+  case class BlockBodyPart(
+      index: SourceIndex,
+      part: BodyPartAST,
+      postPartSpace: Option[Space])
+    extends SoftAST
+
+  sealed trait ParameterClauseAST extends SoftAST
+
+  case class EmptyParameterClause(
+      index: SourceIndex,
+      openParen: OpenParenAST,
+      preCloseParenSpace: Option[Space],
+      closeParen: CloseParenAST)
+    extends ParameterClauseAST
+
+  case class NonEmptyParameterClause(
+      index: SourceIndex,
+      openParen: OpenParenAST,
+      preParamsSpace: Option[Space],
+      headParam: Parameter,
+      tailParams: Seq[TailParameter],
+      postParamSpace: Option[Space],
+      closeParen: CloseParenAST)
+    extends ParameterClauseAST
+
+  case class TailParameter(
+      index: SourceIndex,
+      preCommaSpace: Option[Space],
+      comma: Comma,
+      postCommaSpace: Option[Space],
+      parameter: Parameter)
+    extends SoftAST
+
+  case class Parameter(
+      index: SourceIndex,
+      paramName: IdentifierAST,
+      preColonSpace: Option[Space],
+      colon: ColonAST,
+      postColonSpace: Option[Space],
+      paramType: TypeAST)
+    extends SoftAST
+
+  case class Function(
+      index: SourceIndex,
+      fn: Fn,
+      preSignatureSpace: SpaceAST,
+      signature: FunctionSignature,
+      postSignatureSpace: Option[Space],
+      block: Option[BlockClause])
+    extends BodyPartAST
+
+  case class FunctionSignature(
+      index: SourceIndex,
+      fnName: IdentifierAST,
+      preParamSpace: Option[Space],
+      params: ParameterClauseAST,
+      postParamSpace: Option[Space],
+      returned: FunctionReturnAST)
+    extends SoftAST
+
+  sealed trait TypeAST       extends SoftAST
+  sealed trait SingleTypeAST extends TypeAST
+
+  case class Type(
+      code: String,
+      index: SourceIndex)
+    extends SingleTypeAST
+       with CodeAST
+
+  case class TupledType(
+      index: SourceIndex,
+      openParen: OpenParen,
+      preHeadTypeSpace: Option[Space],
+      headType: TypeAST,
+      tailTypes: Seq[TailType],
+      closeParen: CloseParenAST)
+    extends TypeAST
+
+  case class TypeExpected(
+      index: SourceIndex)
+    extends ExpectedErrorAST("Type")
+       with SingleTypeAST
+
+  case class TailType(
+      index: SourceIndex,
+      comma: Comma,
+      preTypeNameSpace: Option[Space],
+      tpe: TypeAST,
+      postTypeNameSpace: Option[Space])
+    extends SoftAST
+
+  sealed trait FunctionReturnAST extends SoftAST
+
+  case class FunctionReturn(
+      index: SourceIndex,
+      forwardArrow: ForwardArrowAST,
+      space: Option[Space],
+      tpe: TypeAST)
+    extends FunctionReturnAST
+
+  case class FunctionReturnExpected(
+      index: SourceIndex)
+    extends TokenExpectedErrorAST(Token.ForwardArrow)
+       with FunctionReturnAST
+
+  sealed trait IdentifierAST extends SoftAST
+
+  case class Identifier(
+      code: String,
+      index: SourceIndex)
+    extends IdentifierAST
+       with CodeAST
+
+  case class IdentifierExpected(
+      index: SourceIndex)
+    extends ExpectedErrorAST("Identifier")
+       with IdentifierAST
+
+  case class Comment(
+      index: SourceIndex,
+      doubleForwardSlash: DoubleForwardSlash,
+      space: Option[Space],
+      text: Option[Text])
+    extends BodyPartAST
+
+  case class Text(
+      code: String,
+      index: SourceIndex)
+    extends CodeAST
+
+  case class Unresolved(
+      code: String,
+      index: SourceIndex)
+    extends ErrorAST(s"Cannot resolve '$code'")
+       with CodeAST
+       with BodyPartAST
+
+  sealed trait SpaceAST extends SoftAST
+
+  case class Space(
+      code: String,
+      index: SourceIndex)
+    extends SpaceAST
+       with CodeAST {
+
+    override def toStringPretty(): String =
+      this
+        .copy(
+          code = code
+            .replaceAll("\n", "\\\\n") // Replace newline with \\n
+            .replaceAll("\t", "\\\\t") // Replace tab with \\t
+        )
+        .toString
+
+  }
+
+  case class SpaceExpected(
+      index: SourceIndex)
+    extends ExpectedErrorAST("Space")
+       with SpaceAST
+
+  private def collectASTs: PartialFunction[Any, Seq[SoftAST]] = {
+    case ast: SoftAST =>
+      Seq(ast)
+
+    case Some(ast: SoftAST) =>
+      Seq(ast)
+
+    case seq: Seq[_] =>
+      seq flatMap collectASTs
+
+    case _ =>
+      Seq.empty
+  }
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
@@ -58,6 +58,8 @@ object Token {
   case object Dot                                              extends Delimiter(".")
   case object Colon                                            extends Delimiter(":")
   case object Semicolon                                        extends Delimiter(";")
+  case object Newline                                          extends Delimiter("\n")
+  case object Space                                            extends Delimiter(" ")
 
   sealed abstract class Punctuator(override val lexeme: String) extends Token
   case object Hash                                              extends Punctuator("#")

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
@@ -58,7 +58,7 @@ object Token {
   case object Dot                                              extends Delimiter(".")
   case object Colon                                            extends Delimiter(":")
   case object Semicolon                                        extends Delimiter(";")
-  case object Newline                                          extends Delimiter("\n")
+  case object Newline                                          extends Delimiter(System.lineSeparator())
   case object Space                                            extends Delimiter(" ")
 
   sealed abstract class Punctuator(override val lexeme: String) extends Token

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
@@ -1,0 +1,116 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft.ast
+
+sealed trait Token { self =>
+
+  def lexeme: String
+
+}
+
+object Token {
+
+  sealed abstract class Operator(override val lexeme: String) extends Token
+  case object Negative                                        extends Operator("-")
+  case object Positive                                        extends Operator("+")
+  case object Plus                                            extends Operator("+")
+  case object Minus                                           extends Operator("-")
+  case object Asterisk                                        extends Operator("*")
+  case object ForwardSlash                                    extends Operator("/")
+  case object DoubleForwardSlash                              extends Operator("//")
+  case object GreaterThan                                     extends Operator(">")
+  case object LessThan                                        extends Operator("<")
+  case object GreaterThanOrEqual                              extends Operator(">=")
+  case object LessThanOrEqual                                 extends Operator("<=")
+  case object Equal                                           extends Operator("=")
+  case object NotEqual                                        extends Operator("!=")
+  case object Exclamation                                     extends Operator("!")
+  case object Bar                                             extends Operator("|")
+  case object Ampersand                                       extends Operator("&")
+  case object Caret                                           extends Operator("^")
+  case object Percent                                         extends Operator("%")
+  case object ForwardArrow                                    extends Operator("->")
+  case object Or                                              extends Operator("||")
+  case object And                                             extends Operator("&&")
+
+  sealed abstract class Delimiter(override val lexeme: String) extends Token
+  case object OpenParen                                        extends Delimiter("(")
+  case object CloseParen                                       extends Delimiter(")")
+  case object OpenCurly                                        extends Delimiter("{")
+  case object CloseCurly                                       extends Delimiter("}")
+  case object OpenBracket                                      extends Delimiter("[")
+  case object BlockBracket                                     extends Delimiter("]")
+  case object Comma                                            extends Delimiter(",")
+  case object Dot                                              extends Delimiter(".")
+  case object Colon                                            extends Delimiter(":")
+  case object Semicolon                                        extends Delimiter(";")
+
+  sealed abstract class Punctuator(override val lexeme: String) extends Token
+  case object Hash                                              extends Punctuator("#")
+  case object Underscore                                        extends Punctuator("_")
+  case object At                                                extends Punctuator("@")
+  case object Tick                                              extends Punctuator("`")
+  case object Quote                                             extends Punctuator("\"")
+
+  sealed abstract class Data(override val lexeme: String) extends Token
+  case object Let                                         extends Data("let")
+  case object Mut                                         extends Data("mut")
+  case object Struct                                      extends Data("struct")
+  case object Const                                       extends Data("const")
+  case object Enum                                        extends Data("enum")
+
+  sealed abstract class Control(override val lexeme: String) extends Token
+  case object If                                             extends Control("if")
+  case object Else                                           extends Control("else")
+  case object While                                          extends Control("while")
+  case object Return                                         extends Control("return")
+  case object For                                            extends Control("for")
+
+  sealed abstract class AccessModifier(override val lexeme: String) extends Token
+  case object Pub                                                   extends AccessModifier("pub")
+
+  sealed abstract class Definition(override val lexeme: String) extends Token
+  case object Fn                                                extends Definition("fn")
+  case object Event                                             extends Definition("event")
+  case object Import                                            extends Definition("import")
+  case object Contract                                          extends Definition("Contract")
+  case object Abstract                                          extends Definition("Abstract")
+  case object TxScript                                          extends Definition("TxScript")
+  case object AssetScript                                       extends Definition("AssetScript")
+  case object Interface                                         extends Definition("Interface")
+
+  sealed abstract class Inheritance(override val lexeme: String) extends Token
+  case object Extends                                            extends Inheritance("extends")
+  case object Implements                                         extends Inheritance("implements")
+
+  sealed abstract class Native(override val lexeme: String) extends Token
+  case object Using                                         extends Native("using")
+  case object Emit                                          extends Native("emit")
+  case object Embeds                                        extends Native("embeds")
+
+  sealed abstract class Primitive(override val lexeme: String) extends Token
+  case object True                                             extends Primitive("true")
+  case object False                                            extends Primitive("false")
+  case object Alph_Small                                       extends Primitive("alph")
+  case object Alph_Big                                         extends Primitive("ALPH")
+
+  sealed trait Term                        extends Token
+  case class Name(lexeme: String)          extends Term
+  case class NumberLiteral(lexeme: String) extends Term
+  case class StringLiteral(lexeme: String) extends Term
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommentSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommentSpec.scala
@@ -1,0 +1,98 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class CommentSpec extends AnyWordSpec with Matchers {
+
+  "no comment text" should {
+    "store empty comment" in {
+      val comment =
+        parseComment("//")
+
+      val expected =
+        SoftAST.Comment(
+          index = indexOf(">>//<<"),
+          doubleForwardSlash = SoftAST.DoubleForwardSlash(indexOf(">>//<<")),
+          space = None,
+          text = None
+        )
+
+      comment shouldBe expected
+    }
+  }
+
+  "space as comment" should {
+    "store the space and empty comment" in {
+      val comment =
+        parseComment("// ")
+
+      val expected =
+        SoftAST.Comment(
+          index = indexOf(">>// <<"),
+          doubleForwardSlash = SoftAST.DoubleForwardSlash(indexOf(">>//<< ")),
+          space = Some(SoftAST.Space(" ", indexOf("//>> <<"))),
+          text = None
+        )
+
+      comment shouldBe expected
+    }
+  }
+
+  "text as comment" should {
+    "store the space and the comment" in {
+      val comment =
+        parseComment("// my comment")
+
+      val expected =
+        SoftAST.Comment(
+          index = indexOf(">>// my comment<<"),
+          doubleForwardSlash = SoftAST.DoubleForwardSlash(indexOf(">>//<< my comment")),
+          space = Some(SoftAST.Space(" ", indexOf("//>> <<my comment"))),
+          text = Some(SoftAST.Text("my comment", indexOf("// >>my comment<<")))
+        )
+
+      comment shouldBe expected
+    }
+  }
+
+  "code as comment" should {
+    "not parse the comment as code, but as text" in {
+      val code =
+        "// fn function()"
+
+      val comment =
+        parseComment(code)
+
+      val expected =
+        SoftAST.Comment(
+          index = indexOf(s">>$code<<"),
+          doubleForwardSlash = SoftAST.DoubleForwardSlash(indexOf(">>//<< fn function()")),
+          space = Some(SoftAST.Space(" ", indexOf("//>> <<fn function()"))),
+          text = Some(SoftAST.Text("fn function()", indexOf("// >>fn function()<<")))
+        )
+
+      comment shouldBe expected
+    }
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FnDecelerationSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FnDecelerationSpec.scala
@@ -1,0 +1,149 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class FnDecelerationSpec extends AnyWordSpec with Matchers {
+
+  "report missing function identifier" when {
+    "without spaces" in {
+      val function =
+        parseFunction("fn")
+
+      function.fn shouldBe SoftAST.Fn(indexOf(">>fn<<"))
+      function.preSignatureSpace shouldBe SoftAST.SpaceExpected(indexOf("fn>><<"))
+      function.postSignatureSpace shouldBe empty
+      function.block shouldBe empty
+    }
+
+    "with head space" in {
+      val functions =
+        parseSoft(" fn")
+          .parts
+          .map(_.part)
+          .collect {
+            case function: SoftAST.Function =>
+              function
+          }
+
+      functions should have size 1
+      val function = functions.head
+
+      function.fn shouldBe SoftAST.Fn(indexOf(s" >>fn<<"))
+      function.preSignatureSpace shouldBe SoftAST.SpaceExpected(indexOf(s" fn>><<"))
+      function.postSignatureSpace shouldBe empty
+      function.block shouldBe empty
+    }
+
+    "with tail space" in {
+      val function =
+        parseFunction("fn  ")
+
+      function.fn shouldBe SoftAST.Fn(indexOf(s">>fn<< "))
+      function.preSignatureSpace shouldBe SoftAST.Space("  ", indexOf(s"fn>>  <<"))
+      function.postSignatureSpace shouldBe empty
+      function.block shouldBe empty
+    }
+
+    "unresolved tail code" in {
+      val (blahIndex, code) =
+        indexCodeOf {
+          """fn function() -> ABC
+            |>>blah<<
+            |""".stripMargin
+        }
+
+      val body =
+        parseSoft(code)
+
+      val allUnresolved =
+        body
+          .parts
+          .map(_.part)
+          .collect {
+            case unresolved: SoftAST.Unresolved =>
+              unresolved
+          }
+
+      allUnresolved should have size 1
+      val actual = allUnresolved.last
+
+      val expected =
+        SoftAST.Unresolved(
+          code = "blah",
+          index = blahIndex
+        )
+
+      actual shouldBe expected
+    }
+
+    "within another function with invalid syntax" in {
+      val root =
+        parseSoft {
+          """fn function(
+            |  fn
+            |}
+            |""".stripMargin
+        }
+
+      val (functions, unresolved) =
+        root
+          .parts
+          .map(_.part)
+          .collect {
+            case function: SoftAST.Function =>
+              Left(function)
+
+            case unresolved: SoftAST.Unresolved =>
+              Right(unresolved)
+          }
+          .partitionMap(identity)
+
+      /**
+       * Test function
+       */
+      functions should have size 1
+      val function = functions.head
+      function.signature.fnName shouldBe
+        SoftAST.Identifier(
+          code = "function",
+          index = indexOf("fn >>function<<")
+        )
+
+      /**
+       * Test Unresolved
+       */
+      unresolved should have size 1
+      unresolved.head shouldBe
+        SoftAST.Unresolved(
+          code = "}",
+          index = indexOf {
+            """fn function(
+              |  fn
+              |>>}<<
+              |""".stripMargin
+          }
+        )
+    }
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionBlockSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionBlockSpec.scala
@@ -1,0 +1,60 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.OptionValues._
+
+class FunctionBlockSpec extends AnyWordSpec with Matchers {
+
+  "function name is not defined" when {
+    "block is defined" when {
+      "block is empty" in {
+        val function = parseFunction("fn {}")
+        // the block '{}' is parsed even though a lot of the function signature is missing, e.g., function name.
+        val block = function.block.value
+        block.index shouldBe indexOf("fn >>{}<<")
+        block.body shouldBe SoftAST.BlockBody(indexOf("fn {>><<}"), None, Seq.empty)
+      }
+
+      "block contains a space" in {
+        val function = parseFunction("fn -> { }")
+        // the block '{ }' is parsed even though a lot of the function signature is missing.
+        val block = function.block.value
+        block.index shouldBe indexOf("fn -> >>{ }<<")
+        block.body shouldBe SoftAST.BlockBody(indexOf("fn -> { >><<}"), None, Seq.empty)
+      }
+    }
+
+    "closing curly is missing" in {
+      val function =
+        parseFunction("fn {")
+
+      // even with error syntax, the block still gets parsed, reporting the missing closing curly brace
+      val block = function.block.value
+      block.index shouldBe indexOf("fn >>{<<")
+      block.body shouldBe SoftAST.BlockBody(indexOf("fn {>><<"), None, Seq.empty)
+      block.closeCurly shouldBe SoftAST.CloseCurlyExpected(indexOf("fn {>><<"))
+    }
+
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionNameSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionNameSpec.scala
@@ -1,0 +1,182 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class FunctionNameSpec extends AnyWordSpec with Matchers {
+
+  "lowercase function name" in {
+    val function =
+      parseFunction("fn function")
+
+    function.signature.fnName shouldBe
+      SoftAST.Identifier(
+        code = "function",
+        index = indexOf("fn >>function<<")
+      )
+  }
+
+  "randomly cased function name" in {
+    val function =
+      parseFunction("fn _FnUc_TiOn_")
+
+    function.signature.fnName shouldBe
+      SoftAST.Identifier(
+        code = "_FnUc_TiOn_",
+        index = indexOf("fn >>_FnUc_TiOn_<<")
+      )
+  }
+
+  "spaces before and after function name" in {
+    val function =
+      parseFunction("fn       _FnUc_TiOn_        ")
+
+    function.preSignatureSpace shouldBe SoftAST.Space("       ", indexOf("fn>>       <<_FnUc_TiOn_        "))
+
+    function.signature.fnName shouldBe
+      SoftAST.Identifier(
+        code = "_FnUc_TiOn_",
+        index = indexOf("fn       >>_FnUc_TiOn_<<        ")
+      )
+
+    function.signature.preParamSpace should contain(SoftAST.Space("        ", indexOf("fn       _FnUc_TiOn_>>        <<")))
+  }
+
+  "unresolved characters after function name" in {
+    val function =
+      parseFunction("fn abcd efgh ijk")
+
+    val expected =
+      SoftAST.Identifier(
+        code = "abcd",
+        index = indexOf("fn >>abcd<< efgh ijk")
+      )
+
+    function.signature.fnName shouldBe expected
+  }
+
+  "random characters and symbols after function name" in {
+    val root =
+      parseSoft("fn abcd *YNKJ BUP(*P")
+
+    val (functions, unresolved) =
+      root
+        .parts
+        .map(_.part)
+        .collect {
+          case function: SoftAST.Function =>
+            Left(function)
+
+          case unresolve: SoftAST.Unresolved =>
+            Right(unresolve)
+        }
+        .partitionMap(identity)
+
+    /**
+     * Test function
+     */
+    functions should have size 1
+    val function = functions.head
+    function.signature.fnName shouldBe
+      SoftAST.Identifier(
+        code = "abcd",
+        index = indexOf("fn >>abcd<< *YNKJ BUP(*P")
+      )
+
+    /**
+     * Test Unresolved
+     */
+    unresolved should have size 2
+    // head unresolved
+    unresolved.head shouldBe
+      SoftAST.Unresolved(
+        code = "*YNKJ",
+        index = indexOf("fn abcd >>*YNKJ<< BUP(*P")
+      )
+    // last unresolved
+    unresolved.last shouldBe
+      SoftAST.Unresolved(
+        code = "BUP(*P",
+        index = indexOf("fn abcd *YNKJ >>BUP(*P<<")
+      )
+  }
+
+  "random spaces before and after function name" in {
+    val function =
+      parseFunction {
+        """fn
+          |
+          |abcd
+          |
+          |
+          |efgh ijk
+          |
+          |LMNO
+          |""".stripMargin
+      }
+
+    function.signature.fnName shouldBe
+      SoftAST.Identifier(
+        code = "abcd",
+        index = indexOf("""fn
+            |
+            |>>abcd<<
+            |""".stripMargin)
+      )
+
+  }
+
+  "missing closing parentheses" in {
+    val function =
+      parseFunction("fn abcd(")
+
+    function.signature.fnName shouldBe
+      SoftAST.Identifier(
+        code = "abcd",
+        index = indexOf("fn >>abcd<<(")
+      )
+
+    function
+      .signature
+      .params
+      .asInstanceOf[SoftAST.NonEmptyParameterClause]
+      .closeParen shouldBe SoftAST.CloseParenExpected(indexOf("fn abcd(>><<"))
+  }
+
+  "missing opening parentheses" in {
+    val function =
+      parseFunction("fn abcd)")
+
+    function.signature.fnName shouldBe
+      SoftAST.Identifier(
+        code = "abcd",
+        index = indexOf("fn >>abcd<<)")
+      )
+
+    function
+      .signature
+      .params
+      .asInstanceOf[SoftAST.NonEmptyParameterClause]
+      .openParen shouldBe SoftAST.OpenParenExpected(indexOf("fn abcd>><<)"))
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionReturnClauseSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionReturnClauseSpec.scala
@@ -1,0 +1,227 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
+
+  "function name is not defined" when {
+    "arrow is defined" in {
+      val function =
+        parseFunction("fn -> ")
+
+      function.signature.returned shouldBe
+        SoftAST.FunctionReturn(
+          index = indexOf("fn >>-> <<"),
+          forwardArrow = SoftAST.ForwardArrow(indexOf("fn >>-><< ")),
+          space = Some(SoftAST.Space(" ", indexOf("fn __>> <<"))),
+          tpe = SoftAST.TypeExpected(indexOf("fn -> >><<"))
+        )
+    }
+
+    "arrow and type are defined" in {
+      val function =
+        parseFunction("fn -> type")
+
+      function.signature.returned shouldBe
+        SoftAST.FunctionReturn(
+          index = indexOf("fn >>-> type<<"),
+          forwardArrow = SoftAST.ForwardArrow(indexOf("fn >>-><< type")),
+          space = Some(SoftAST.Space(" ", indexOf("fn __>> <<type"))),
+          tpe = SoftAST.Type("type", indexOf("fn -> >>type<<"))
+        )
+    }
+  }
+
+  "function name is defined without parameter parens" when {
+    "arrow is defined" in {
+      val function =
+        parseFunction("fn function -> ")
+
+      function.signature.fnName shouldBe
+        SoftAST.Identifier(
+          code = "function",
+          index = indexOf("fn >>function<< -> ")
+        )
+
+      function.signature.returned shouldBe
+        SoftAST.FunctionReturn(
+          index = indexOf("fn function >>-> <<"),
+          forwardArrow = SoftAST.ForwardArrow(indexOf("fn function >>-><< ")),
+          space = Some(SoftAST.Space(" ", indexOf("fn function __>> <<"))),
+          tpe = SoftAST.TypeExpected(indexOf("fn function -> >><<"))
+        )
+    }
+
+    "arrow and type are defined" in {
+      val function =
+        parseFunction("fn function -> type")
+
+      function.signature.fnName shouldBe
+        SoftAST.Identifier(
+          code = "function",
+          index = indexOf("fn >>function<< -> ")
+        )
+
+      function.signature.returned shouldBe
+        SoftAST.FunctionReturn(
+          index = indexOf("fn function >>-> type<<"),
+          forwardArrow = SoftAST.ForwardArrow(indexOf("fn function >>-><< type")),
+          space = Some(SoftAST.Space(" ", indexOf("fn function __>> <<type"))),
+          tpe = SoftAST.Type("type", indexOf("fn function -> >>type<<"))
+        )
+    }
+  }
+
+  "function name is defined with only the parameter open parens" when {
+    "arrow is defined" in {
+      val function =
+        parseFunction("fn function(-> ")
+
+      function.signature.fnName shouldBe
+        SoftAST.Identifier(
+          code = "function",
+          index = indexOf("fn >>function<<(-> ")
+        )
+
+      val params = function.signature.params.asInstanceOf[SoftAST.NonEmptyParameterClause]
+      params.openParen shouldBe SoftAST.OpenParen(indexOf("fn function>>(<<-> "))
+      params.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("fn function(>><<-> "))
+
+      function.signature.returned shouldBe
+        SoftAST.FunctionReturn(
+          index = indexOf("fn function(>>-> <<"),
+          forwardArrow = SoftAST.ForwardArrow(indexOf("fn function(>>-><< ")),
+          space = Some(SoftAST.Space(" ", indexOf("fn function(__>> <<"))),
+          tpe = SoftAST.TypeExpected(indexOf("fn function(-> >><<"))
+        )
+    }
+
+    "arrow and type are defined" in {
+      val function =
+        parseFunction("fn function(-> Type")
+
+      function.signature.fnName shouldBe
+        SoftAST.Identifier(
+          code = "function",
+          index = indexOf("fn >>function<<(-> Type")
+        )
+
+      val params = function.signature.params.asInstanceOf[SoftAST.NonEmptyParameterClause]
+      params.openParen shouldBe SoftAST.OpenParen(indexOf("fn function>>(<<-> Type"))
+      params.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("fn function(>><<-> Type"))
+
+      function.signature.returned shouldBe
+        SoftAST.FunctionReturn(
+          index = indexOf("fn function(>>-> Type<<"),
+          forwardArrow = SoftAST.ForwardArrow(indexOf("fn function(>>-><< Type")),
+          space = Some(SoftAST.Space(" ", indexOf("fn function(__>> <<Type"))),
+          tpe = SoftAST.Type("Type", indexOf("fn function(-> >>Type<<"))
+        )
+
+    }
+  }
+
+  "function name is defined with parameter open parens" when {
+    "arrow is defined" in {
+      val function =
+        parseFunction("fn function() -> ")
+
+      function.signature.fnName shouldBe
+        SoftAST.Identifier(
+          code = "function",
+          index = indexOf("fn >>function<<() -> ")
+        )
+
+      val params = function.signature.params.asInstanceOf[SoftAST.EmptyParameterClause]
+      params.openParen shouldBe SoftAST.OpenParen(indexOf("fn function>>(<<) -> "))
+      params.closeParen shouldBe SoftAST.CloseParen(indexOf("fn function(>>)<< -> "))
+
+      function.signature.returned shouldBe
+        SoftAST.FunctionReturn(
+          index = indexOf("fn function() >>-> <<"),
+          forwardArrow = SoftAST.ForwardArrow(indexOf("fn function() >>-><< ")),
+          space = Some(SoftAST.Space(" ", indexOf("fn function() __>> <<"))),
+          tpe = SoftAST.TypeExpected(indexOf("fn function() -> >><<"))
+        )
+    }
+
+    "arrow and type are defined" in {
+      val function =
+        parseFunction("fn function() -> type")
+
+      function.signature.fnName shouldBe
+        SoftAST.Identifier(
+          code = "function",
+          index = indexOf("fn >>function<<() -> type")
+        )
+
+      val params = function.signature.params.asInstanceOf[SoftAST.EmptyParameterClause]
+      params.openParen shouldBe SoftAST.OpenParen(indexOf("fn function>>(<<) -> type"))
+      params.closeParen shouldBe SoftAST.CloseParen(indexOf("fn function(>>)<< -> type"))
+
+      function.signature.returned shouldBe
+        SoftAST.FunctionReturn(
+          index = indexOf("fn function() >>-> type<<"),
+          forwardArrow = SoftAST.ForwardArrow(indexOf("fn function() >>-><< type")),
+          space = Some(SoftAST.Space(" ", indexOf("fn function() __>> <<type"))),
+          tpe = SoftAST.Type("type", indexOf("fn function() -> >>type<<"))
+        )
+    }
+
+  }
+
+  "invalid function return signature" in {
+    val block =
+      parseSoft("fn function() => ABC")
+
+    block.parts should have size 3
+
+    /**
+     * First part is [[SoftAST.Function]]
+     */
+    val function = block.parts.head.part.asInstanceOf[SoftAST.Function]
+
+    function.signature.fnName shouldBe
+      SoftAST.Identifier(
+        code = "function",
+        index = indexOf("fn >>function<<() => ABC")
+      )
+
+    val params = function.signature.params.asInstanceOf[SoftAST.EmptyParameterClause]
+    params.openParen shouldBe SoftAST.OpenParen(indexOf("fn function>>(<<) => ABC"))
+    params.closeParen shouldBe SoftAST.CloseParen(indexOf("fn function(>>)<< => ABC"))
+
+    /**
+     * Second part is [[SoftAST.Unresolved]] arrow `=>`
+     */
+    val unresolvedArrow = block.parts(1).part.asInstanceOf[SoftAST.Unresolved]
+    unresolvedArrow shouldBe SoftAST.Unresolved("=>", indexOf("fn function() >>=><< ABC"))
+
+    /**
+     * Third part is [[SoftAST.Unresolved]] token `ABC`
+     */
+    val unresolvedToken = block.parts(2).part.asInstanceOf[SoftAST.Unresolved]
+    unresolvedToken shouldBe SoftAST.Unresolved("ABC", indexOf("fn function() => >>ABC<<"))
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ParameterSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ParameterSpec.scala
@@ -1,0 +1,137 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.OptionValues._
+
+class ParameterSpec extends AnyWordSpec with Matchers {
+
+  "missing opening paren" in {
+    val parameter = parseParameter(")").asInstanceOf[SoftAST.NonEmptyParameterClause]
+
+    parameter.openParen shouldBe SoftAST.OpenParenExpected(indexOf(">><<)"))
+    parameter.closeParen shouldBe SoftAST.CloseParen(indexOf(">>)<<"))
+  }
+
+  "missing closing paren" in {
+    val parameter = parseParameter("(").asInstanceOf[SoftAST.NonEmptyParameterClause]
+
+    parameter.openParen shouldBe SoftAST.OpenParen(indexOf(">>(<<"))
+    parameter.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("(>><<"))
+  }
+
+  "no parameters" when {
+    "without spaces" in {
+      val parameter = parseParameter("()")
+
+      val expected =
+        SoftAST.EmptyParameterClause(
+          index = indexOf(">>()<<"),
+          openParen = SoftAST.OpenParen(indexOf(">>(<<)")),
+          preCloseParenSpace = None,
+          closeParen = SoftAST.CloseParen(indexOf("(>>)<<)"))
+        )
+
+      parameter shouldBe expected
+    }
+
+    "with spaces" in {
+      val parameter = parseParameter("( )")
+
+      val expected =
+        SoftAST.EmptyParameterClause(
+          index = indexOf(">>( )<<"),
+          openParen = SoftAST.OpenParen(indexOf(">>(<< )")),
+          preCloseParenSpace = Some(SoftAST.Space(" ", indexOf("(>> <<)"))),
+          closeParen = SoftAST.CloseParen(indexOf("( >>)<<)"))
+        )
+
+      parameter shouldBe expected
+    }
+  }
+
+  "error parameter exist" in {
+    val parameter = parseParameter("(aaa typename").asInstanceOf[SoftAST.NonEmptyParameterClause]
+
+    parameter.openParen shouldBe SoftAST.OpenParen(indexOf(">>(<<aaa typename"))
+    parameter.headParam.paramName shouldBe SoftAST.Identifier("aaa", indexOf("(>>aaa<< typename"))
+    parameter.headParam.colon shouldBe SoftAST.ColonExpected(indexOf("(aaa >><<typename"))
+
+    parameter.headParam.paramType shouldBe
+      SoftAST.Type(
+        code = "typename",
+        index = indexOf("(aaa >>typename<<")
+      )
+
+    parameter.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("(aaa typename>><<"))
+  }
+
+  "valid parameter exist" in {
+    val parameter = parseParameter("(aaa: typename)").asInstanceOf[SoftAST.NonEmptyParameterClause]
+
+    parameter.openParen shouldBe SoftAST.OpenParen(indexOf(">>(<<aaa: typename"))
+    parameter.headParam.paramName shouldBe SoftAST.Identifier("aaa", indexOf("(>>aaa<<: typename"))
+    parameter.headParam.colon shouldBe SoftAST.Colon(indexOf("(aaa>>:<< typename"))
+
+    parameter.headParam.postColonSpace.value shouldBe SoftAST.Space(" ", indexOf("(aaa:>> <<typename"))
+
+    parameter.headParam.paramType shouldBe
+      SoftAST.Type(
+        code = "typename",
+        index = indexOf("(aaa: >>typename<<")
+      )
+
+    parameter.closeParen shouldBe SoftAST.CloseParen(indexOf("(aaa: typename>>)<<"))
+  }
+
+  "second parameter exists" in {
+    val result = parseParameter("(aaa: typename, bbb: type2)").asInstanceOf[SoftAST.NonEmptyParameterClause]
+
+    result.tailParams should have size 1
+    val bbb = result.tailParams.head
+
+    bbb.preCommaSpace shouldBe empty
+    bbb.comma shouldBe SoftAST.Comma(indexOf("(aaa: typename>>,<< bbb: type2)"))
+    bbb.postCommaSpace.value shouldBe SoftAST.Space(" ", indexOf("(aaa: typename,>> <<bbb: type2)"))
+    bbb.parameter.paramName shouldBe SoftAST.Identifier("bbb", indexOf("(aaa: typename, >>bbb<<: type2)"))
+    bbb.parameter.paramType shouldBe
+      SoftAST.Type(
+        code = "type2",
+        index = indexOf("(aaa: typename, bbb: >>type2<<)")
+      )
+  }
+
+  "second parameter type is a tuple" in {
+    val result = parseParameter("(aaa: typename, bbb: (tuple1, tuple2))").asInstanceOf[SoftAST.NonEmptyParameterClause]
+
+    result.tailParams should have size 1
+    val bbb = result.tailParams.head
+
+    bbb.preCommaSpace shouldBe empty
+    bbb.comma shouldBe SoftAST.Comma(indexOf("(aaa: typename>>,<< bbb: (tuple1, tuple2))"))
+    bbb.postCommaSpace.value shouldBe SoftAST.Space(" ", indexOf("(aaa: typename,>> <<bbb: (tuple1, tuple2))"))
+    bbb.parameter.paramName shouldBe SoftAST.Identifier("bbb", indexOf("(aaa: typename, >>bbb<<: (tuple1, tuple2))"))
+    bbb.parameter.paramType shouldBe a[SoftAST.TupledType]
+    bbb.parameter.paramType.toCode() shouldBe "(tuple1, tuple2)"
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateSpec.scala
@@ -1,0 +1,259 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.OptionValues._
+
+class TemplateSpec extends AnyWordSpec with Matchers {
+
+  "parse template type" when {
+    def testTokenIsReportedUnresolved(templateToken: String) = {
+      val block = parseSoft(templateToken)
+
+      val expected =
+        SoftAST.BlockBody(
+          index = indexOf(s">>$templateToken<<"),
+          prePartsSpace = None,
+          parts = Seq(
+            SoftAST.BlockBodyPart(
+              index = indexOf(s">>$templateToken<<"),
+              part = SoftAST.Unresolved(templateToken, indexOf(s">>$templateToken<<")),
+              postPartSpace = None
+            )
+          )
+        )
+
+      block shouldBe expected
+    }
+
+    "Contract" when {
+      "camelcase" in {
+        val templateToken =
+          "Contract"
+
+        val template =
+          parseTemplate(templateToken)
+
+        template.index shouldBe indexOf(s">>$templateToken<<")
+        template.templateType shouldBe SoftAST.Contract(indexOf(s">>$templateToken<<"))
+        template.preIdentifierSpace shouldBe SoftAST.SpaceExpected(indexOf(s"$templateToken>><<"))
+        template.identifier shouldBe SoftAST.IdentifierExpected(indexOf(s"$templateToken>><<"))
+        template.preParamSpace shouldBe None
+        template.params shouldBe a[SoftAST.NonEmptyParameterClause] // TODO: This should default to Empty when parens are missing
+        template.postParamSpace shouldBe None
+        template.block.openCurly shouldBe SoftAST.OpenCurlyExpected(indexOf(s"$templateToken>><<"))
+        template.block.closeCurly shouldBe SoftAST.CloseCurlyExpected(indexOf(s"$templateToken>><<"))
+      }
+
+      "lowercase" in {
+        testTokenIsReportedUnresolved("contract")
+      }
+    }
+
+    "TxScript" when {
+      "camelcase" in {
+        val templateToken =
+          "TxScript"
+
+        val template =
+          parseTemplate(templateToken)
+
+        template.index shouldBe indexOf(s">>$templateToken<<")
+        template.templateType shouldBe SoftAST.TxScript(indexOf(s">>$templateToken<<"))
+        template.preIdentifierSpace shouldBe SoftAST.SpaceExpected(indexOf(s"$templateToken>><<"))
+        template.identifier shouldBe SoftAST.IdentifierExpected(indexOf(s"$templateToken>><<"))
+        template.preParamSpace shouldBe None
+        template.params shouldBe a[SoftAST.NonEmptyParameterClause] // TODO: This should default to Empty when parens are missing
+        template.postParamSpace shouldBe None
+        template.block.openCurly shouldBe SoftAST.OpenCurlyExpected(indexOf(s"$templateToken>><<"))
+        template.block.closeCurly shouldBe SoftAST.CloseCurlyExpected(indexOf(s"$templateToken>><<"))
+      }
+
+      "lowercase" in {
+        testTokenIsReportedUnresolved("txscript")
+      }
+    }
+  }
+
+  "parse template identifier" in {
+    val template =
+      parseTemplate("Contract mycontract")
+
+    template.identifier shouldBe SoftAST.Identifier("mycontract", indexOf("Contract >>mycontract<<"))
+  }
+
+  "parse params" when {
+    "open closing paren is missing" in {
+      val template =
+        parseTemplate("Contract mycontract(")
+
+      val params = template.params.asInstanceOf[SoftAST.NonEmptyParameterClause]
+      params.openParen shouldBe SoftAST.OpenParen(indexOf("Contract mycontract>>(<<"))
+      params.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("Contract mycontract(>><<"))
+    }
+
+    "params are empty" in {
+      val template =
+        parseTemplate("Contract mycontract( )")
+
+      val params = template.params.asInstanceOf[SoftAST.EmptyParameterClause]
+      params.preCloseParenSpace.value shouldBe SoftAST.Space(" ", indexOf("Contract mycontract(>> <<)"))
+    }
+  }
+
+  "parse block" when {
+    "open brace is missing" in {
+      val template =
+        parseTemplate("Contract mycontract }")
+
+      template.block.closeCurly shouldBe SoftAST.CloseCurly(indexOf("Contract mycontract >>}<<"))
+      template.block.openCurly shouldBe SoftAST.OpenCurlyExpected(indexOf("Contract mycontract >><<}"))
+    }
+
+    "close brace and identifier are missing" in {
+      val template =
+        parseTemplate("Contract {")
+
+      template.identifier shouldBe SoftAST.IdentifierExpected(indexOf("Contract >><<{"))
+      template.preIdentifierSpace shouldBe SoftAST.Space(" ", indexOf("Contract>> <<{"))
+      template.block.openCurly shouldBe SoftAST.OpenCurly(indexOf("Contract >>{<<"))
+      template.block.closeCurly shouldBe SoftAST.CloseCurlyExpected(indexOf("Contract {>><<"))
+    }
+
+    "a function is defined" in {
+      val template =
+        parseTemplate {
+          """Contract {
+            |  fn function( ->
+            |
+            |""".stripMargin
+        }
+
+      template.identifier shouldBe SoftAST.IdentifierExpected(indexOf("Contract >><<{"))
+      template.preIdentifierSpace shouldBe SoftAST.Space(" ", indexOf("Contract>> <<{"))
+      // block
+      template.block.openCurly shouldBe SoftAST.OpenCurly(indexOf("Contract >>{<<"))
+      template.block.closeCurly shouldBe
+        SoftAST.CloseCurlyExpected(
+          indexOf("""Contract {
+              |  fn function( ->
+              |
+              |>><<""".stripMargin)
+        )
+
+      /**
+       * Body part: Function
+       */
+      template.block.body.parts should have size 1
+      val function = template.block.body.parts.head.part.asInstanceOf[SoftAST.Function]
+
+      function.fn shouldBe
+        SoftAST.Fn(
+          indexOf("""Contract {
+              |  >>fn<< function( ->
+              |
+              |""".stripMargin)
+        )
+
+      function.signature.fnName shouldBe
+        SoftAST.Identifier(
+          "function",
+          indexOf("""Contract {
+                    |  fn >>function<<( ->
+                    |
+                    |""".stripMargin)
+        )
+    }
+
+    "a TxScript is defined within a Contract" in {
+      val template =
+        parseTemplate {
+          """Contract {
+            |  TxScript myScript
+            |
+            |""".stripMargin
+        }
+
+      template.identifier shouldBe SoftAST.IdentifierExpected(indexOf("Contract >><<{"))
+      template.preIdentifierSpace shouldBe SoftAST.Space(" ", indexOf("Contract>> <<{"))
+      // block
+      template.block.openCurly shouldBe SoftAST.OpenCurly(indexOf("Contract >>{<<"))
+      template.block.closeCurly shouldBe
+        SoftAST.CloseCurlyExpected(
+          indexOf("""Contract {
+                    |  TxScript myScript
+                    |
+                    |>><<""".stripMargin)
+        )
+
+      /**
+       * Body part: TxScript
+       */
+      template.block.body.parts should have size 1
+      val txScriptTemplate = template.block.body.parts.head.part.asInstanceOf[SoftAST.Template]
+
+      txScriptTemplate.templateType shouldBe
+        SoftAST.TxScript(
+          indexOf("""Contract {
+                    |  >>TxScript<< myScript
+                    |
+                    |""".stripMargin)
+        )
+
+      txScriptTemplate.identifier shouldBe
+        SoftAST.Identifier(
+          "myScript",
+          indexOf("""Contract {
+                    |  TxScript >>myScript<<
+                    |
+                    |""".stripMargin)
+        )
+    }
+
+    "an unresolved token is defined within a TxScript" in {
+      val template =
+        parseTemplate {
+          """Contract MyContract {
+            |  blah
+            |
+            |""".stripMargin
+        }
+
+      /**
+       * Body part: TxScript
+       */
+      template.block.body.parts should have size 1
+      val part = template.block.body.parts.head.part
+
+      part shouldBe
+        SoftAST.Unresolved(
+          "blah",
+          indexOf("""Contract MyContract {
+                    |  >>blah<<
+                    |
+                    |""".stripMargin)
+        )
+
+    }
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
@@ -1,0 +1,91 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse.{P, Parsed}
+import org.alephium.ralph.lsp.access.compiler.message.error.FastParseError
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.scalatest.matchers.should.Matchers._
+
+object TestParser {
+
+  def parseSoft(code: String): SoftAST.BlockBody =
+    runParser(SoftParser.parse(_))(code)
+
+  def parseTemplate(code: String): SoftAST.Template =
+    runParser(TemplateParser.parse(_))(code)
+
+  def parseFunction(code: String): SoftAST.Function =
+    runParser(FunctionParser.parse(_))(code)
+
+  def parseParameter(code: String): SoftAST.ParameterClauseAST =
+    runParser(ParameterParser.parse(_))(code)
+
+  def parseBlockClause(mandatory: Boolean)(code: String): SoftAST.BlockClause =
+    runParser(BlockParser.clause(mandatory)(_))(code)
+
+  def parseBlockBody(code: String): SoftAST.BlockBody =
+    runParser(BlockParser.body(_))(code)
+
+  def parseComment(code: String): SoftAST.Comment =
+    runParser(CommentParser.parse(_))(code)
+
+  def parseType(code: String): SoftAST.TypeAST =
+    runParser(TypeParser.parse(_))(code)
+
+  private def runParser[T <: SoftAST](parser: P[_] => P[T])(code: String): T = {
+    // invoke .get to ensure that the parser should NEVER fail
+    val result =
+      fastparse.parse(code, parser) match {
+        case Parsed.Success(ast, _) =>
+          Right(ast)
+
+        case failure: Parsed.Failure =>
+          Left(FastParseError(failure))
+      }
+
+    val ast =
+      result match {
+        case Left(error) =>
+          // Print a formatted error so it's easier to debug.
+          fail(error.error.toFormatter().format(Some(Console.RED)))
+
+        case Right(ast) =>
+          ast
+      }
+
+    val astToCode =
+      ast.toCode()
+
+    // AST returned by the parser should ALWAYS emit code identical to the inputted code.
+    // Always assert this for each test case.
+    try
+      code shouldBe astToCode
+    catch {
+      case throwable: Throwable =>
+        // Print debug info for cases where the emitted code differs from the input code.
+        println("Input Code:")
+        println(code)
+        println("\nAST to Code:")
+        println(astToCode)
+        throw throwable
+    }
+
+    ast
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeParserSpec.scala
@@ -1,0 +1,106 @@
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class TypeParserSpec extends AnyWordSpec with Matchers {
+
+  "type expected" when {
+    "empty" in {
+      parseType("") shouldBe SoftAST.TypeExpected(indexOf(">><<"))
+    }
+  }
+
+  "type is provided" in {
+    parseType("one") shouldBe SoftAST.Type("one", indexOf(">>one<<"))
+  }
+
+  "tuple 1" when {
+    "closing parentheses is missing" in {
+      val tpe = parseType("( one")
+
+      val expected =
+        SoftAST.TupledType(
+          index = indexOf(">>( one<<"),
+          openParen = SoftAST.OpenParen(indexOf(">>(<< one")),
+          preHeadTypeSpace = Some(SoftAST.Space(" ", indexOf("(>> <<one"))),
+          headType = SoftAST.Type("one", indexOf("( >>one<<")),
+          tailTypes = Seq.empty,
+          closeParen = SoftAST.CloseParenExpected(indexOf("( one>><<"))
+        )
+
+      tpe shouldBe expected
+    }
+
+    "closing parentheses is provided" in {
+      val tpe = parseType("( one)")
+
+      val expected =
+        SoftAST.TupledType(
+          index = indexOf(">>( one)<<"),
+          openParen = SoftAST.OpenParen(indexOf(">>(<< one)")),
+          preHeadTypeSpace = Some(SoftAST.Space(" ", indexOf("(>> <<one)"))),
+          headType = SoftAST.Type("one", indexOf("( >>one<<)")),
+          tailTypes = Seq.empty,
+          closeParen = SoftAST.CloseParen(indexOf("( one>>)<<"))
+        )
+
+      tpe shouldBe expected
+    }
+  }
+
+  "tuple 2" when {
+    "second type is missing" in {
+      val tpe = parseType("(one, )").asInstanceOf[SoftAST.TupledType]
+
+      tpe.tailTypes should have size 1
+      val secondType = tpe.tailTypes.head
+
+      val expected =
+        SoftAST.TailType(
+          index = indexOf("(one>>, <<)"),
+          comma = SoftAST.Comma(indexOf("(one>>,<< )")),
+          preTypeNameSpace = Some(SoftAST.Space(" ", indexOf("(one,>> <<)"))),
+          tpe = SoftAST.TypeExpected(indexOf("(one, >><<)")),
+          postTypeNameSpace = None
+        )
+
+      secondType shouldBe expected
+    }
+
+    "second type is a simple type name" in {
+      val tpe = parseType("(one, two)").asInstanceOf[SoftAST.TupledType]
+
+      tpe.tailTypes should have size 1
+      val secondType = tpe.tailTypes.head
+
+      val expected =
+        SoftAST.TailType(
+          index = indexOf("(one>>, two<<)"),
+          comma = SoftAST.Comma(indexOf("(one>>,<< two)")),
+          preTypeNameSpace = Some(SoftAST.Space(" ", indexOf("(one,>> <<two)"))),
+          tpe = SoftAST.Type(
+            code = "two",
+            index = indexOf("(one, >>two<<)")
+          ),
+          postTypeNameSpace = None
+        )
+
+      secondType shouldBe expected
+    }
+
+    "second type is another tuple" in {
+      val tpe = parseType("(one, (two, three))").asInstanceOf[SoftAST.TupledType]
+
+      tpe.tailTypes should have size 1
+      val tailType = tpe.tailTypes.head
+      tailType.tpe shouldBe a[SoftAST.TupledType]
+      tailType.tpe.toCode() shouldBe "(two, three)"
+    }
+
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/util/TestCodeUtil.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/util/TestCodeUtil.scala
@@ -16,7 +16,8 @@
 
 package org.alephium.ralph.lsp.access.util
 
-import org.alephium.ralph.lsp.access.compiler.message.{LinePosition, LineRange}
+import org.alephium.ralph.SourceIndex
+import org.alephium.ralph.lsp.access.compiler.message.{LinePosition, LineRange, SourceIndexExtra}
 import org.scalatest.Assertions.fail
 
 object TestCodeUtil {
@@ -90,6 +91,33 @@ object TestCodeUtil {
       case None =>
         fail(s"Location indicator '$SEARCH_INDICATOR' not provided")
     }
+  }
+
+  /**
+   * Extracts the [[SourceIndex]] of the substring the extracted [[SourceIndex]].
+   *
+   * @param code the input string containing the tokens `>>` and `<<`
+   * @return [[SourceIndex]] of the substring between the tokens `>>` and `<<`
+   */
+  def indexOf(code: String): SourceIndex =
+    indexCodeOf(code)._1
+
+  /**
+   * Extracts the [[SourceIndex]] for the substring between the tokens `>>` and `<<`
+   * and returns a tuple containing the extracted [[SourceIndex]] and the code
+   * with the `>>` and `<<` tokens removed.
+   *
+   * @param code String containing the tokens `>>` and `<<`.
+   * @return A tuple where:
+   *          - The first element is the [[SourceIndex]] of the substring between the tokens `>>` and `<<`.
+   *          - The second element is the code with the `>>` and `<<` tokens removed.
+   */
+  def indexCodeOf(code: String): (SourceIndex, String) = {
+    val start              = code.indexOf(">>")
+    val codeWithoutStart   = code.replaceFirst(">>", "")
+    val end                = codeWithoutStart.indexOf("<<")
+    val codeWithoutSymbols = codeWithoutStart.replaceFirst("<<", "")
+    (SourceIndexExtra.range(start, end), codeWithoutSymbols)
   }
 
 }

--- a/utils/src/main/scala/org/alephium/ralph/lsp/utils/Node.scala
+++ b/utils/src/main/scala/org/alephium/ralph/lsp/utils/Node.scala
@@ -157,4 +157,38 @@ case class Node[+A, B] private (
     else
       self.asInstanceOf[Node[C, B]]
 
+  /**
+   * Builds a string representation of the tree structure of the current [[Node]]
+   * and its children, formatted according to the provided function.
+   *
+   * @param format Converts a [[Node]] of type `B` into a displayable string format.
+   * @param tab    Number of spaces to use for indentation.
+   * @return String representing the tree structure.
+   */
+  def toStringTree(
+      format: B => String,
+      tab: Int = 2): String = {
+    def toStringTree(
+        node: Node[B, B],
+        index: Int): Seq[String] = {
+      val children =
+        node.children flatMap {
+          child =>
+            toStringTree(child, index + tab)
+        }
+
+      val spaces         = " " * index
+      val thisNodeString = spaces + format(node.data)
+      thisNodeString +: children
+    }
+
+    val strings =
+      toStringTree(
+        node = self.asInstanceOf[Node[B, B]],
+        index = 0
+      )
+
+    strings.mkString("\n")
+  }
+
 }


### PR DESCRIPTION
## Overview 

- Towards #104.
- Run [Demo.scala](https://github.com/alephium/ralph-lsp/blob/soft_parser/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala) to test the following properties of `SoftParser`.

## Syntax error-insensitive

`SoftParser` always generates an AST, even if the code contains syntax errors. This ensures that LSP APIs (jump-to-definition, code completion etc) are always available.

- **Multiple Errors**: The following screenshot is for demo only. It shows how multiple errors can be generated by a single parser run. These errors are required for "Code Actions" (no plans to replace errors reported by ralphc). It's also not tested yet, this version of the parser is only tested to ensure that an AST is always available. 
   ![image](https://github.com/user-attachments/assets/269f3ad0-6137-4255-92ec-9bc62fc6116f)
- **Unknown Tokens**: Unknown syntax tokens are stored as `Unresolved` in the Syntax Tree.
  ```scala
  Unresolved(code = 🚀, index = SourceIndex(113,2,None))
  ```

## Order-insensitive

The order of the code is not enforced. For example, the following code is parseable:

```rust
fn function() -> Bool {
   Contract MyContract() { }

   fn nestedFunction() -> ABC
}
```

## Releases & Incremental implementation

Being error-insensitive allows `SoftParser` to be implemented and integrated incrementally. For example, the following is valid Ralph code, but `let bool = true` is parsed as `Unresolved` by `SoftParser` because it does not recognise this syntax yet. 

```rust
fn function() -> Bool {
  let bool = true
}
```

- This ensures that any future changes to Ralph syntax in Node will not delay the release of `ralph-lsp` with the latest `Node` version.
- This also allows `SoftParser` to used by jump-definitions, code-completion etc, even though it is only partially implemented.

## Convert `SoftAST` to Code

`SoftAST` can always be converted back to the original string code using the `toCode()` method call:

```scala
val code: String = ast.toCode()
```

`toCode()` can be also be invoked on any sub-tree, resulting in code just for that tree. 

See [Demo.scala](https://github.com/alephium/ralph-lsp/blob/soft_parser/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala#L36).

## Formatting

- Towards #236
- Since the AST can be converted code, [text-document formatting requests](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_formatting) can be processed by updating the [`SoftAST.Space`](https://github.com/alephium/ralph-lsp/blob/soft_parser/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala#L284) instances within an `AST`.
- `SoftParser` does not enforce strict ordering. For example, `fn function()` is parsable even when it is not embedded within a `Contract` or `TxScript`. This allows the implementation of [on type formatting](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_onTypeFormatting).

## AST as `String`

Invoke the following to generate a String tree representation of the AST.

```scala
val tree: String = ast.toStringTree()
```

See [Demo.scala](https://github.com/alephium/ralph-lsp/blob/soft_parser/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala#L40).

## Next steps

- Pending documentation.
- Instead of implementing formatting as a new feature, I think we should integrate this parser into the currently implemented APIs, so that existing features are complete before implementing on new features. WDYT?
