### PR TITLE
Infix operators

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/InfixCallParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/InfixCallParser.scala
@@ -13,7 +13,7 @@ case object InfixCallParser {
       Index ~
         ExpressionParser.parseOrFailSelective(parseInfix = false, parseMethodCall = true) ~
         spaceOrFail.? ~
-        TokenParser.OperatorOrFail ~
+        TokenParser.InfixOperatorOrFail ~
         spaceOrFail.? ~
         ExpressionParser.parse ~
         Index

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/util/ParserUtil.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/util/ParserUtil.scala
@@ -1,0 +1,43 @@
+package org.alephium.ralph.lsp.access.util
+
+import fastparse._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.Token
+
+object ParserUtil {
+
+  /**
+   * Combines all items using the "or" combinator with the given parser.
+   *
+   * <b>Prerequisite</b>: The `items` iterator must not be empty.
+   *
+   * @param items  The items to be parsed.
+   * @param parser The parser to execute.
+   * @tparam Unknown The current fastparse context.
+   * @tparam I       The type of input items.
+   * @tparam O       The type of output produced by the parser.
+   * @return A combined parser all input items using the "or" combinator.
+   */
+  def orCombinator[Unknown: P, I, O](
+      items: Iterator[I],
+      parser: I => P[O]): P[O] =
+    items.nextOption() match {
+      case Some(head) =>
+        items.foldLeft(parser(head))(_ | parser(_))
+
+      case None =>
+        Fail("Expected nonempty items in orCombinator")
+    }
+
+  def orTokenCombinator[Unknown: P, T <: Token](tokens: Iterator[T]): P[T] =
+    orCombinator(
+      items = tokens,
+      parser = createParser(_: T)
+    )
+
+  @inline private def createParser[Unknown: P, T <: Token](item: T): P[T] =
+    P(item.lexeme) map {
+      _ =>
+        item
+    }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
@@ -54,6 +54,9 @@ object TestParser {
   def parseReservedToken(code: String): Token.Reserved =
     runAnyParser(TokenParser.Reserved(_))(code)
 
+  def parseInfixOperatorOrFail(code: String): SoftAST.Operator =
+    runAnyParser(TokenParser.InfixOperatorOrFail(_))(code)
+
   def parseReservedTokenOrError(code: String): Either[Parsed.Failure, Token.Reserved] =
     runAnyParserOrError(TokenParser.Reserved(_))(code)
 

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParserSpec.scala
@@ -1,0 +1,38 @@
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.Token
+import org.scalatest.matchers.should.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
+
+class TokenParserSpec extends AnyWordSpec {
+
+  "InfixOperatorOrFail" when {
+    "ForwardSlash" should {
+      "not parse double forward slash as it is reserved for comments" in {
+        assertThrows[Exception](
+          parseInfixOperatorOrFail("//")
+        )
+      }
+    }
+
+    "all infix operators" should {
+      "succeed" in {
+        val infixOperators = Token.infix
+        infixOperators should not be empty
+
+        infixOperators foreach {
+          infix =>
+            parseInfixOperatorOrFail(infix.lexeme) shouldBe
+              InfixOperator(
+                index = range(0, infix.lexeme.length),
+                token = infix
+              )
+        }
+      }
+    }
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -42,6 +42,18 @@ object TestSoftAST {
       )
     )
 
+  def InfixOperator(
+      index: SourceIndex,
+      token: Token.InfixOperator): SoftAST.Operator =
+    SoftAST.Operator(
+      index = index,
+      documentation = None,
+      code = Code(
+        index = index,
+        token = token
+      )
+    )
+
   def Contract(index: SourceIndex): SoftAST.Contract =
     SoftAST.Contract(
       index = index,


### PR DESCRIPTION
- Uses `EnumerationMacros.sealedInstancesOf[InfixOperator]` to fetch infix operators instead of calling parser on each manually.
- Added `ParserUtil`.