### PR TITLE
Suggest `inline` annotation

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/AnnotationCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/AnnotationCompleter.scala
@@ -34,6 +34,11 @@ object AnnotationCompleter {
         label = Parser.FunctionUsingAnnotation.id,
         insert = Parser.FunctionUsingAnnotation.id,
         detail = ""
+      ),
+      Suggestion.Keyword(
+        label = Parser.FunctionInlineAnnotation.id,
+        insert = Parser.FunctionInlineAnnotation.id,
+        detail = ""
       )
     )
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/completion/AnnotationCompleterSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/completion/AnnotationCompleterSpec.scala
@@ -28,7 +28,22 @@ class AnnotationCompleterSpec extends AnyWordSpec with Matchers {
         """
           |Contract Test() {
           |
-          |  @usi@@
+          |  @using@@
+          |  fn function() -> () { }
+          |}
+          |""".stripMargin
+      }
+
+    suggestions should contain allElementsOf AnnotationCompleter.suggestAnnotationNames().toList
+  }
+
+  "suggest `inline` annotation name" in {
+    val suggestions =
+      suggest {
+        """
+          |Contract Test() {
+          |
+          |  @inline@@
           |  fn function() -> () { }
           |}
           |""".stripMargin

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,10 +12,10 @@ object Dependencies {
   /** TEST */
   lazy val scalaTest  = "org.scalatest"     %% "scalatest"       % "3.2.19"   % Test
   lazy val scalaCheck = "org.scalatestplus" %% "scalacheck-1-17" % "3.2.18.0" % Test
-  lazy val scalaMock  = "org.scalamock"     %% "scalamock"       % "6.0.0"    % Test
+  lazy val scalaMock  = "org.scalamock"     %% "scalamock"       % "6.1.1"    % Test
 
   /** Core */
-  lazy val ralphc = "org.alephium" %% "alephium-ralphc" % "3.9.2" excludeAll (
+  lazy val ralphc = "org.alephium" %% "alephium-ralphc" % "3.11.2" excludeAll (
     ExclusionRule(organization = "org.rocksdb"),
     ExclusionRule(organization = "io.prometheus"),
     ExclusionRule(organization = "org.alephium", name = "alephium-api_2.13"),
@@ -26,6 +26,6 @@ object Dependencies {
 
   /** Logging */
   lazy val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging"   % "3.9.5"
-  lazy val logback      = "ch.qos.logback"              % "logback-classic" % "1.5.12"
+  lazy val logback      = "ch.qos.logback"              % "logback-classic" % "1.5.15"
 
 }


### PR DESCRIPTION
- Prepare release.

## Code completion on Annotation 

ralphc now requires annotations to be fully defined. For example: `@usin` now results in a parser error. 

Code completion for annotation does not make much sense anymore, because suggesting `using` after they've already typed `using` is not useful. But we can leave this to be resolved in #104.