### PR TITLE
Reference call parser

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ArgumentParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ArgumentParser.scala
@@ -1,0 +1,99 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse._
+import fastparse.NoWhitespace.noWhitespaceImplicit
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
+import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+
+private object ArgumentParser {
+
+  def parseOrFail[Unknown: P]: P[SoftAST.Arguments] =
+    P(arguments(required = false))
+
+  def parse[Unknown: P]: P[SoftAST.Arguments] =
+    P(arguments(required = true))
+
+  def parse[Unknown: P](required: Boolean): P[SoftAST.Arguments] =
+    P(arguments(required))
+
+  /**
+   * Parses a sequence of arguments enclosed within parentheses.
+   *
+   * Syntax: (arg1, arg2, (arg3, arg4), arg5)
+   *
+   * @param required Determines if the parser should fail when the opening parenthesis is missing.
+   * @return An instance of [[SoftAST.Arguments]].
+   */
+  private def arguments[Unknown: P](required: Boolean): P[SoftAST.Arguments] =
+    P(Index ~ TokenParser.openParen(required) ~ spaceOrFail.? ~ Index ~ tupledOrNamedOrFail.? ~ tailArgument.rep ~ TokenParser.closeParen ~ Index) map {
+      // if tail argument is provided, but head argument is missing, report the head argument as required
+      case (from, openParen, preHeadArgumentSpace, headArgumentIndex, None, tailArguments, closeParen, to) if tailArguments.nonEmpty =>
+        SoftAST.Arguments(
+          index = range(from, to),
+          openParen = openParen,
+          preHeadArgumentSpace = preHeadArgumentSpace,
+          headArgument = Some(SoftAST.ArgumentExpected(range(headArgumentIndex, headArgumentIndex))),
+          tailArguments = tailArguments,
+          closeParen = closeParen
+        )
+
+      case (from, openParen, preHeadArgumentSpace, _, headArgument, tailArguments, closeParen, to) =>
+        SoftAST.Arguments(
+          index = range(from, to),
+          openParen = openParen,
+          preHeadArgumentSpace = preHeadArgumentSpace,
+          headArgument = headArgument,
+          tailArguments = tailArguments,
+          closeParen = closeParen
+        )
+    }
+
+  /**
+   * Parses a "tail argument" which may contain nested arguments.
+   *
+   * Syntax: (arg1>>, arg2, (arg3, arg4), arg5<<)
+   *
+   * @return An instance of [[SoftAST.TailArgument]].
+   */
+  private def tailArgument[Unknown: P]: P[SoftAST.TailArgument] =
+    P(Index ~ TokenParser.commaOrFail ~ spaceOrFail.? ~ tupledOrNamedExpected ~ spaceOrFail.? ~ Index) map {
+      case (from, comma, preArgumentNameSpace, argumentName, postArgumentNameSpace, to) =>
+        SoftAST.TailArgument(
+          index = range(from, to),
+          comma = comma,
+          preArgumentSpace = preArgumentNameSpace,
+          argument = argumentName,
+          postArgumentSpace = postArgumentNameSpace
+        )
+    }
+
+  private def tupledOrNamedExpected[Unknown: P]: P[SoftAST.ArgumentAST] =
+    P(Index ~ tupledOrNamedOrFail.? ~ Index) map {
+      case (_, Some(argument), _) =>
+        argument
+
+      case (from, None, to) =>
+        SoftAST.ArgumentExpected(range(from, to))
+    }
+
+  private def tupledOrNamedOrFail[Unknown: P]: P[SoftAST.NonEmptyArguments] =
+    P(parseOrFail | namedArgumentOrFail)
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
@@ -64,6 +64,7 @@ private object BlockParser {
     P {
       TemplateParser.parseOrFail |
         FunctionParser.parseOrFail |
+        ReferenceCallParser.parseOrFail |
         CommentParser.parseOrFail |
         unresolved(stopChars)
     }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommonParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommonParser.scala
@@ -77,7 +77,7 @@ private object CommonParser {
         SoftAST.IdentifierExpected(range(from, to))
     }
 
-  def identifierOrFail[Unknown: P]: P[SoftAST.IdentifierAST] =
+  def identifierOrFail[Unknown: P]: P[SoftAST.Identifier] =
     P(Index ~ isLetterDigitOrUnderscore.! ~ Index) map {
       case (from, identifier, to) =>
         SoftAST.Identifier(

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommonParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommonParser.scala
@@ -71,6 +71,15 @@ private object CommonParser {
         SoftAST.IdentifierExpected(range(from, to))
     }
 
+  def namedArgumentOrFail[Unknown: P]: P[SoftAST.Argument] =
+    P(Index ~ isLetterDigitOrUnderscore.! ~ Index) map {
+      case (from, argument, to) =>
+        SoftAST.Argument(
+          code = argument,
+          index = range(from, to)
+        )
+    }
+
   def typeName[Unknown: P]: P[SoftAST.SingleTypeAST] =
     P(Index ~ isLetterDigitOrUnderscore.!.? ~ Index) map {
       case (from, Some(typeName), to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommonParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommonParser.scala
@@ -59,6 +59,12 @@ private object CommonParser {
         )
     }
 
+  def identifier[Unknown: P](required: Boolean): P[SoftAST.IdentifierAST] =
+    if (required)
+      identifier
+    else
+      identifierOrFail
+
   def identifier[Unknown: P]: P[SoftAST.IdentifierAST] =
     P(Index ~ isLetterDigitOrUnderscore.!.? ~ Index) map {
       case (from, Some(identifier), to) =>
@@ -69,6 +75,15 @@ private object CommonParser {
 
       case (from, None, to) =>
         SoftAST.IdentifierExpected(range(from, to))
+    }
+
+  def identifierOrFail[Unknown: P]: P[SoftAST.IdentifierAST] =
+    P(Index ~ isLetterDigitOrUnderscore.! ~ Index) map {
+      case (from, identifier, to) =>
+        SoftAST.Identifier(
+          code = identifier,
+          index = range(from, to)
+        )
     }
 
   def namedArgumentOrFail[Unknown: P]: P[SoftAST.Argument] =

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala
@@ -10,10 +10,11 @@ object Demo extends App {
   val ast =
     compiler.parseSoft {
       """
-        |Contract HelloWorld(type: SomeType, tuple: (A, B)) {
+        |Contract HelloWorld(type: SomeType, tuple: (A, B)) extends Parent1(arg1, arg2) implements Parent2 {
         |
         |  fn function(nested_tuple: (A, (B, C))) -> ABC {
         |    // comment
+        |    function(arg1, (arg2, arg3))
         |  }
         |
         |  🚀

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReferenceCallParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReferenceCallParser.scala
@@ -1,0 +1,37 @@
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse._
+import fastparse.NoWhitespace.noWhitespaceImplicit
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
+import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+
+private object ReferenceCallParser {
+
+  def parse[Unknown: P]: P[SoftAST.ReferenceCall] =
+    referenceCall(required = true)
+
+  def parseOrFail[Unknown: P]: P[SoftAST.ReferenceCall] =
+    referenceCall(required = false)
+
+  /**
+   * Parses a function or object call along with its arguments [[ArgumentParser]].
+   *
+   * Syntax: reference(arg1, arg2, (arg3, arg4))
+   *
+   * @param required Determines if the parser should fail
+   *                 when the reference name or the opening parenthesis is missing.
+   * @return A parsed instance of [[SoftAST.ReferenceCall]].
+   */
+  private def referenceCall[Unknown: P](required: Boolean): P[SoftAST.ReferenceCall] =
+    P(Index ~ identifier(required) ~ spaceOrFail.? ~ ArgumentParser.parse(required) ~ Index) map {
+      case (from, identifier, space, arguments, to) =>
+        SoftAST.ReferenceCall(
+          index = range(from, to),
+          reference = identifier,
+          preArgumentsSpace = space,
+          arguments = arguments
+        )
+    }
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -32,6 +32,12 @@ private object TokenParser {
         SoftAST.ColonExpected(range(from, to))
     }
 
+  def openParen[Unknown: P](required: Boolean): P[SoftAST.OpenParenAST] =
+    if (required)
+      openParen
+    else
+      openParenOrFail
+
   def openParen[Unknown: P]: P[SoftAST.OpenParenAST] =
     P(Index ~ Token.OpenParen.lexeme.!.? ~ Index) map {
       case (from, Some(_), to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -137,4 +137,16 @@ private object TokenParser {
         SoftAST.Fn(range(from, to))
     }
 
+  def Implements[Unknown: P]: P[SoftAST.Implements] =
+    P(Index ~ Token.Implements.lexeme ~ Index) map {
+      case (from, to) =>
+        SoftAST.Implements(range(from, to))
+    }
+
+  def Extends[Unknown: P]: P[SoftAST.Extends] =
+    P(Index ~ Token.Extends.lexeme ~ Index) map {
+      case (from, to) =>
+        SoftAST.Extends(range(from, to))
+    }
+
 }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -233,6 +233,44 @@ object SoftAST {
       postTypeNameSpace: Option[Space])
     extends SoftAST
 
+  sealed trait ArgumentAST       extends SoftAST     // Syntax: (arg1, arg2, (arg3, arg4))
+  sealed trait NonEmptyArguments extends ArgumentAST // Does not contain `ArgumentExpected`
+  sealed trait SingleArgumentAST extends ArgumentAST // Does not contain multiple arguments
+
+  /** A named argument. Syntax: (arg1) */
+  case class Argument(
+      code: String,
+      index: SourceIndex)
+    extends SingleArgumentAST
+       with NonEmptyArguments
+       with CodeAST
+
+  /** Multiple arguments. Syntax: (arg1, (arg2, arg3)) */
+  case class Arguments(
+      index: SourceIndex,
+      openParen: OpenParenAST,
+      preHeadArgumentSpace: Option[Space],
+      headArgument: Option[ArgumentAST],
+      tailArguments: Seq[TailArgument],
+      closeParen: CloseParenAST)
+    extends NonEmptyArguments
+       with BodyPartAST
+
+  /** Missing argument. Syntax: (>>missing<<, (arg2, arg3)) */
+  case class ArgumentExpected(
+      index: SourceIndex)
+    extends ExpectedErrorAST("Argument")
+       with SingleArgumentAST
+
+  /** Syntax: (arg1, >>arg2, (arg3, arg4)<<) */
+  case class TailArgument(
+      index: SourceIndex,
+      comma: Comma,
+      preArgumentSpace: Option[Space],
+      argument: ArgumentAST,
+      postArgumentSpace: Option[Space])
+    extends SoftAST
+
   sealed trait FunctionReturnAST extends SoftAST
 
   case class FunctionReturn(

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -342,6 +342,20 @@ object SoftAST {
     extends ExpectedErrorAST("Space")
        with SpaceAST
 
+  /**
+   * TODO: Currently a reference is an identifier [[IdentifierAST]].
+   *       It should be replaced with an expression, when an `Expression`
+   *       type is available.
+   *
+   * Syntax: reference(arg1, arg2, (arg3, arg4))
+   */
+  case class ReferenceCall(
+      index: SourceIndex,
+      reference: IdentifierAST,
+      preArgumentsSpace: Option[Space],
+      arguments: Arguments)
+    extends BodyPartAST
+
   private def collectASTs: PartialFunction[Any, Seq[SoftAST]] = {
     case ast: SoftAST =>
       Seq(ast)

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ArgumentSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ArgumentSpec.scala
@@ -1,0 +1,185 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.EitherValues._
+
+class ArgumentSpec extends AnyWordSpec with Matchers {
+
+  "parseOrFail" should {
+    "fail" when {
+      "no open parens are provided" in {
+        // If an open paren is not provided, then the following syntax might now be an argument
+        val argument =
+          parseOrFailArgument("")
+            .left
+            .value
+
+        // this error message is from FastParse
+        argument.message shouldBe """Expected "(""""
+      }
+    }
+
+    "succeed" when {
+      "open parens is provided but argument is missing" in {
+        // if an open paren is provided, the syntax is for an argument.
+        // Tokens following `(` must be parsed
+        val argument =
+          parseOrFailArgument("(").value
+
+        argument.openParen shouldBe SoftAST.OpenParen(indexOf(">>(<<"))
+        argument.headArgument shouldBe empty
+        argument.tailArguments shouldBe empty
+        argument.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("(>><<"))
+      }
+    }
+  }
+
+  "parse" when {
+    "named arguments" when {
+      "single" when {
+        "missing closing paren" in {
+          val argument =
+            parseOrFailArgument("(one").value
+
+          argument.openParen shouldBe SoftAST.OpenParen(indexOf(">>(<<one"))
+          argument.headArgument shouldBe Some(SoftAST.Argument("one", indexOf("(>>one<<")))
+          argument.tailArguments shouldBe empty
+          argument.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("(one>><<"))
+        }
+
+        "closing paren is provided" in {
+          val argument =
+            parseOrFailArgument("(one)").value
+
+          argument.openParen shouldBe SoftAST.OpenParen(indexOf(">>(<<one)"))
+          argument.headArgument shouldBe Some(SoftAST.Argument("one", indexOf("(>>one<<)")))
+          argument.tailArguments shouldBe empty
+          argument.closeParen shouldBe SoftAST.CloseParen(indexOf("(one>>)<<"))
+        }
+      }
+
+      "multiple" when {
+        "missing closing paren" in {
+          val argument =
+            parseOrFailArgument("(one, two").value
+
+          argument.openParen shouldBe SoftAST.OpenParen(indexOf(">>(<<one, two"))
+          argument.headArgument shouldBe Some(SoftAST.Argument("one", indexOf("(>>one<<")))
+
+          argument.tailArguments should have size 1
+          argument.tailArguments.head shouldBe
+            SoftAST.TailArgument(
+              index = indexOf("(one>>, two<<"),
+              comma = SoftAST.Comma(indexOf("(one>>,<< two")),
+              preArgumentSpace = Some(SoftAST.Space(" ", indexOf("(one,>> <<two"))),
+              argument = SoftAST.Argument("two", indexOf("(one, >>two<<")),
+              postArgumentSpace = None
+            )
+
+          argument.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("(one, two>><<"))
+        }
+
+        "comma is provided but the argument is missing" when {
+          "second argument is missing" in {
+            val argument =
+              parseOrFailArgument("(one, ").value
+
+            argument.openParen shouldBe SoftAST.OpenParen(indexOf(">>(<<one, "))
+            argument.headArgument shouldBe Some(SoftAST.Argument("one", indexOf("(>>one<<")))
+
+            argument.tailArguments should have size 1
+            argument.tailArguments.head shouldBe
+              SoftAST.TailArgument(
+                index = indexOf("(one>>, <<"),
+                comma = SoftAST.Comma(indexOf("(one>>,<< ")),
+                preArgumentSpace = Some(SoftAST.Space(" ", indexOf("(one,>> <<"))),
+                argument = SoftAST.ArgumentExpected(indexOf("(one, >><<")),
+                postArgumentSpace = None
+              )
+
+            argument.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("(one, >><<"))
+          }
+
+          "first argument is missing" in {
+            val argument =
+              parseOrFailArgument("(, two").value
+
+            argument.openParen shouldBe SoftAST.OpenParen(indexOf(">>(<<, two"))
+            argument.headArgument shouldBe Some(SoftAST.ArgumentExpected(indexOf("(>><<, two")))
+
+            argument.tailArguments should have size 1
+            argument.tailArguments.head shouldBe
+              SoftAST.TailArgument(
+                index = indexOf("(>>, two<<"),
+                comma = SoftAST.Comma(indexOf("(>>,<< two")),
+                preArgumentSpace = Some(SoftAST.Space(" ", indexOf("(,>> <<two"))),
+                argument = SoftAST.Argument("two", indexOf("(, >>two<<")),
+                postArgumentSpace = None
+              )
+
+            argument.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("(, two>><<"))
+          }
+        }
+      }
+    }
+
+    "tupled arguments" when {
+      "missing closing paren" in {
+        val argument =
+          parseOrFailArgument("(one, (two, three))").value
+
+        argument.openParen shouldBe SoftAST.OpenParen(indexOf(">>(<<one, (two, three))"))
+        argument.headArgument shouldBe Some(SoftAST.Argument("one", indexOf("(>>one<<, (two, three))")))
+
+        argument.tailArguments should have size 1
+        argument.tailArguments.head shouldBe
+          SoftAST.TailArgument(
+            index = indexOf("(one>>, (two, three)<<)"),
+            comma = SoftAST.Comma(indexOf("(one>>,<< (two, three))")),
+            preArgumentSpace = Some(SoftAST.Space(" ", indexOf("(one,>> <<(two, three))"))),
+            argument = SoftAST.Arguments(
+              index = indexOf("(one, >>(two, three)<<)"),
+              openParen = SoftAST.OpenParen(indexOf("(one, >>(<<two, three))")),
+              preHeadArgumentSpace = None,
+              headArgument = Some(SoftAST.Argument("two", indexOf("(one, (>>two<<, three))"))),
+              tailArguments = Seq(
+                SoftAST.TailArgument(
+                  index = indexOf("(one, (two>>, three<<))"),
+                  comma = SoftAST.Comma(indexOf("(one, (two>>,<< three))")),
+                  preArgumentSpace = Some(SoftAST.Space(" ", indexOf("(one, (two,>> <<three))"))),
+                  argument = SoftAST.Argument("three", indexOf("(one, (two, >>three<<))")),
+                  postArgumentSpace = None
+                )
+              ),
+              closeParen = SoftAST.CloseParen(indexOf("(one, (two, three>>)<<)"))
+            ),
+            postArgumentSpace = None
+          )
+
+        argument.closeParen shouldBe SoftAST.CloseParen(indexOf("(one, (two, three)>>)<<"))
+      }
+    }
+
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockBodyReferenceCallSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockBodyReferenceCallSpec.scala
@@ -1,0 +1,142 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/** Tests related to [[SoftAST.ReferenceCall]] when [[SoftAST.BlockBody]] is parsed */
+class BlockBodyReferenceCallSpec extends AnyWordSpec with Matchers {
+
+  "parse a reference call" in {
+    val code =
+      """
+        |Contract ABC () {}
+        |
+        |function(one)
+        |
+        |blah
+        |""".stripMargin
+
+    val actual =
+      parseBlockBody(code)
+
+    val expected =
+      SoftAST.BlockBodyPart(
+        index = indexOf {
+          """
+            |Contract ABC () {}
+            |
+            |>>function(one)
+            |
+            |<<blah
+            |""".stripMargin
+        },
+        part = SoftAST.ReferenceCall(
+          index = indexOf {
+            """
+              |Contract ABC () {}
+              |
+              |>>function(one)<<
+              |
+              |blah
+              |""".stripMargin
+          },
+          reference = SoftAST.Identifier(
+            code = "function",
+            index = indexOf {
+              """
+                |Contract ABC () {}
+                |
+                |>>function<<(one)
+                |
+                |blah
+                |""".stripMargin
+            }
+          ),
+          preArgumentsSpace = None,
+          arguments = SoftAST.Arguments(
+            index = indexOf {
+              """
+                |Contract ABC () {}
+                |
+                |function>>(one)<<
+                |
+                |blah
+                |""".stripMargin
+            },
+            openParen = SoftAST.OpenParen(
+              indexOf {
+                """
+                  |Contract ABC () {}
+                  |
+                  |function>>(<<one)
+                  |
+                  |blah
+                  |""".stripMargin
+              }
+            ),
+            preHeadArgumentSpace = None,
+            headArgument = Some(
+              SoftAST.Argument(
+                code = "one",
+                index = indexOf {
+                  """
+                    |Contract ABC () {}
+                    |
+                    |function(>>one<<)
+                    |
+                    |blah
+                    |""".stripMargin
+                }
+              )
+            ),
+            tailArguments = Seq.empty,
+            closeParen = SoftAST.CloseParen(indexOf {
+              """
+                |Contract ABC () {}
+                |
+                |function(one>>)<<
+                |
+                |blah
+                |""".stripMargin
+            })
+          )
+        ),
+        postPartSpace = Some(
+          SoftAST.Space(
+            code = "\n\n",
+            index = indexOf {
+              """
+                |Contract ABC () {}
+                |
+                |function(one)>>
+                |
+                |<<blah
+                |""".stripMargin
+            }
+          )
+        )
+      )
+
+    actual.parts should contain(expected)
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockBodyReferenceCallSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockBodyReferenceCallSpec.scala
@@ -17,7 +17,7 @@
 package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -122,7 +122,7 @@ class BlockBodyReferenceCallSpec extends AnyWordSpec with Matchers {
         ),
         postPartSpace = Some(
           SoftAST.Space(
-            code = "\n\n",
+            code = Token.Newline.lexeme * 2, // Newline twice
             index = indexOf {
               """
                 |Contract ABC () {}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionNameSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionNameSpec.scala
@@ -76,7 +76,7 @@ class FunctionNameSpec extends AnyWordSpec with Matchers {
 
   "random characters and symbols after function name" in {
     val root =
-      parseSoft("fn abcd *YNKJ BUP(*P")
+      parseSoft("fn abcd *YNKJ BUP*P")
 
     val (functions, unresolved) =
       root
@@ -99,7 +99,7 @@ class FunctionNameSpec extends AnyWordSpec with Matchers {
     function.signature.fnName shouldBe
       SoftAST.Identifier(
         code = "abcd",
-        index = indexOf("fn >>abcd<< *YNKJ BUP(*P")
+        index = indexOf("fn >>abcd<< *YNKJ BUP*P")
       )
 
     /**
@@ -110,13 +110,13 @@ class FunctionNameSpec extends AnyWordSpec with Matchers {
     unresolved.head shouldBe
       SoftAST.Unresolved(
         code = "*YNKJ",
-        index = indexOf("fn abcd >>*YNKJ<< BUP(*P")
+        index = indexOf("fn abcd >>*YNKJ<< BUP*P")
       )
     // last unresolved
     unresolved.last shouldBe
       SoftAST.Unresolved(
-        code = "BUP(*P",
-        index = indexOf("fn abcd *YNKJ >>BUP(*P<<")
+        code = "BUP*P",
+        index = indexOf("fn abcd *YNKJ >>BUP*P<<")
       )
   }
 

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReferenceCallSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReferenceCallSpec.scala
@@ -1,0 +1,97 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.EitherValues._
+
+class ReferenceCallSpec extends AnyWordSpec with Matchers {
+
+  "parseOrFail" should {
+    "fail" when {
+      "open paren is not provided" in {
+        val actual =
+          parseOrFailReferenceCall("object")
+            .left
+            .value
+
+        // This error message is from FastParse, not something we use for reporting, but for parser composition.
+        // Therefore, the actual FastParse error message is not important here.
+        // This test is to ensure that a FastParse failure does occur.
+        actual.message shouldBe """Expected "(""""
+      }
+
+      "parentheses are provided but reference name is not" in {
+        // Checks that a FastParse failure does occur, the actual error message from FastParse is not important.
+        parseOrFailReferenceCall("()")
+          .left
+          .value
+      }
+    }
+  }
+
+  "succeed" when {
+    "reference call is without parameters" in {
+      val actual =
+        parseReferenceCall("object(")
+
+      val expected =
+        SoftAST.ReferenceCall(
+          index = indexOf(">>object(<<"),
+          reference = SoftAST.Identifier("object", indexOf(">>object<<(")),
+          preArgumentsSpace = None,
+          arguments = SoftAST.Arguments(
+            index = indexOf("object>>(<<"),
+            openParen = SoftAST.OpenParen(indexOf("object>>(<<")),
+            preHeadArgumentSpace = None,
+            headArgument = None,
+            tailArguments = Seq.empty,
+            closeParen = SoftAST.CloseParenExpected(indexOf("object(>><<"))
+          )
+        )
+
+      actual shouldBe expected
+    }
+
+    "reference call is with a parameter" in {
+      val actual =
+        parseReferenceCall("object(one)")
+
+      val expected =
+        SoftAST.ReferenceCall(
+          index = indexOf(">>object(one)<<"),
+          reference = SoftAST.Identifier("object", indexOf(">>object<<(one)")),
+          preArgumentsSpace = None,
+          arguments = SoftAST.Arguments(
+            index = indexOf("object>>(one)<<"),
+            openParen = SoftAST.OpenParen(indexOf("object>>(<<one)")),
+            preHeadArgumentSpace = None,
+            headArgument = Some(SoftAST.Argument("one", indexOf("object(>>one<<)"))),
+            tailArguments = Seq.empty,
+            closeParen = SoftAST.CloseParen(indexOf("object(one>>)<<"))
+          )
+        )
+
+      actual shouldBe expected
+    }
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateInheritanceSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateInheritanceSpec.scala
@@ -1,0 +1,160 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.alephium.ralph.lsp.utils.Node
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class TemplateInheritanceSpec extends AnyWordSpec with Matchers {
+
+  "fail" when {
+    "implements contains typo" in {
+      val template =
+        parseTemplate("Contract Child() implem Parent(arg) {}")
+
+      // implem is marked as unresolved
+      template
+        .toNode()
+        .walkDown
+        .collectFirst {
+          case Node(ast @ SoftAST.Unresolved("implem", index), _) if index == indexOf("Contract Child() >>implem<< Parent(arg) {}") =>
+            ast
+        }
+        .shouldBe(defined)
+    }
+
+    "identifier or reference is missing" in {
+      val template =
+        parseTemplate("Contract Child() implements {}")
+
+      val expected =
+        SoftAST.TemplateInheritance(
+          index = indexOf("Contract Child() >>implements <<{}"),
+          inheritanceType = SoftAST.Implements(indexOf("Contract Child() >>implements<< {}")),
+          preConstructorCallSpace = SoftAST.Space(" ", indexOf("Contract Child() implements>> <<{}")),
+          reference = SoftAST.IdentifierExpected(indexOf("Contract Child() implements >><<{}")),
+          postConstructorCallSpace = None
+        )
+
+      template.inheritance should have size 1
+      template.inheritance.head shouldBe expected
+    }
+  }
+
+  "succeed" when {
+    "the contract implements" when {
+      "an identifier" in {
+        val template =
+          parseTemplate("Contract Child() implements Parent")
+
+        val expected =
+          SoftAST.TemplateInheritance(
+            index = indexOf(s"Contract Child() >>implements Parent<<"),
+            inheritanceType = SoftAST.Implements(indexOf(s"Contract Child() >>implements<< Parent")),
+            preConstructorCallSpace = SoftAST.Space(" ", indexOf(s"Contract Child() implements>> <<Parent")),
+            reference = SoftAST.Identifier("Parent", indexOf("Contract Child() implements >>Parent<<")),
+            postConstructorCallSpace = None
+          )
+
+        template.inheritance should have size 1
+        template.inheritance.head shouldBe expected
+      }
+
+      "a reference" in {
+        val template =
+          parseTemplate("Contract Child() implements Parent(arg)")
+
+        val expected =
+          SoftAST.TemplateInheritance(
+            index = indexOf(s"Contract Child() >>implements Parent(arg)<<"),
+            inheritanceType = SoftAST.Implements(indexOf(s"Contract Child() >>implements<< Parent(arg)")),
+            preConstructorCallSpace = SoftAST.Space(" ", indexOf(s"Contract Child() implements>> <<Parent(arg)")),
+            reference = SoftAST.ReferenceCall(
+              index = indexOf(s"Contract Child() implements >>Parent(arg)<<"),
+              reference = SoftAST.Identifier("Parent", indexOf(s"Contract Child() implements >>Parent<<(arg)")),
+              preArgumentsSpace = None,
+              arguments = SoftAST.Arguments(
+                index = indexOf(s"Contract Child() implements Parent>>(arg)<<"),
+                openParen = SoftAST.OpenParen(indexOf(s"Contract Child() implements Parent>>(<<arg)")),
+                preHeadArgumentSpace = None,
+                headArgument = Some(SoftAST.Argument("arg", indexOf(s"Contract Child() implements Parent(>>arg<<)"))),
+                tailArguments = Seq.empty,
+                closeParen = SoftAST.CloseParen(indexOf(s"Contract Child() implements Parent(arg>>)<<"))
+              )
+            ),
+            postConstructorCallSpace = None
+          )
+
+        template.inheritance should have size 1
+        template.inheritance.head shouldBe expected
+      }
+    }
+
+    "the contract extends" when {
+      "an identifier" in {
+        val template =
+          parseTemplate("Contract Child() extends Parent")
+
+        val expected =
+          SoftAST.TemplateInheritance(
+            index = indexOf(s"Contract Child() >>extends Parent<<"),
+            inheritanceType = SoftAST.Extends(indexOf(s"Contract Child() >>extends<< Parent")),
+            preConstructorCallSpace = SoftAST.Space(" ", indexOf(s"Contract Child() extends>> <<Parent")),
+            reference = SoftAST.Identifier("Parent", indexOf("Contract Child() extends >>Parent<<")),
+            postConstructorCallSpace = None
+          )
+
+        template.inheritance should have size 1
+        template.inheritance.head shouldBe expected
+      }
+
+      "a reference" in {
+        val template =
+          parseTemplate("Contract Child() extends Parent(arg)")
+
+        val expected =
+          SoftAST.TemplateInheritance(
+            index = indexOf(s"Contract Child() >>extends Parent(arg)<<"),
+            inheritanceType = SoftAST.Extends(indexOf(s"Contract Child() >>extends<< Parent(arg)")),
+            preConstructorCallSpace = SoftAST.Space(" ", indexOf(s"Contract Child() extends>> <<Parent(arg)")),
+            reference = SoftAST.ReferenceCall(
+              index = indexOf(s"Contract Child() extends >>Parent(arg)<<"),
+              reference = SoftAST.Identifier("Parent", indexOf(s"Contract Child() extends >>Parent<<(arg)")),
+              preArgumentsSpace = None,
+              arguments = SoftAST.Arguments(
+                index = indexOf(s"Contract Child() extends Parent>>(arg)<<"),
+                openParen = SoftAST.OpenParen(indexOf(s"Contract Child() extends Parent>>(<<arg)")),
+                preHeadArgumentSpace = None,
+                headArgument = Some(SoftAST.Argument("arg", indexOf(s"Contract Child() extends Parent(>>arg<<)"))),
+                tailArguments = Seq.empty,
+                closeParen = SoftAST.CloseParen(indexOf(s"Contract Child() extends Parent(arg>>)<<"))
+              )
+            ),
+            postConstructorCallSpace = None
+          )
+
+        template.inheritance should have size 1
+        template.inheritance.head shouldBe expected
+      }
+    }
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
@@ -54,6 +54,12 @@ object TestParser {
   def parseArgument(code: String): SoftAST.Arguments =
     runParser(ArgumentParser.parse(_))(code)
 
+  def parseOrFailReferenceCall(code: String): Either[CompilerError.FastParseError, SoftAST.ReferenceCall] =
+    runParserOrFail(ReferenceCallParser.parseOrFail(_))(code)
+
+  def parseReferenceCall(code: String): SoftAST.ReferenceCall =
+    runParser(ReferenceCallParser.parse(_))(code)
+
   /**
    * Executes the parser ensuring no [[CompilerError.FastParseError]] error.
    * If a [[CompilerError.FastParseError]] error does occur, a formatted error message is printed.
@@ -67,6 +73,8 @@ object TestParser {
     runParserOrFail(parser)(code) match {
       case Left(error) =>
         // Print a formatted error so it's easier to debug.
+        // FastParse failures and error messages are not something we use for reporting,
+        // but they are used for parser function composition.
         fail(error.toFormatter().format(Some(Console.RED)))
 
       case Right(ast) =>


### PR DESCRIPTION
Syntax: `reference(args ...)`

This syntax is used by:
- Inheritance `implements Parent(args ...)`
- Function calls `function(args ...)`
- The same parser will be used in cases such as `contract.function(args ...)` etc

TODO: [Expression](https://github.com/alephium/ralph-lsp/pull/333/files#diff-7d27c6fd7ae6c49fe901e62ab7bffc4096b8dc1514e68830097a9188b35b5711R362).

See changes in [`Demo.scala`](https://github.com/alephium/ralph-lsp/compare/a_bit_renaming...argument_and_call_parser?expand=1#diff-fd129a5ab464bd3bdc46fbb14687186253eef15c07e6bef9447c4fb35603ab9aR13).