### PR TITLE
Move test constructors out from `SoftAST` to `TestSoftAST`

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -103,17 +103,6 @@ object SoftAST {
   abstract class ExpectedErrorAST(element: String)   extends ErrorAST(s"$element expected")
   abstract class TokenExpectedErrorAST(token: Token) extends ExpectedErrorAST(s"'${token.lexeme}'")
 
-  object Fn {
-
-    def apply(code: Code): Fn =
-      Fn(
-        index = code.index,
-        documentation = None,
-        code = code
-      )
-
-  }
-
   case class Fn(
       index: SourceIndex,
       documentation: Option[Comments],
@@ -125,17 +114,6 @@ object SoftAST {
       documentation: Option[Comments],
       code: Code)
     extends TokenDocumentedAST
-
-  object Comma {
-
-    def apply(code: Code): Comma =
-      Comma(
-        index = code.index,
-        documentation = None,
-        code = code
-      )
-
-  }
 
   case class Comma(
       index: SourceIndex,
@@ -186,17 +164,6 @@ object SoftAST {
       code: Code)
     extends TokenDocumentedAST
 
-  object At {
-
-    def apply(code: Code): At =
-      At(
-        index = code.index,
-        documentation = None,
-        code = code
-      )
-
-  }
-
   case class At(
       index: SourceIndex,
       documentation: Option[Comments],
@@ -227,33 +194,11 @@ object SoftAST {
 
   sealed trait TemplateToken extends TokenDocumentedAST
 
-  object Contract {
-
-    def apply(code: Code): Contract =
-      Contract(
-        index = code.index,
-        documentation = None,
-        code = code
-      )
-
-  }
-
   case class Contract(
       index: SourceIndex,
       documentation: Option[Comments],
       code: Code)
     extends TemplateToken
-
-  object TxScript {
-
-    def apply(code: Code): TxScript =
-      TxScript(
-        index = code.index,
-        documentation = None,
-        code = code
-      )
-
-  }
 
   case class TxScript(
       index: SourceIndex,
@@ -283,17 +228,6 @@ object SoftAST {
 
   sealed trait ColonAST extends SoftAST
 
-  object Colon {
-
-    def apply(code: Code): Colon =
-      Colon(
-        index = code.index,
-        documentation = None,
-        code = code
-      )
-
-  }
-
   case class Colon(
       index: SourceIndex,
       documentation: Option[Comments],
@@ -307,17 +241,6 @@ object SoftAST {
        with ColonAST
 
   sealed trait ForwardArrowAST extends SoftAST
-
-  object ForwardArrow {
-
-    def apply(code: Code): ForwardArrow =
-      ForwardArrow(
-        index = code.index,
-        documentation = None,
-        code = code
-      )
-
-  }
 
   case class ForwardArrow(
       index: SourceIndex,
@@ -333,17 +256,6 @@ object SoftAST {
 
   sealed trait OpenParenAST extends SoftAST
 
-  object OpenParen {
-
-    def apply(code: Code): OpenParen =
-      OpenParen(
-        index = code.index,
-        documentation = None,
-        code = code
-      )
-
-  }
-
   case class OpenParen(
       index: SourceIndex,
       documentation: Option[Comments],
@@ -357,17 +269,6 @@ object SoftAST {
        with OpenParenAST
 
   sealed trait CloseParenAST extends SoftAST
-
-  object CloseParen {
-
-    def apply(code: Code): CloseParen =
-      CloseParen(
-        index = code.index,
-        documentation = None,
-        code = code
-      )
-
-  }
 
   case class CloseParen(
       index: SourceIndex,
@@ -383,17 +284,6 @@ object SoftAST {
 
   sealed trait OpenCurlyAST extends SoftAST
 
-  object OpenCurly {
-
-    def apply(code: Code): OpenCurly =
-      OpenCurly(
-        index = code.index,
-        documentation = None,
-        code = code
-      )
-
-  }
-
   case class OpenCurly(
       index: SourceIndex,
       documentation: Option[Comments],
@@ -407,17 +297,6 @@ object SoftAST {
        with OpenCurlyAST
 
   sealed trait CloseCurlyAST extends SoftAST
-
-  object CloseCurly {
-
-    def apply(code: Code): CloseCurly =
-      CloseCurly(
-        index = code.index,
-        documentation = None,
-        code = code
-      )
-
-  }
 
   case class CloseCurly(
       index: SourceIndex,
@@ -570,17 +449,6 @@ object SoftAST {
 
   sealed trait IdentifierAST extends TypeAST with ReferenceCallOrIdentifier
 
-  object Identifier {
-
-    def apply(code: Code): Identifier =
-      Identifier(
-        index = code.index,
-        documentation = None,
-        code = code
-      )
-
-  }
-
   case class Identifier(
       index: SourceIndex,
       documentation: Option[Comments],
@@ -608,17 +476,6 @@ object SoftAST {
       text: Option[Code],
       postTextSpace: Option[Space])
     extends BodyPartAST
-
-  object Unresolved {
-
-    def apply(code: Code): Unresolved =
-      Unresolved(
-        index = code.index,
-        documentation = None,
-        code = code
-      )
-
-  }
 
   case class Unresolved(
       index: SourceIndex,

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AnnotationSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AnnotationSpec.scala
@@ -18,6 +18,7 @@ package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.alephium.ralph.lsp.utils.Node
 import org.scalatest.matchers.should.Matchers
@@ -34,12 +35,7 @@ class AnnotationSpec extends AnyWordSpec with Matchers {
       annotation shouldBe
         SoftAST.Annotation(
           index = indexOf(">>@<<"),
-          at = SoftAST.At(
-            SoftAST.Code(
-              index = indexOf(">>@<<"),
-              text = Token.At.lexeme
-            )
-          ),
+          at = At(indexOf(">>@<<")),
           preIdentifierSpace = None,
           identifier = SoftAST.IdentifierExpected(indexOf("@>><<")),
           postIdentifierSpace = None,
@@ -53,14 +49,7 @@ class AnnotationSpec extends AnyWordSpec with Matchers {
         parseAnnotation("@anno(")
 
       // opening paren is parsed
-      annotation.tuple.value.openParen shouldBe
-        SoftAST.OpenParen(
-          SoftAST.Code(
-            index = indexOf("@anno>>(<<"),
-            text = Token.OpenParen.lexeme
-          )
-        )
-
+      annotation.tuple.value.openParen shouldBe OpenParen(indexOf("@anno>>(<<"))
       // closing paren is reported as expected
       annotation.tuple.value.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("@anno(>><<"))
     }
@@ -84,12 +73,7 @@ class AnnotationSpec extends AnyWordSpec with Matchers {
       annotation shouldBe
         SoftAST.Annotation(
           index = indexOf(">>@<<fn function()"),
-          at = SoftAST.At(
-            SoftAST.Code(
-              index = indexOf(">>@<<fn function()"),
-              text = Token.At.lexeme
-            )
-          ),
+          at = At(indexOf(">>@<<fn function()")),
           preIdentifierSpace = None,
           identifier = SoftAST.IdentifierExpected(indexOf("@>><<fn function()")),
           postIdentifierSpace = None,
@@ -106,18 +90,11 @@ class AnnotationSpec extends AnyWordSpec with Matchers {
     annotation shouldBe
       SoftAST.Annotation(
         index = indexOf(">>@anno<<"),
-        at = SoftAST.At(
-          SoftAST.Code(
-            index = indexOf(">>@<<anno"),
-            text = Token.At.lexeme
-          )
-        ),
+        at = At(indexOf(">>@<<anno")),
         preIdentifierSpace = None,
-        identifier = SoftAST.Identifier(
-          SoftAST.Code(
-            index = indexOf("@>>anno<<"),
-            text = "anno"
-          )
+        identifier = Identifier(
+          index = indexOf("@>>anno<<"),
+          text = "anno"
         ),
         postIdentifierSpace = None,
         tuple = None,
@@ -132,18 +109,11 @@ class AnnotationSpec extends AnyWordSpec with Matchers {
     annotation shouldBe
       SoftAST.Annotation(
         index = indexOf(">>@anno(a, b, c + d)<<"),
-        at = SoftAST.At(
-          SoftAST.Code(
-            index = indexOf(">>@<<anno(a, b, c + d)"),
-            text = Token.At.lexeme
-          )
-        ),
+        at = At(indexOf(">>@<<anno(a, b, c + d)")),
         preIdentifierSpace = None,
-        identifier = SoftAST.Identifier(
-          SoftAST.Code(
-            index = indexOf("@>>anno<<(a, b, c + d)"),
-            text = "anno"
-          )
+        identifier = Identifier(
+          index = indexOf("@>>anno<<(a, b, c + d)"),
+          text = "anno"
         ),
         postIdentifierSpace = None,
         // No need to test the AST for the Tuple. Simply test that a tuple is defined
@@ -189,35 +159,33 @@ class AnnotationSpec extends AnyWordSpec with Matchers {
             // These test-cases are for annotations.
             // The behaviour of Comments is tests in CommentsSpec
             Some(expectedComment),
-          code = SoftAST.Code(
+          code = Code(
             index = indexOf {
               """// documentation
                 |>>@<<anno
                 |""".stripMargin
             },
-            text = Token.At.lexeme
+            token = Token.At
           )
         ),
         preIdentifierSpace = None,
-        identifier = SoftAST.Identifier(
-          SoftAST.Code(
-            index = indexOf {
-              """// documentation
-                |@>>anno<<
-                |""".stripMargin
-            },
-            text = "anno"
-          )
+        identifier = Identifier(
+          index = indexOf {
+            """// documentation
+              |@>>anno<<
+              |""".stripMargin
+          },
+          text = "anno"
         ),
         postIdentifierSpace = Some(
           SoftAST.Space(
-            SoftAST.Code(
+            Code(
               index = indexOf {
                 """// documentation
                   |@anno>>
                   |<<""".stripMargin
               },
-              text = Token.Newline.lexeme
+              token = Token.Newline
             )
           )
         ),

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommentSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommentSpec.scala
@@ -18,6 +18,7 @@ package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -36,12 +37,7 @@ class CommentSpec extends AnyWordSpec with Matchers {
           comments = Seq(
             SoftAST.Comment(
               index = indexOf(">>//<<"),
-              doubleForwardSlash = SoftAST.DoubleForwardSlash(
-                code = SoftAST.Code(
-                  index = indexOf(">>//<<"),
-                  text = "//"
-                )
-              ),
+              doubleForwardSlash = DoubleForwardSlash(indexOf(">>//<<")),
               preTextSpace = None,
               text = None,
               postTextSpace = None
@@ -66,20 +62,8 @@ class CommentSpec extends AnyWordSpec with Matchers {
           comments = Seq(
             SoftAST.Comment(
               index = indexOf(">>// <<"),
-              doubleForwardSlash = SoftAST.DoubleForwardSlash(
-                code = SoftAST.Code(
-                  index = indexOf(">>//<< "),
-                  text = Token.DoubleForwardSlash.lexeme
-                )
-              ),
-              Some(
-                SoftAST.Space(
-                  code = SoftAST.Code(
-                    index = indexOf("//>> <<"),
-                    text = " "
-                  )
-                )
-              ),
+              doubleForwardSlash = DoubleForwardSlash(indexOf(">>//<< ")),
+              preTextSpace = Some(SpaceOne(indexOf("//>> <<"))),
               text = None,
               postTextSpace = None
             )
@@ -106,34 +90,15 @@ class CommentSpec extends AnyWordSpec with Matchers {
           comments = Seq(
             SoftAST.Comment(
               index = indexOf(s">>// my comment $newLine<<"),
-              doubleForwardSlash = SoftAST.DoubleForwardSlash(
-                code = SoftAST.Code(
-                  index = indexOf(s">>//<< my comment $newLine"),
-                  text = "//"
-                )
-              ),
-              preTextSpace = Some(
-                SoftAST.Space(
-                  code = SoftAST.Code(
-                    index = indexOf(s"//>> <<my comment $newLine"),
-                    text = " "
-                  )
-                )
-              ),
+              doubleForwardSlash = DoubleForwardSlash(indexOf(s">>//<< my comment $newLine")),
+              preTextSpace = Some(SpaceOne(indexOf(s"//>> <<my comment $newLine"))),
               text = Some(
                 SoftAST.Code(
                   index = indexOf(s"// >>my comment <<$newLine"),
                   text = "my comment "
                 )
               ),
-              postTextSpace = Some(
-                SoftAST.Space(
-                  code = SoftAST.Code(
-                    index = indexOf(s"// my comment >>$newLine<<"),
-                    text = newLine
-                  )
-                )
-              )
+              postTextSpace = Some(SpaceNewline(indexOf(s"// my comment >>$newLine<<")))
             )
           ),
           postCommentSpace = None
@@ -158,20 +123,8 @@ class CommentSpec extends AnyWordSpec with Matchers {
           comments = Seq(
             SoftAST.Comment(
               index = indexOf(s">>$code<<"),
-              doubleForwardSlash = SoftAST.DoubleForwardSlash(
-                code = SoftAST.Code(
-                  index = indexOf(">>//<< fn function()"),
-                  text = "//"
-                )
-              ),
-              preTextSpace = Some(
-                SoftAST.Space(
-                  code = SoftAST.Code(
-                    index = indexOf("//>> <<fn function()"),
-                    text = " "
-                  )
-                )
-              ),
+              doubleForwardSlash = DoubleForwardSlash(indexOf(">>//<< fn function()")),
+              preTextSpace = Some(SpaceOne(indexOf("//>> <<fn function()"))),
               text = Some(
                 SoftAST.Code(
                   index = indexOf("// >>fn function()<<"),

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommentsSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommentsSpec.scala
@@ -1,7 +1,8 @@
 package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser.parseComment
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -11,8 +12,8 @@ class CommentsSpec extends AnyWordSpec with Matchers {
   "text comment exist" in {
     val code =
       """// one
-          |// two
-          |""".stripMargin
+        |// two
+        |""".stripMargin
 
     val comment =
       parseComment(code)
@@ -21,51 +22,42 @@ class CommentsSpec extends AnyWordSpec with Matchers {
       SoftAST.Comment(
         index = indexOf {
           """>>// one
-              |<<// two
-              |""".stripMargin
+            |<<// two
+            |""".stripMargin
         },
-        doubleForwardSlash = SoftAST.DoubleForwardSlash(
-          SoftAST.Code(
-            index = indexOf {
-              """>>//<< one
-                |// two
-                |""".stripMargin
-            },
-            text = Token.DoubleForwardSlash.lexeme
-          )
+        doubleForwardSlash = DoubleForwardSlash(
+          indexOf {
+            """>>//<< one
+              |// two
+              |""".stripMargin
+          }
         ),
         preTextSpace = Some(
-          SoftAST.Space(
-            SoftAST.Code(
-              indexOf {
-                """//>> <<one
-                  |// two
-                  |""".stripMargin
-              },
-              " "
-            )
+          SpaceOne(
+            indexOf {
+              """//>> <<one
+                |// two
+                |""".stripMargin
+            }
           )
         ),
         text = Some(
           SoftAST.Code(
             index = indexOf {
               """// >>one<<
-                  |// two
-                  |""".stripMargin
+                |// two
+                |""".stripMargin
             },
             text = "one"
           )
         ),
         postTextSpace = Some(
-          SoftAST.Space(
-            SoftAST.Code(
-              index = indexOf {
-                """// one>>
-                  |<<// two
-                  |""".stripMargin
-              },
-              text = Token.Newline.lexeme
-            )
+          SpaceNewline(
+            indexOf {
+              """// one>>
+                |<<// two
+                |""".stripMargin
+            }
           )
         )
       )
@@ -77,51 +69,42 @@ class CommentsSpec extends AnyWordSpec with Matchers {
       SoftAST.Comment(
         index = indexOf {
           """// one
-              |>>// two
-              |<<""".stripMargin
+            |>>// two
+            |<<""".stripMargin
         },
-        doubleForwardSlash = SoftAST.DoubleForwardSlash(
-          SoftAST.Code(
-            index = indexOf {
-              """// one
-                |>>//<< two
-                |""".stripMargin
-            },
-            text = Token.DoubleForwardSlash.lexeme
-          )
+        doubleForwardSlash = DoubleForwardSlash(
+          index = indexOf {
+            """// one
+              |>>//<< two
+              |""".stripMargin
+          }
         ),
         preTextSpace = Some(
-          SoftAST.Space(
-            SoftAST.Code(
-              indexOf {
-                """// one
-                  |//>> <<two
-                  |""".stripMargin
-              },
-              text = " "
-            )
+          SpaceOne(
+            indexOf {
+              """// one
+                |//>> <<two
+                |""".stripMargin
+            }
           )
         ),
         text = Some(
           SoftAST.Code(
             index = indexOf {
               """// one
-                  |// >>two<<
-                  |""".stripMargin
+                |// >>two<<
+                |""".stripMargin
             },
             text = "two"
           )
         ),
         postTextSpace = Some(
-          SoftAST.Space(
-            SoftAST.Code(
-              index = indexOf {
-                """// one
-                  |// two>>
-                  |<<""".stripMargin
-              },
-              text = Token.Newline.lexeme
-            )
+          SpaceNewline(
+            index = indexOf {
+              """// one
+                |// two>>
+                |<<""".stripMargin
+            }
           )
         )
       )
@@ -158,20 +141,8 @@ class CommentsSpec extends AnyWordSpec with Matchers {
             comments = Seq(
               SoftAST.Comment(
                 index = indexOf(s">>$code<<"),
-                doubleForwardSlash = SoftAST.DoubleForwardSlash(
-                  SoftAST.Code(
-                    index = indexOf(s">>//<< //"),
-                    text = Token.DoubleForwardSlash.lexeme
-                  )
-                ),
-                preTextSpace = Some(
-                  SoftAST.Space(
-                    SoftAST.Code(
-                      index = indexOf(s"//>> <<//"),
-                      text = " "
-                    )
-                  )
-                ),
+                doubleForwardSlash = DoubleForwardSlash(indexOf(s">>//<< //")),
+                preTextSpace = Some(SpaceOne(indexOf(s"//>> <<//"))),
                 text = Some(
                   SoftAST.Code(
                     index = indexOf(s"// >>//<<"),
@@ -190,7 +161,7 @@ class CommentsSpec extends AnyWordSpec with Matchers {
       "// is on a new line" in {
         val code =
           """//
-              |//""".stripMargin
+            |//""".stripMargin
 
         val comment =
           parseComment(code)
@@ -202,31 +173,25 @@ class CommentsSpec extends AnyWordSpec with Matchers {
             comments = Seq(
               SoftAST.Comment(
                 index = indexOf(s">>$code<<"),
-                doubleForwardSlash = SoftAST.DoubleForwardSlash(
-                  SoftAST.Code(
-                    index = indexOf {
-                      """>>//<<
-                        |//""".stripMargin
-                    },
-                    text = Token.DoubleForwardSlash.lexeme
-                  )
+                doubleForwardSlash = DoubleForwardSlash(
+                  indexOf {
+                    """>>//<<
+                      |//""".stripMargin
+                  }
                 ),
                 preTextSpace = Some(
-                  SoftAST.Space(
-                    SoftAST.Code(
-                      index = indexOf {
-                        """//>>
-                          |<<//""".stripMargin
-                      },
-                      text = Token.Newline.lexeme
-                    )
+                  SpaceNewline(
+                    indexOf {
+                      """//>>
+                        |<<//""".stripMargin
+                    }
                   )
                 ),
                 text = Some(
                   SoftAST.Code(
                     index = indexOf {
                       """//
-                          |>>//<<""".stripMargin
+                        |>>//<<""".stripMargin
                     },
                     text = "//"
                   )

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FnAnnotationSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FnAnnotationSpec.scala
@@ -17,7 +17,8 @@
 package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -43,31 +44,25 @@ class FnAnnotationSpec extends AnyWordSpec with Matchers {
     function.annotations should have size 1
     function.annotations.head shouldBe
       SoftAST.Annotation(
-        index = indexOf {
+        indexOf {
           """>>@
             |<<fn function() -> ()
             |""".stripMargin
         },
-        at = SoftAST.At(
-          SoftAST.Code(
-            index = indexOf {
-              """>>@<<
-                |fn function() -> ()
-                |""".stripMargin
-            },
-            text = Token.At.lexeme
-          )
+        at = At(
+          indexOf {
+            """>>@<<
+              |fn function() -> ()
+              |""".stripMargin
+          }
         ),
         preIdentifierSpace = Some(
-          SoftAST.Space(
-            SoftAST.Code(
-              index = indexOf {
-                """@>>
-                  |<<fn function() -> ()
-                  |""".stripMargin
-              },
-              text = Token.Newline.lexeme
-            )
+          SpaceNewline(
+            indexOf {
+              """@>>
+                |<<fn function() -> ()
+                |""".stripMargin
+            }
           )
         ),
         identifier = SoftAST.IdentifierExpected(
@@ -94,42 +89,34 @@ class FnAnnotationSpec extends AnyWordSpec with Matchers {
 
       val expected =
         SoftAST.Annotation(
-          index = indexOf {
+          indexOf {
             """>>@annotation
               |<<fn function() -> ()
               |""".stripMargin
           },
-          at = SoftAST.At(
-            SoftAST.Code(
-              indexOf {
-                """>>@<<annotation
-                  |fn function() -> ()
-                  |""".stripMargin
-              },
-              Token.At.lexeme
-            )
+          at = At(
+            indexOf {
+              """>>@<<annotation
+                |fn function() -> ()
+                |""".stripMargin
+            }
           ),
           preIdentifierSpace = None,
-          identifier = SoftAST.Identifier(
-            SoftAST.Code(
-              indexOf {
-                """@>>annotation<<
-                  |fn function() -> ()
-                  |""".stripMargin
-              },
-              "annotation"
-            )
+          identifier = Identifier(
+            index = indexOf {
+              """@>>annotation<<
+                |fn function() -> ()
+                |""".stripMargin
+            },
+            text = "annotation"
           ),
           postIdentifierSpace = Some(
-            SoftAST.Space(
-              code = SoftAST.Code(
-                indexOf {
-                  """@annotation>>
-                    |<<fn function() -> ()
-                    |""".stripMargin
-                },
-                Token.Newline.lexeme
-              )
+            SpaceNewline(
+              indexOf {
+                """@annotation>>
+                  |<<fn function() -> ()
+                  |""".stripMargin
+              }
             )
           ),
           tuple = None,
@@ -154,148 +141,120 @@ class FnAnnotationSpec extends AnyWordSpec with Matchers {
 
       function.annotations.head shouldBe
         SoftAST.Annotation(
-          index = indexOf {
+          indexOf {
             """>>@ annotation (a, b + c, c = 4)
               |<<@ last ()
               |fn function() -> ()
               |""".stripMargin
           },
-          at = SoftAST.At(
-            SoftAST.Code(
-              index = indexOf {
-                """>>@<< annotation (a, b + c, c = 4)
-                  |@ last ()
-                  |fn function() -> ()
-                  |""".stripMargin
-              },
-              text = Token.At.lexeme
-            )
+          at = At(
+            indexOf {
+              """>>@<< annotation (a, b + c, c = 4)
+                |@ last ()
+                |fn function() -> ()
+                |""".stripMargin
+            }
           ),
           preIdentifierSpace = Some(
-            SoftAST.Space(
-              SoftAST.Code(
-                index = indexOf {
-                  """@>> <<annotation (a, b + c, c = 4)
-                    |@ last ()
-                    |fn function() -> ()
-                    |""".stripMargin
-                },
-                text = " "
-              )
-            )
-          ),
-          identifier = SoftAST.Identifier(
-            SoftAST.Code(
-              index = indexOf {
-                """@ >>annotation<< (a, b + c, c = 4)
+            SpaceOne(
+              indexOf {
+                """@>> <<annotation (a, b + c, c = 4)
                   |@ last ()
                   |fn function() -> ()
                   |""".stripMargin
-              },
-              text = "annotation"
+              }
             )
           ),
+          identifier = Identifier(
+            index = indexOf {
+              """@ >>annotation<< (a, b + c, c = 4)
+                |@ last ()
+                |fn function() -> ()
+                |""".stripMargin
+            },
+            text = "annotation"
+          ),
           postIdentifierSpace = Some(
-            SoftAST.Space(
-              code = SoftAST.Code(
-                index = indexOf {
-                  """@ annotation>> <<(a, b + c, c = 4)
-                    |@ last ()
-                    |fn function() -> ()
-                    |""".stripMargin
-                },
-                text = " "
-              )
+            SpaceOne(
+              index = indexOf {
+                """@ annotation>> <<(a, b + c, c = 4)
+                  |@ last ()
+                  |fn function() -> ()
+                  |""".stripMargin
+              }
             )
           ),
           tuple =
             // This test case is not targeting Tuples AST, simply parse it.
             Some(findAnnotation("annotation")(code).flatMap(_.tuple).value),
           postTupleSpace = Some(
-            SoftAST.Space(
-              SoftAST.Code(
-                index = indexOf {
-                  """@ annotation (a, b + c, c = 4)>>
-                    |<<@ last ()
-                    |fn function() -> ()
-                    |""".stripMargin
-                },
-                text = Token.Newline.lexeme
-              )
+            SpaceNewline(
+              index = indexOf {
+                """@ annotation (a, b + c, c = 4)>>
+                  |<<@ last ()
+                  |fn function() -> ()
+                  |""".stripMargin
+              }
             )
           )
         )
 
       function.annotations.last shouldBe
         SoftAST.Annotation(
-          index = indexOf {
+          indexOf {
             """@ annotation (a, b + c, c = 4)
               |>>@ last ()
               |<<fn function() -> ()
               |""".stripMargin
           },
-          at = SoftAST.At(
-            SoftAST.Code(
-              index = indexOf {
-                """@ annotation (a, b + c, c = 4)
-                  |>>@<< last ()
-                  |fn function() -> ()
-                  |""".stripMargin
-              },
-              text = Token.At.lexeme
-            )
+          at = At(
+            indexOf {
+              """@ annotation (a, b + c, c = 4)
+                |>>@<< last ()
+                |fn function() -> ()
+                |""".stripMargin
+            }
           ),
           preIdentifierSpace = Some(
-            SoftAST.Space(
-              SoftAST.Code(
-                index = indexOf {
-                  """@ annotation (a, b + c, c = 4)
-                    |@>> <<last ()
-                    |fn function() -> ()
-                    |""".stripMargin
-                },
-                text = " "
-              )
-            )
-          ),
-          identifier = SoftAST.Identifier(
-            SoftAST.Code(
+            SpaceOne(
               index = indexOf {
                 """@ annotation (a, b + c, c = 4)
-                  |@ >>last<< ()
+                  |@>> <<last ()
                   |fn function() -> ()
                   |""".stripMargin
-              },
-              text = "last"
+              }
             )
           ),
+          identifier = Identifier(
+            index = indexOf {
+              """@ annotation (a, b + c, c = 4)
+                |@ >>last<< ()
+                |fn function() -> ()
+                |""".stripMargin
+            },
+            text = "last"
+          ),
           postIdentifierSpace = Some(
-            SoftAST.Space(
-              code = SoftAST.Code(
-                index = indexOf {
-                  """@ annotation (a, b + c, c = 4)
-                    |@ last>> <<()
-                    |fn function() -> ()
-                    |""".stripMargin
-                },
-                text = " "
-              )
+            SpaceOne(
+              index = indexOf {
+                """@ annotation (a, b + c, c = 4)
+                  |@ last>> <<()
+                  |fn function() -> ()
+                  |""".stripMargin
+              }
             )
           ),
           tuple =
             // This test case is not targeting Tuples AST, simply parse it.
             Some(findAnnotation("last")(code).flatMap(_.tuple).value),
           postTupleSpace = Some(
-            SoftAST.Space(
-              SoftAST.Code(
-                index = indexOf {
-                  """@ annotation (a, b + c, c = 4)
-                    |@ last ()>>
-                    |<<fn function() -> ()
-                    |""".stripMargin
-                },
-                text = Token.Newline.lexeme
-              )
+            SpaceNewline(
+              indexOf {
+                """@ annotation (a, b + c, c = 4)
+                  |@ last ()>>
+                  |<<fn function() -> ()
+                  |""".stripMargin
+              }
             )
           )
         )

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FnDecelerationSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FnDecelerationSpec.scala
@@ -17,7 +17,8 @@
 package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -29,14 +30,7 @@ class FnDecelerationSpec extends AnyWordSpec with Matchers {
       val function =
         parseFunction("fn")
 
-      function.fn shouldBe
-        SoftAST.Fn(
-          SoftAST.Code(
-            index = indexOf(">>fn<<"),
-            text = Token.Fn.lexeme
-          )
-        )
-
+      function.fn shouldBe Fn(indexOf(">>fn<<"))
       function.preSignatureSpace shouldBe SoftAST.SpaceExpected(indexOf("fn>><<"))
       function.postSignatureSpace shouldBe empty
       function.block shouldBe empty
@@ -55,14 +49,7 @@ class FnDecelerationSpec extends AnyWordSpec with Matchers {
       functions should have size 1
       val function = functions.head
 
-      function.fn shouldBe
-        SoftAST.Fn(
-          SoftAST.Code(
-            index = indexOf(" >>fn<<"),
-            text = Token.Fn.lexeme
-          )
-        )
-
+      function.fn shouldBe Fn(indexOf(" >>fn<<"))
       function.preSignatureSpace shouldBe SoftAST.SpaceExpected(indexOf(s" fn>><<"))
       function.postSignatureSpace shouldBe empty
       function.block shouldBe empty
@@ -72,20 +59,12 @@ class FnDecelerationSpec extends AnyWordSpec with Matchers {
       val function =
         parseFunction("fn  ")
 
-      function.fn shouldBe
-        SoftAST.Fn(
-          SoftAST.Code(
-            index = indexOf(">>fn<<  "),
-            text = Token.Fn.lexeme
-          )
-        )
+      function.fn shouldBe Fn(indexOf(">>fn<<  "))
 
       function.preSignatureSpace shouldBe
-        SoftAST.Space(
-          SoftAST.Code(
-            index = indexOf(s"fn>>  <<"),
-            text = "  "
-          )
+        Space(
+          index = indexOf(s"fn>>  <<"),
+          text = "  "
         )
 
       function.postSignatureSpace shouldBe empty
@@ -116,11 +95,9 @@ class FnDecelerationSpec extends AnyWordSpec with Matchers {
       val actual = blahIdentifiers.last
 
       val expected =
-        SoftAST.Identifier(
-          SoftAST.Code(
-            index = blahIndex,
-            text = "blah"
-          )
+        Identifier(
+          index = blahIndex,
+          text = "blah"
         )
 
       actual shouldBe expected
@@ -152,27 +129,22 @@ class FnDecelerationSpec extends AnyWordSpec with Matchers {
        * Test first function
        */
       functions.head.signature.fnName shouldBe
-        SoftAST.Identifier(
-          SoftAST.Code(
-            index = indexOf("fn >>function<<"),
-            text = "function"
-          )
+        Identifier(
+          index = indexOf("fn >>function<<"),
+          text = "function"
         )
 
       /**
        * Test second function
        */
       functions.last.fn shouldBe
-        SoftAST.Fn(
-          SoftAST.Code(
-            index = indexOf {
-              """fn function(
-                |  >>fn<<
-                |}
-                |""".stripMargin
-            },
-            text = Token.Fn.lexeme
-          )
+        Fn(
+          indexOf {
+            """fn function(
+              |  >>fn<<
+              |}
+              |""".stripMargin
+          }
         )
 
       functions.last.signature.fnName shouldBe

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionNameSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionNameSpec.scala
@@ -18,6 +18,7 @@ package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -29,11 +30,9 @@ class FunctionNameSpec extends AnyWordSpec with Matchers {
       parseFunction("fn function")
 
     function.signature.fnName shouldBe
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf("fn >>function<<"),
-          text = "function"
-        )
+      Identifier(
+        index = indexOf("fn >>function<<"),
+        text = "function"
       )
   }
 
@@ -42,11 +41,9 @@ class FunctionNameSpec extends AnyWordSpec with Matchers {
       parseFunction("fn _FnUc_TiOn_")
 
     function.signature.fnName shouldBe
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf("fn >>_FnUc_TiOn_<<"),
-          text = "_FnUc_TiOn_"
-        )
+      Identifier(
+        index = indexOf("fn >>_FnUc_TiOn_<<"),
+        text = "_FnUc_TiOn_"
       )
   }
 
@@ -55,28 +52,22 @@ class FunctionNameSpec extends AnyWordSpec with Matchers {
       parseFunction("fn       _FnUc_TiOn_        ")
 
     function.preSignatureSpace shouldBe
-      SoftAST.Space(
-        SoftAST.Code(
-          index = indexOf("fn>>       <<_FnUc_TiOn_        "),
-          text = "       "
-        )
+      Space(
+        index = indexOf("fn>>       <<_FnUc_TiOn_        "),
+        text = "       "
       )
 
     function.signature.fnName shouldBe
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf("fn       >>_FnUc_TiOn_<<        "),
-          text = "_FnUc_TiOn_"
-        )
+      Identifier(
+        index = indexOf("fn       >>_FnUc_TiOn_<<        "),
+        text = "_FnUc_TiOn_"
       )
 
     function.signature.preParamSpace should
       contain(
-        SoftAST.Space(
-          SoftAST.Code(
-            index = indexOf("fn       _FnUc_TiOn_>>        <<"),
-            text = "        "
-          )
+        Space(
+          index = indexOf("fn       _FnUc_TiOn_>>        <<"),
+          text = "        "
         )
       )
   }
@@ -86,11 +77,9 @@ class FunctionNameSpec extends AnyWordSpec with Matchers {
       parseFunction("fn abcd efgh ijk")
 
     val expected =
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf("fn >>abcd<< efgh ijk"),
-          text = "abcd"
-        )
+      Identifier(
+        index = indexOf("fn >>abcd<< efgh ijk"),
+        text = "abcd"
       )
 
     function.signature.fnName shouldBe expected
@@ -119,11 +108,9 @@ class FunctionNameSpec extends AnyWordSpec with Matchers {
     functions should have size 1
     val function = functions.head
     function.signature.fnName shouldBe
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf("fn >>abcd<< *YNKJ *BUPP"),
-          text = "abcd"
-        )
+      Identifier(
+        index = indexOf("fn >>abcd<< *YNKJ *BUPP"),
+        text = "abcd"
       )
 
     /**
@@ -132,19 +119,15 @@ class FunctionNameSpec extends AnyWordSpec with Matchers {
     unresolved should have size 2
     // head unresolved
     unresolved.head shouldBe
-      SoftAST.Unresolved(
-        SoftAST.Code(
-          index = indexOf("fn abcd >>*YNKJ<< *BUPP"),
-          text = "*YNKJ"
-        )
+      Unresolved(
+        index = indexOf("fn abcd >>*YNKJ<< *BUPP"),
+        text = "*YNKJ"
       )
     // last unresolved
     unresolved.last shouldBe
-      SoftAST.Unresolved(
-        SoftAST.Code(
-          index = indexOf("fn abcd *YNKJ >>*BUPP<<"),
-          text = "*BUPP"
-        )
+      Unresolved(
+        index = indexOf("fn abcd *YNKJ >>*BUPP<<"),
+        text = "*BUPP"
       )
   }
 
@@ -161,14 +144,12 @@ class FunctionNameSpec extends AnyWordSpec with Matchers {
       }
 
     function.signature.fnName shouldBe
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf("""fn
-              |
-              |>>abcd<<
-              |""".stripMargin),
-          text = "abcd"
-        )
+      Identifier(
+        index = indexOf("""fn
+            |
+            |>>abcd<<
+            |""".stripMargin),
+        text = "abcd"
       )
 
   }
@@ -178,11 +159,9 @@ class FunctionNameSpec extends AnyWordSpec with Matchers {
       parseFunction("fn abcd(")
 
     function.signature.fnName shouldBe
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf("fn >>abcd<<("),
-          text = "abcd"
-        )
+      Identifier(
+        index = indexOf("fn >>abcd<<("),
+        text = "abcd"
       )
 
     function
@@ -196,11 +175,9 @@ class FunctionNameSpec extends AnyWordSpec with Matchers {
       parseFunction("fn abcd)")
 
     function.signature.fnName shouldBe
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf("fn >>abcd<<)"),
-          text = "abcd"
-        )
+      Identifier(
+        index = indexOf("fn >>abcd<<)"),
+        text = "abcd"
       )
 
     function

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionReturnClauseSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionReturnClauseSpec.scala
@@ -17,7 +17,8 @@
 package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -32,20 +33,8 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
           index = indexOf("fn >>-> <<"),
-          forwardArrow = SoftAST.ForwardArrow(
-            SoftAST.Code(
-              index = indexOf("fn >>-><< "),
-              text = Token.ForwardArrow.lexeme
-            )
-          ),
-          space = Some(
-            SoftAST.Space(
-              SoftAST.Code(
-                index = indexOf("fn __>> <<"),
-                text = " "
-              )
-            )
-          ),
+          forwardArrow = ForwardArrow(indexOf("fn >>-><< ")),
+          space = Some(SpaceOne(indexOf("fn __>> <<"))),
           tpe = SoftAST.IdentifierExpected(indexOf("fn -> >><<"))
         )
     }
@@ -57,12 +46,7 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
           index = indexOf("fn >>-> type<<"),
-          forwardArrow = SoftAST.ForwardArrow(
-            SoftAST.Code(
-              index = indexOf("fn >>-><< type"),
-              text = Token.ForwardArrow.lexeme
-            )
-          ),
+          forwardArrow = ForwardArrow(indexOf("fn >>-><< type")),
           space = Some(
             SoftAST.Space(
               SoftAST.Code(
@@ -71,11 +55,9 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
               )
             )
           ),
-          tpe = SoftAST.Identifier(
-            SoftAST.Code(
-              index = indexOf("fn -> >>type<<"),
-              text = "type"
-            )
+          tpe = Identifier(
+            index = indexOf("fn -> >>type<<"),
+            text = "type"
           )
         )
     }
@@ -87,30 +69,16 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
         parseFunction("fn function -> ")
 
       function.signature.fnName shouldBe
-        SoftAST.Identifier(
-          SoftAST.Code(
-            index = indexOf("fn >>function<< -> "),
-            text = "function"
-          )
+        Identifier(
+          index = indexOf("fn >>function<< -> "),
+          text = "function"
         )
 
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
           index = indexOf("fn function >>-> <<"),
-          forwardArrow = SoftAST.ForwardArrow(
-            SoftAST.Code(
-              index = indexOf("fn function >>-><< "),
-              text = Token.ForwardArrow.lexeme
-            )
-          ),
-          space = Some(
-            SoftAST.Space(
-              SoftAST.Code(
-                index = indexOf("fn function __>> <<"),
-                text = " "
-              )
-            )
-          ),
+          forwardArrow = ForwardArrow(indexOf("fn function >>-><< ")),
+          space = Some(SpaceOne(indexOf("fn function __>> <<"))),
           tpe = SoftAST.IdentifierExpected(indexOf("fn function -> >><<"))
         )
     }
@@ -120,35 +88,19 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
         parseFunction("fn function -> type")
 
       function.signature.fnName shouldBe
-        SoftAST.Identifier(
-          SoftAST.Code(
-            index = indexOf("fn >>function<< -> "),
-            text = "function"
-          )
+        Identifier(
+          index = indexOf("fn >>function<< -> "),
+          text = "function"
         )
 
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
           index = indexOf("fn function >>-> type<<"),
-          forwardArrow = SoftAST.ForwardArrow(
-            SoftAST.Code(
-              index = indexOf("fn function >>-><< type"),
-              text = Token.ForwardArrow.lexeme
-            )
-          ),
-          space = Some(
-            SoftAST.Space(
-              SoftAST.Code(
-                index = indexOf("fn function __>> <<type"),
-                text = " "
-              )
-            )
-          ),
-          tpe = SoftAST.Identifier(
-            SoftAST.Code(
-              index = indexOf("fn function -> >>type<<"),
-              text = "type"
-            )
+          forwardArrow = ForwardArrow(indexOf("fn function >>-><< type")),
+          space = Some(SpaceOne(indexOf("fn function __>> <<type"))),
+          tpe = Identifier(
+            index = indexOf("fn function -> >>type<<"),
+            text = "type"
           )
         )
     }
@@ -160,20 +112,12 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
         parseFunction("fn function(-> ")
 
       function.signature.fnName shouldBe
-        SoftAST.Identifier(
-          SoftAST.Code(
-            index = indexOf("fn >>function<<(-> "),
-            text = "function"
-          )
+        Identifier(
+          index = indexOf("fn >>function<<(-> "),
+          text = "function"
         )
 
-      function.signature.params.openParen shouldBe
-        SoftAST.OpenParen(
-          SoftAST.Code(
-            index = indexOf("fn function>>(<<-> "),
-            text = Token.OpenParen.lexeme
-          )
-        )
+      function.signature.params.openParen shouldBe OpenParen(indexOf("fn function>>(<<-> "))
 
       function.signature.params.closeParen shouldBe
         SoftAST.CloseParenExpected(indexOf("fn function(>><<-> "))
@@ -181,20 +125,8 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
           index = indexOf("fn function(>>-> <<"),
-          forwardArrow = SoftAST.ForwardArrow(
-            SoftAST.Code(
-              index = indexOf("fn function(>>-><< "),
-              text = Token.ForwardArrow.lexeme
-            )
-          ),
-          space = Some(
-            SoftAST.Space(
-              SoftAST.Code(
-                index = indexOf("fn function(__>> <<"),
-                text = " "
-              )
-            )
-          ),
+          forwardArrow = ForwardArrow(indexOf("fn function(>>-><< ")),
+          space = Some(SpaceOne(indexOf("fn function(__>> <<"))),
           tpe = SoftAST.IdentifierExpected(indexOf("fn function(-> >><<"))
         )
     }
@@ -204,46 +136,22 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
         parseFunction("fn function(-> Type")
 
       function.signature.fnName shouldBe
-        SoftAST.Identifier(
-          SoftAST.Code(
-            index = indexOf("fn >>function<<(-> Type"),
-            text = "function"
-          )
+        Identifier(
+          index = indexOf("fn >>function<<(-> Type"),
+          text = "function"
         )
 
-      function.signature.params.openParen shouldBe
-        SoftAST.OpenParen(
-          SoftAST.Code(
-            index = indexOf("fn function>>(<<-> Type"),
-            text = Token.OpenParen.lexeme
-          )
-        )
-
-      function.signature.params.closeParen shouldBe
-        SoftAST.CloseParenExpected(indexOf("fn function(>><<-> Type"))
+      function.signature.params.openParen shouldBe OpenParen(indexOf("fn function>>(<<-> Type"))
+      function.signature.params.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("fn function(>><<-> Type"))
 
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
           index = indexOf("fn function(>>-> Type<<"),
-          forwardArrow = SoftAST.ForwardArrow(
-            SoftAST.Code(
-              index = indexOf("fn function(>>-><< Type"),
-              text = Token.ForwardArrow.lexeme
-            )
-          ),
-          space = Some(
-            SoftAST.Space(
-              SoftAST.Code(
-                index = indexOf("fn function(__>> <<Type"),
-                text = " "
-              )
-            )
-          ),
-          tpe = SoftAST.Identifier(
-            SoftAST.Code(
-              index = indexOf("fn function(-> >>Type<<"),
-              text = "Type"
-            )
+          forwardArrow = ForwardArrow(indexOf("fn function(>>-><< Type")),
+          space = Some(SpaceOne(indexOf("fn function(__>> <<Type"))),
+          tpe = Identifier(
+            index = indexOf("fn function(-> >>Type<<"),
+            text = "Type"
           )
         )
 
@@ -256,46 +164,19 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
         parseFunction("fn function() -> ")
 
       function.signature.fnName shouldBe
-        SoftAST.Identifier(
-          SoftAST.Code(
-            index = indexOf("fn >>function<<() -> "),
-            text = "function"
-          )
+        Identifier(
+          index = indexOf("fn >>function<<() -> "),
+          text = "function"
         )
 
-      function.signature.params.openParen shouldBe
-        SoftAST.OpenParen(
-          SoftAST.Code(
-            index = indexOf("fn function>>(<<) -> "),
-            text = Token.OpenParen.lexeme
-          )
-        )
-
-      function.signature.params.closeParen shouldBe
-        SoftAST.CloseParen(
-          SoftAST.Code(
-            index = indexOf("fn function(>>)<< -> "),
-            text = Token.CloseParen.lexeme
-          )
-        )
+      function.signature.params.openParen shouldBe OpenParen(indexOf("fn function>>(<<) -> "))
+      function.signature.params.closeParen shouldBe CloseParen(indexOf("fn function(>>)<< -> "))
 
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
           index = indexOf("fn function() >>-> <<"),
-          forwardArrow = SoftAST.ForwardArrow(
-            SoftAST.Code(
-              index = indexOf("fn function() >>-><< "),
-              text = Token.ForwardArrow.lexeme
-            )
-          ),
-          space = Some(
-            SoftAST.Space(
-              SoftAST.Code(
-                index = indexOf("fn function() __>> <<"),
-                text = " "
-              )
-            )
-          ),
+          forwardArrow = ForwardArrow(indexOf("fn function() >>-><< ")),
+          space = Some(SpaceOne(indexOf("fn function() __>> <<"))),
           tpe = SoftAST.IdentifierExpected(indexOf("fn function() -> >><<"))
         )
     }
@@ -305,51 +186,22 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
         parseFunction("fn function() -> type")
 
       function.signature.fnName shouldBe
-        SoftAST.Identifier(
-          SoftAST.Code(
-            index = indexOf("fn >>function<<() -> type"),
-            text = "function"
-          )
+        Identifier(
+          index = indexOf("fn >>function<<() -> type"),
+          text = "function"
         )
 
-      function.signature.params.openParen shouldBe
-        SoftAST.OpenParen(
-          SoftAST.Code(
-            index = indexOf("fn function>>(<<) -> type"),
-            text = Token.OpenParen.lexeme
-          )
-        )
-
-      function.signature.params.closeParen shouldBe
-        SoftAST.CloseParen(
-          SoftAST.Code(
-            index = indexOf("fn function(>>)<< -> type"),
-            text = Token.CloseParen.lexeme
-          )
-        )
+      function.signature.params.openParen shouldBe OpenParen(indexOf("fn function>>(<<) -> type"))
+      function.signature.params.closeParen shouldBe CloseParen(indexOf("fn function(>>)<< -> type"))
 
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
           index = indexOf("fn function() >>-> type<<"),
-          forwardArrow = SoftAST.ForwardArrow(
-            SoftAST.Code(
-              index = indexOf("fn function() >>-><< type"),
-              text = Token.ForwardArrow.lexeme
-            )
-          ),
-          space = Some(
-            SoftAST.Space(
-              SoftAST.Code(
-                index = indexOf("fn function() __>> <<type"),
-                text = " "
-              )
-            )
-          ),
-          tpe = SoftAST.Identifier(
-            SoftAST.Code(
-              index = indexOf("fn function() -> >>type<<"),
-              text = "type"
-            )
+          forwardArrow = ForwardArrow(indexOf("fn function() >>-><< type")),
+          space = Some(SpaceOne(indexOf("fn function() __>> <<type"))),
+          tpe = Identifier(
+            index = indexOf("fn function() -> >>type<<"),
+            text = "type"
           )
         )
     }
@@ -368,51 +220,32 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
     val function = block.parts.head.part.asInstanceOf[SoftAST.Function]
 
     function.signature.fnName shouldBe
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf("fn >>function<<() => ABC"),
-          text = "function"
-        )
+      Identifier(
+        index = indexOf("fn >>function<<() => ABC"),
+        text = "function"
       )
 
-    function.signature.params.openParen shouldBe
-      SoftAST.OpenParen(
-        SoftAST.Code(
-          index = indexOf("fn function>>(<<) => ABC"),
-          text = Token.OpenParen.lexeme
-        )
-      )
-
-    function.signature.params.closeParen shouldBe
-      SoftAST.CloseParen(
-        SoftAST.Code(
-          index = indexOf("fn function(>>)<< => ABC"),
-          text = Token.CloseParen.lexeme
-        )
-      )
+    function.signature.params.openParen shouldBe OpenParen(indexOf("fn function>>(<<) => ABC"))
+    function.signature.params.closeParen shouldBe CloseParen(indexOf("fn function(>>)<< => ABC"))
 
     /**
      * Second part is [[SoftAST.Unresolved]] arrow `=>`
      */
     val unresolvedArrow = block.parts(1).part.asInstanceOf[SoftAST.Unresolved]
     unresolvedArrow shouldBe
-      SoftAST.Unresolved(
-        SoftAST.Code(
-          index = indexOf("fn function() >>=><< ABC"),
-          text = "=>"
-        )
+      Unresolved(
+        index = indexOf("fn function() >>=><< ABC"),
+        text = "=>"
       )
 
     /**
-     * Third part is [[SoftAST.Identifier]] token `ABC`
+     * Third part is [[Identifier]] token `ABC`
      */
     val identifier = block.parts(2).part.asInstanceOf[SoftAST.Identifier]
     identifier shouldBe
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf("fn function() => >>ABC<<"),
-          text = "ABC"
-        )
+      Identifier(
+        index = indexOf("fn function() => >>ABC<<"),
+        text = "ABC"
       )
   }
 

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateSpec.scala
@@ -17,7 +17,8 @@
 package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -36,11 +37,9 @@ class TemplateSpec extends AnyWordSpec with Matchers {
           parts = Seq(
             SoftAST.BlockBodyPart(
               index = indexOf(s">>$templateToken<<"),
-              part = SoftAST.Identifier(
-                SoftAST.Code(
-                  index = indexOf(s">>$templateToken<<"),
-                  text = templateToken
-                )
+              part = Identifier(
+                index = indexOf(s">>$templateToken<<"),
+                text = templateToken
               ),
               postPartSpace = None
             )
@@ -59,15 +58,7 @@ class TemplateSpec extends AnyWordSpec with Matchers {
           parseTemplate(templateToken)
 
         template.index shouldBe indexOf(s">>$templateToken<<")
-
-        template.templateType shouldBe
-          SoftAST.Contract(
-            SoftAST.Code(
-              index = indexOf(s">>$templateToken<<"),
-              text = Token.Contract.lexeme
-            )
-          )
-
+        template.templateType shouldBe Contract(indexOf(s">>$templateToken<<"))
         template.preIdentifierSpace shouldBe SoftAST.SpaceExpected(indexOf(s"$templateToken>><<"))
         template.identifier shouldBe SoftAST.IdentifierExpected(indexOf(s"$templateToken>><<"))
         template.preParamSpace shouldBe None
@@ -91,15 +82,7 @@ class TemplateSpec extends AnyWordSpec with Matchers {
           parseTemplate(templateToken)
 
         template.index shouldBe indexOf(s">>$templateToken<<")
-
-        template.templateType shouldBe
-          SoftAST.TxScript(
-            SoftAST.Code(
-              index = indexOf(s">>$templateToken<<"),
-              text = Token.TxScript.lexeme
-            )
-          )
-
+        template.templateType shouldBe TxScript(indexOf(s">>$templateToken<<"))
         template.preIdentifierSpace shouldBe SoftAST.SpaceExpected(indexOf(s"$templateToken>><<"))
         template.identifier shouldBe SoftAST.IdentifierExpected(indexOf(s"$templateToken>><<"))
         template.preParamSpace shouldBe empty
@@ -120,11 +103,9 @@ class TemplateSpec extends AnyWordSpec with Matchers {
       parseTemplate("Contract mycontract")
 
     template.identifier shouldBe
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf("Contract >>mycontract<<"),
-          text = "mycontract"
-        )
+      Identifier(
+        index = indexOf("Contract >>mycontract<<"),
+        text = "mycontract"
       )
   }
 
@@ -134,14 +115,7 @@ class TemplateSpec extends AnyWordSpec with Matchers {
         parseTemplate("Contract mycontract(")
 
       val params = template.params.value
-      params.openParen shouldBe
-        SoftAST.OpenParen(
-          SoftAST.Code(
-            index = indexOf("Contract mycontract>>(<<"),
-            text = Token.OpenParen.lexeme
-          )
-        )
-
+      params.openParen shouldBe OpenParen(indexOf("Contract mycontract>>(<<"))
       params.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("Contract mycontract(>><<"))
     }
 
@@ -151,13 +125,7 @@ class TemplateSpec extends AnyWordSpec with Matchers {
 
       val params = template.params.value
 
-      params.preHeadExpressionSpace.value shouldBe
-        SoftAST.Space(
-          SoftAST.Code(
-            index = indexOf("Contract mycontract(>> <<)"),
-            text = " "
-          )
-        )
+      params.preHeadExpressionSpace.value shouldBe SpaceOne(indexOf("Contract mycontract(>> <<)"))
     }
   }
 
@@ -166,14 +134,7 @@ class TemplateSpec extends AnyWordSpec with Matchers {
       val template =
         parseTemplate("Contract mycontract }")
 
-      template.block.closeCurly shouldBe
-        SoftAST.CloseCurly(
-          SoftAST.Code(
-            index = indexOf("Contract mycontract >>}<<"),
-            text = Token.CloseCurly.lexeme
-          )
-        )
-
+      template.block.closeCurly shouldBe CloseCurly(indexOf("Contract mycontract >>}<<"))
       template.block.openCurly shouldBe SoftAST.OpenCurlyExpected(indexOf("Contract mycontract >><<}"))
     }
 
@@ -183,22 +144,9 @@ class TemplateSpec extends AnyWordSpec with Matchers {
 
       template.identifier shouldBe SoftAST.IdentifierExpected(indexOf("Contract >><<{"))
 
-      template.preIdentifierSpace shouldBe
-        SoftAST.Space(
-          SoftAST.Code(
-            index = indexOf("Contract>> <<{"),
-            text = " "
-          )
-        )
+      template.preIdentifierSpace shouldBe SpaceOne(indexOf("Contract>> <<{"))
 
-      template.block.openCurly shouldBe
-        SoftAST.OpenCurly(
-          SoftAST.Code(
-            index = indexOf("Contract >>{<<"),
-            text = Token.OpenCurly.lexeme
-          )
-        )
-
+      template.block.openCurly shouldBe OpenCurly(indexOf("Contract >>{<<"))
       template.block.closeCurly shouldBe SoftAST.CloseCurlyExpected(indexOf("Contract {>><<"))
     }
 
@@ -212,21 +160,9 @@ class TemplateSpec extends AnyWordSpec with Matchers {
         }
 
       template.identifier shouldBe SoftAST.IdentifierExpected(indexOf("Contract >><<{"))
-      template.preIdentifierSpace shouldBe
-        SoftAST.Space(
-          SoftAST.Code(
-            index = indexOf("Contract>> <<{"),
-            text = " "
-          )
-        )
+      template.preIdentifierSpace shouldBe SpaceOne(indexOf("Contract>> <<{"))
       // block
-      template.block.openCurly shouldBe
-        SoftAST.OpenCurly(
-          SoftAST.Code(
-            index = indexOf("Contract >>{<<"),
-            text = Token.OpenCurly.lexeme
-          )
-        )
+      template.block.openCurly shouldBe OpenCurly(indexOf("Contract >>{<<"))
 
       template.block.closeCurly shouldBe
         SoftAST.CloseCurlyExpected(
@@ -245,29 +181,24 @@ class TemplateSpec extends AnyWordSpec with Matchers {
       val function = template.block.body.parts.head.part.asInstanceOf[SoftAST.Function]
 
       function.fn shouldBe
-        SoftAST.Fn(
-          SoftAST.Code(
-            index = indexOf {
-              """Contract {
-                |  >>fn<< function( ->
-                |
-                |""".stripMargin
-            },
-            text = Token.Fn.lexeme
-          )
+        Fn(
+          indexOf {
+            """Contract {
+              |  >>fn<< function( ->
+              |
+              |""".stripMargin
+          }
         )
 
       function.signature.fnName shouldBe
-        SoftAST.Identifier(
-          SoftAST.Code(
-            index = indexOf {
-              """Contract {
-                |  fn >>function<<( ->
-                |
-                |""".stripMargin
-            },
-            text = "function"
-          )
+        Identifier(
+          index = indexOf {
+            """Contract {
+              |  fn >>function<<( ->
+              |
+              |""".stripMargin
+          },
+          text = "function"
         )
     }
 
@@ -281,21 +212,9 @@ class TemplateSpec extends AnyWordSpec with Matchers {
         }
 
       template.identifier shouldBe SoftAST.IdentifierExpected(indexOf("Contract >><<{"))
-      template.preIdentifierSpace shouldBe
-        SoftAST.Space(
-          SoftAST.Code(
-            index = indexOf("Contract>> <<{"),
-            text = " "
-          )
-        )
+      template.preIdentifierSpace shouldBe SpaceOne(indexOf("Contract>> <<{"))
       // block
-      template.block.openCurly shouldBe
-        SoftAST.OpenCurly(
-          SoftAST.Code(
-            index = indexOf("Contract >>{<<"),
-            text = Token.OpenCurly.lexeme
-          )
-        )
+      template.block.openCurly shouldBe OpenCurly(indexOf("Contract >>{<<"))
 
       template.block.closeCurly shouldBe
         SoftAST.CloseCurlyExpected(
@@ -314,29 +233,24 @@ class TemplateSpec extends AnyWordSpec with Matchers {
       val txScriptTemplate = template.block.body.parts.head.part.asInstanceOf[SoftAST.Template]
 
       txScriptTemplate.templateType shouldBe
-        SoftAST.TxScript(
-          SoftAST.Code(
-            index = indexOf {
-              """Contract {
-                |  >>TxScript<< myScript
-                |
-                |""".stripMargin
-            },
-            text = Token.TxScript.lexeme
-          )
+        TxScript(
+          indexOf {
+            """Contract {
+              |  >>TxScript<< myScript
+              |
+              |""".stripMargin
+          }
         )
 
       txScriptTemplate.identifier shouldBe
-        SoftAST.Identifier(
-          SoftAST.Code(
-            index = indexOf {
-              """Contract {
-                |  TxScript >>myScript<<
-                |
-                |""".stripMargin
-            },
-            text = "myScript"
-          )
+        Identifier(
+          index = indexOf {
+            """Contract {
+              |  TxScript >>myScript<<
+              |
+              |""".stripMargin
+          },
+          text = "myScript"
         )
     }
 
@@ -356,16 +270,14 @@ class TemplateSpec extends AnyWordSpec with Matchers {
       val part = template.block.body.parts.head.part
 
       part shouldBe
-        SoftAST.Identifier(
-          SoftAST.Code(
-            indexOf {
-              """Contract MyContract {
-                |  >>blah<<
-                |
-                |""".stripMargin
-            },
-            "blah"
-          )
+        Identifier(
+          index = indexOf {
+            """Contract MyContract {
+              |  >>blah<<
+              |
+              |""".stripMargin
+          },
+          text = "blah"
         )
 
     }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TupleSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TupleSpec.scala
@@ -17,7 +17,8 @@
 package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -29,32 +30,16 @@ class TupleSpec extends AnyWordSpec with Matchers {
     val tuple =
       parseTuple(")")
 
-    tuple.openParen shouldBe
-      SoftAST.OpenParenExpected(indexOf(">><<)"))
-
-    tuple.closeParen shouldBe
-      SoftAST.CloseParen(
-        SoftAST.Code(
-          index = indexOf(">>)<<"),
-          text = Token.CloseParen.lexeme
-        )
-      )
+    tuple.openParen shouldBe SoftAST.OpenParenExpected(indexOf(">><<)"))
+    tuple.closeParen shouldBe CloseParen(indexOf(">>)<<"))
   }
 
   "missing closing paren" in {
     val tuple =
       parseTuple("(")
 
-    tuple.openParen shouldBe
-      SoftAST.OpenParen(
-        SoftAST.Code(
-          index = indexOf(">>(<<"),
-          text = Token.OpenParen.lexeme
-        )
-      )
-
-    tuple.closeParen shouldBe
-      SoftAST.CloseParenExpected(indexOf("(>><<"))
+    tuple.openParen shouldBe OpenParen(indexOf(">>(<<"))
+    tuple.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("(>><<"))
   }
 
   "empty tuple" when {
@@ -65,22 +50,12 @@ class TupleSpec extends AnyWordSpec with Matchers {
       val expected =
         SoftAST.Tuple(
           index = indexOf(">>()<<"),
-          openParen = SoftAST.OpenParen(
-            SoftAST.Code(
-              index = indexOf(">>(<<)"),
-              text = Token.OpenParen.lexeme
-            )
-          ),
+          openParen = OpenParen(indexOf(">>(<<)")),
           preHeadExpressionSpace = None,
           headExpression = None,
           postHeadExpressionSpace = None,
           tailExpressions = Seq.empty,
-          closeParen = SoftAST.CloseParen(
-            SoftAST.Code(
-              index = indexOf("(>>)<<)"),
-              text = Token.CloseParen.lexeme
-            )
-          )
+          closeParen = CloseParen(indexOf("(>>)<<)"))
         )
 
       tuple shouldBe expected
@@ -93,29 +68,12 @@ class TupleSpec extends AnyWordSpec with Matchers {
       val expected =
         SoftAST.Tuple(
           index = indexOf(">>( )<<"),
-          openParen = SoftAST.OpenParen(
-            SoftAST.Code(
-              index = indexOf(">>(<< )"),
-              text = Token.OpenParen.lexeme
-            )
-          ),
-          preHeadExpressionSpace = Some(
-            SoftAST.Space(
-              SoftAST.Code(
-                index = indexOf("(>> <<)"),
-                text = " "
-              )
-            )
-          ),
+          openParen = OpenParen(indexOf(">>(<< )")),
+          preHeadExpressionSpace = Some(SpaceOne(indexOf("(>> <<)"))),
           headExpression = None,
           postHeadExpressionSpace = None,
           tailExpressions = Seq.empty,
-          closeParen = SoftAST.CloseParen(
-            SoftAST.Code(
-              index = indexOf("( >>)<<)"),
-              text = Token.CloseParen.lexeme
-            )
-          )
+          closeParen = CloseParen(indexOf("( >>)<<)"))
         )
 
       tuple shouldBe expected
@@ -132,20 +90,12 @@ class TupleSpec extends AnyWordSpec with Matchers {
     val tuple =
       body.parts.head.part.asInstanceOf[SoftAST.Tuple]
 
-    tuple.openParen shouldBe
-      SoftAST.OpenParen(
-        SoftAST.Code(
-          index = indexOf(">>(<<aaa typename"),
-          text = Token.OpenParen.lexeme
-        )
-      )
+    tuple.openParen shouldBe OpenParen(indexOf(">>(<<aaa typename"))
 
     tuple.headExpression.value.asInstanceOf[SoftAST.Identifier] shouldBe
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf("(>>aaa<< typename"),
-          text = "aaa"
-        )
+      Identifier(
+        index = indexOf("(>>aaa<< typename"),
+        text = "aaa"
       )
 
     tuple.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("(aaa >><<typename"))
@@ -157,67 +107,37 @@ class TupleSpec extends AnyWordSpec with Matchers {
       body.parts.last.part.asInstanceOf[SoftAST.Identifier]
 
     identifier shouldBe
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf("(aaa >>typename<<"),
-          text = "typename"
-        )
+      Identifier(
+        index = indexOf("(aaa >>typename<<"),
+        text = "typename"
       )
   }
 
   "valid type assignment expression exists" in {
     val tuple = parseTuple("(aaa: typename)")
 
-    tuple.openParen shouldBe
-      SoftAST.OpenParen(
-        SoftAST.Code(
-          index = indexOf(">>(<<aaa: typename"),
-          text = Token.OpenParen.lexeme
-        )
-      )
+    tuple.openParen shouldBe OpenParen(indexOf(">>(<<aaa: typename"))
 
     val headExpression =
       tuple.headExpression.value.asInstanceOf[SoftAST.TypeAssignment]
 
     headExpression.name shouldBe
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf("(>>aaa<<: typename"),
-          text = "aaa"
-        )
+      Identifier(
+        index = indexOf("(>>aaa<<: typename"),
+        text = "aaa"
       )
 
-    headExpression.colon shouldBe
-      SoftAST.Colon(
-        SoftAST.Code(
-          index = indexOf("(aaa>>:<< typename"),
-          text = Token.Colon.lexeme
-        )
-      )
+    headExpression.colon shouldBe Colon(indexOf("(aaa>>:<< typename"))
 
-    headExpression.postColonSpace.value shouldBe
-      SoftAST.Space(
-        SoftAST.Code(
-          index = indexOf("(aaa:>> <<typename"),
-          text = " "
-        )
-      )
+    headExpression.postColonSpace.value shouldBe SpaceOne(indexOf("(aaa:>> <<typename"))
 
     headExpression.tpe shouldBe
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf("(aaa: >>typename<<"),
-          text = "typename"
-        )
+      Identifier(
+        index = indexOf("(aaa: >>typename<<"),
+        text = "typename"
       )
 
-    tuple.closeParen shouldBe
-      SoftAST.CloseParen(
-        SoftAST.Code(
-          index = indexOf("(aaa: typename>>)<<"),
-          text = Token.CloseParen.lexeme
-        )
-      )
+    tuple.closeParen shouldBe CloseParen(indexOf("(aaa: typename>>)<<"))
   }
 
   "valid second type assignment expression exists" in {
@@ -226,39 +146,23 @@ class TupleSpec extends AnyWordSpec with Matchers {
     tuple.tailExpressions should have size 1
     val bbb = tuple.tailExpressions.head
 
-    bbb.comma shouldBe
-      SoftAST.Comma(
-        SoftAST.Code(
-          indexOf("(aaa: typename>>,<< bbb: type2)"),
-          Token.Comma.lexeme
-        )
-      )
+    bbb.comma shouldBe Comma(indexOf("(aaa: typename>>,<< bbb: type2)"))
 
-    bbb.preExpressionSpace.value shouldBe
-      SoftAST.Space(
-        SoftAST.Code(
-          index = indexOf("(aaa: typename,>> <<bbb: type2)"),
-          text = " "
-        )
-      )
+    bbb.preExpressionSpace.value shouldBe SpaceOne(indexOf("(aaa: typename,>> <<bbb: type2)"))
 
     val bbbTypeAssignment =
       bbb.expression.asInstanceOf[SoftAST.TypeAssignment]
 
     bbbTypeAssignment.name shouldBe
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf("(aaa: typename, >>bbb<<: type2)"),
-          text = "bbb"
-        )
+      Identifier(
+        index = indexOf("(aaa: typename, >>bbb<<: type2)"),
+        text = "bbb"
       )
 
     bbbTypeAssignment.tpe shouldBe
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf("(aaa: typename, bbb: >>type2<<)"),
-          text = "type2"
-        )
+      Identifier(
+        index = indexOf("(aaa: typename, bbb: >>type2<<)"),
+        text = "type2"
       )
 
     bbb.postExpressionSpace shouldBe empty
@@ -270,30 +174,16 @@ class TupleSpec extends AnyWordSpec with Matchers {
     tuple.tailExpressions should have size 1
     val tupleTail = tuple.tailExpressions.head
 
-    tupleTail.comma shouldBe
-      SoftAST.Comma(
-        SoftAST.Code(
-          index = indexOf("(aaa: typename>>,<< bbb: (tuple1, tuple2))"),
-          text = Token.Comma.lexeme
-        )
-      )
+    tupleTail.comma shouldBe Comma(indexOf("(aaa: typename>>,<< bbb: (tuple1, tuple2))"))
 
-    tupleTail.preExpressionSpace.value shouldBe
-      SoftAST.Space(
-        SoftAST.Code(
-          index = indexOf("(aaa: typename,>> <<bbb: (tuple1, tuple2))"),
-          text = " "
-        )
-      )
+    tupleTail.preExpressionSpace.value shouldBe SpaceOne(indexOf("(aaa: typename,>> <<bbb: (tuple1, tuple2))"))
 
     val bbb = tupleTail.expression.asInstanceOf[SoftAST.TypeAssignment]
 
     bbb.name shouldBe
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf("(aaa: typename, >>bbb<<: (tuple1, tuple2))"),
-          text = "bbb"
-        )
+      Identifier(
+        index = indexOf("(aaa: typename, >>bbb<<: (tuple1, tuple2))"),
+        text = "bbb"
       )
 
     // A quick text to check that the tuple is actually a tuple

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeParserSpec.scala
@@ -2,6 +2,7 @@ package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -16,11 +17,9 @@ class TypeParserSpec extends AnyWordSpec with Matchers {
 
   "type is provided" in {
     parseType("one") shouldBe
-      SoftAST.Identifier(
-        SoftAST.Code(
-          index = indexOf(">>one<<"),
-          text = "one"
-        )
+      Identifier(
+        index = indexOf(">>one<<"),
+        text = "one"
       )
   }
 

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -1,0 +1,183 @@
+package org.alephium.ralph.lsp.access.compiler.parser.soft.ast
+
+import org.alephium.ralph.SourceIndex
+
+object TestSoftAST {
+
+  def Fn(index: SourceIndex): SoftAST.Fn =
+    SoftAST.Fn(
+      index = index,
+      documentation = None,
+      code = Code(
+        index = index,
+        token = Token.Fn
+      )
+    )
+
+  def Comma(index: SourceIndex): SoftAST.Comma =
+    SoftAST.Comma(
+      index = index,
+      documentation = None,
+      code = Code(
+        index = index,
+        token = Token.Comma
+      )
+    )
+
+  def DoubleForwardSlash(index: SourceIndex): SoftAST.DoubleForwardSlash =
+    SoftAST.DoubleForwardSlash(
+      code = Code(
+        index = index,
+        token = Token.DoubleForwardSlash
+      )
+    )
+
+  def At(index: SourceIndex): SoftAST.At =
+    SoftAST.At(
+      index = index,
+      documentation = None,
+      code = Code(
+        index = index,
+        token = Token.At
+      )
+    )
+
+  def Contract(index: SourceIndex): SoftAST.Contract =
+    SoftAST.Contract(
+      index = index,
+      documentation = None,
+      code = Code(
+        index = index,
+        token = Token.Contract
+      )
+    )
+
+  def TxScript(index: SourceIndex): SoftAST.TxScript =
+    SoftAST.TxScript(
+      index = index,
+      documentation = None,
+      code = Code(
+        index = index,
+        token = Token.TxScript
+      )
+    )
+
+  def Colon(index: SourceIndex): SoftAST.Colon =
+    SoftAST.Colon(
+      index = index,
+      documentation = None,
+      code = Code(
+        index = index,
+        token = Token.Colon
+      )
+    )
+
+  def ForwardArrow(index: SourceIndex): SoftAST.ForwardArrow =
+    SoftAST.ForwardArrow(
+      index = index,
+      documentation = None,
+      code = Code(
+        index = index,
+        token = Token.ForwardArrow
+      )
+    )
+
+  def OpenParen(index: SourceIndex): SoftAST.OpenParen =
+    SoftAST.OpenParen(
+      index = index,
+      documentation = None,
+      code = Code(
+        index = index,
+        token = Token.OpenParen
+      )
+    )
+
+  def CloseParen(index: SourceIndex): SoftAST.CloseParen =
+    SoftAST.CloseParen(
+      index = index,
+      documentation = None,
+      code = Code(
+        index = index,
+        token = Token.CloseParen
+      )
+    )
+
+  def OpenCurly(index: SourceIndex): SoftAST.OpenCurly =
+    SoftAST.OpenCurly(
+      index = index,
+      documentation = None,
+      code = Code(
+        index = index,
+        token = Token.OpenCurly
+      )
+    )
+
+  def CloseCurly(index: SourceIndex): SoftAST.CloseCurly =
+    SoftAST.CloseCurly(
+      index = index,
+      documentation = None,
+      code = Code(
+        index = index,
+        token = Token.CloseCurly
+      )
+    )
+
+  def Identifier(
+      index: SourceIndex,
+      text: String): SoftAST.Identifier =
+    SoftAST.Identifier(
+      index = index,
+      documentation = None,
+      code = SoftAST.Code(
+        index = index,
+        text = text
+      )
+    )
+
+  def Unresolved(
+      index: SourceIndex,
+      text: String): SoftAST.Unresolved =
+    SoftAST.Unresolved(
+      index = index,
+      documentation = None,
+      code = SoftAST.Code(
+        index = index,
+        text = text
+      )
+    )
+
+  def Space(
+      index: SourceIndex,
+      text: String): SoftAST.Space =
+    SoftAST.Space(
+      code = SoftAST.Code(
+        index = index,
+        text = text
+      )
+    )
+
+  def SpaceOne(index: SourceIndex): SoftAST.Space =
+    SoftAST.Space(
+      code = SoftAST.Code(
+        index = index,
+        text = " "
+      )
+    )
+
+  def SpaceNewline(index: SourceIndex): SoftAST.Space =
+    SoftAST.Space(
+      code = Code(
+        index = index,
+        token = Token.Newline
+      )
+    )
+
+  def Code(
+      index: SourceIndex,
+      token: Token): SoftAST.Code =
+    SoftAST.Code(
+      index = index,
+      text = token.lexeme
+    )
+
+}


### PR DESCRIPTION
These constructors are used only by test-cases, therefore, should not be in production code.

The constructors reduce the amount of code needed for each test-case by a small margin (see number of lines).