### PR TITLE
Common Parser and AST for `Token`s

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AccessModifierParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AccessModifierParser.scala
@@ -20,14 +20,14 @@ import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object AccessModifierParser {
 
   def parseOrFail[Unknown: P]: P[SoftAST.AccessModifier] =
     P {
       Index ~
-        TokenParser.PubOrFail ~
+        TokenParser.parseOrFail(Token.Pub) ~
         spaceOrFail.? ~
         Index
     } map {

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AnnotationParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AnnotationParser.scala
@@ -20,7 +20,7 @@ import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object AnnotationParser {
 
@@ -39,7 +39,7 @@ private object AnnotationParser {
   def parseOrFail[Unknown: P]: P[SoftAST.Annotation] =
     P {
       Index ~
-        TokenParser.AtOrFail ~
+        TokenParser.parseOrFail(Token.At) ~
         spaceOrFail.? ~
         identifier ~
         spaceOrFail.? ~

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentAccessModifierParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentAccessModifierParser.scala
@@ -20,21 +20,21 @@ import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object AssignmentAccessModifierParser {
 
   def parseOrFail[Unknown: P]: P[SoftAST.AssignmentAccessModifier] =
     P {
       Index ~
-        (TokenParser.LetOrFail | TokenParser.MutOrFail) ~
+        (TokenParser.parseOrFail(Token.Let) | TokenParser.parseOrFail(Token.Mut)) ~
         spaceOrFail.? ~
         Index
     } map {
-      case (from, doubleForwardSlash, space, to) =>
+      case (from, dataAssignment, space, to) =>
         SoftAST.AssignmentAccessModifier(
           index = range(from, to),
-          doubleForwardSlash,
+          token = dataAssignment,
           postTokenSpace = space
         )
     }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentParser.scala
@@ -4,7 +4,7 @@ import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object AssignmentParser {
 
@@ -14,7 +14,7 @@ private object AssignmentParser {
         AssignmentAccessModifierParser.parseOrFail.rep ~
         identifierOrFail ~
         spaceOrFail.? ~
-        TokenParser.EqualOrFail ~
+        TokenParser.parseOrFail(Token.Equal) ~
         spaceOrFail.? ~
         ExpressionParser.parse ~
         Index

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
@@ -27,11 +27,11 @@ private object BlockParser {
   def clause[Unknown: P](required: Boolean): P[SoftAST.BlockClause] =
     P {
       Index ~
-        TokenParser.OpenCurly(required) ~
+        TokenParser.parse(required, Token.OpenCurly) ~
         spaceOrFail.? ~
         body(Some(Token.CloseCurly.lexeme)) ~
         spaceOrFail.? ~
-        TokenParser.CloseCurly ~
+        TokenParser.parse(Token.CloseCurly) ~
         Index
     } map {
       case (from, openCurly, preBodySpace, body, postBodySpace, closeCurly, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CodeParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CodeParser.scala
@@ -1,0 +1,28 @@
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse._
+import fastparse.NoWhitespace.noWhitespaceImplicit
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
+
+object CodeParser {
+
+  def parseOrFail[Unknown: P, T <: Token](token: T): P[SoftAST.CodeToken[T]] =
+    P(Index ~ token.lexeme ~ Index) map {
+      case (from, to) =>
+        SoftAST.CodeToken(
+          index = range(from, to),
+          token = token
+        )
+    }
+
+  def parseOrFail[Unknown: P](parser: => P[String]): P[SoftAST.CodeString] =
+    P(Index ~ parser ~ Index) map {
+      case (from, code, to) =>
+        SoftAST.CodeString(
+          index = range(from, to),
+          text = code
+        )
+    }
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommentParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommentParser.scala
@@ -20,7 +20,7 @@ import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object CommentParser {
 
@@ -63,7 +63,7 @@ private object CommentParser {
   private def one[Unknown: P]: P[SoftAST.Comment] =
     P {
       Index ~
-        TokenParser.DoubleForwardSlashOrFail ~
+        TokenParser.parseOrFailUndocumented(Token.DoubleForwardSlash) ~
         spaceOrFail.? ~
         text.? ~
         spaceOrFail.? ~

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommonParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommonParser.scala
@@ -38,10 +38,10 @@ private object CommonParser {
         SoftAST.Space(text)
     }
 
-  def text[Unknown: P]: P[SoftAST.Code] =
+  def text[Unknown: P]: P[SoftAST.CodeString] =
     P(Index ~ CharsWhileNot(Token.Newline.lexeme).! ~ Index) map {
       case (from, text, to) =>
-        SoftAST.Code(
+        SoftAST.CodeString(
           text = text,
           index = range(from, to)
         )
@@ -107,10 +107,10 @@ private object CommonParser {
         )
     }
 
-  def toCodeOrFail[Unknown: P](parser: => P[String]): P[SoftAST.Code] =
+  def toCodeOrFail[Unknown: P](parser: => P[String]): P[SoftAST.CodeString] =
     P(Index ~ parser ~ Index) map {
       case (from, code, to) =>
-        SoftAST.Code(
+        SoftAST.CodeString(
           text = code,
           index = range(from, to)
         )

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/DataTemplateParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/DataTemplateParser.scala
@@ -4,14 +4,14 @@ import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object DataTemplateParser {
 
   def parseOrFail[Unknown: P]: P[SoftAST.DataTemplate] =
     P {
       Index ~
-        (TokenParser.StructOrFail | TokenParser.EnumOrFail | TokenParser.EventOrFail) ~
+        (TokenParser.parseOrFail(Token.Struct) | TokenParser.parseOrFail(Token.Enum) | TokenParser.parseOrFail(Token.Event)) ~
         space ~
         identifier ~
         spaceOrFail.? ~

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ForLoopParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ForLoopParser.scala
@@ -13,7 +13,7 @@ private object ForLoopParser {
       Index ~
         TokenParser.parseOrFail(Token.For) ~
         spaceOrFail.? ~
-        TokenParser.OpenParen ~
+        TokenParser.parse(Token.OpenParen) ~
         spaceOrFail.? ~
         ExpressionParser.parse ~
         spaceOrFail.? ~
@@ -25,7 +25,7 @@ private object ForLoopParser {
         spaceOrFail.? ~
         ExpressionParser.parse ~
         spaceOrFail.? ~
-        TokenParser.CloseParen ~
+        TokenParser.parse(Token.CloseParen) ~
         spaceOrFail.? ~
         BlockParser.clause(required = true) ~
         Index

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ForLoopParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ForLoopParser.scala
@@ -17,11 +17,11 @@ private object ForLoopParser {
         spaceOrFail.? ~
         ExpressionParser.parse ~
         spaceOrFail.? ~
-        TokenParser.Semicolon ~
+        TokenParser.parse(Token.Semicolon) ~
         spaceOrFail.? ~
         ExpressionParser.parse ~
         spaceOrFail.? ~
-        TokenParser.Semicolon ~
+        TokenParser.parse(Token.Semicolon) ~
         spaceOrFail.? ~
         ExpressionParser.parse ~
         spaceOrFail.? ~

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ForLoopParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ForLoopParser.scala
@@ -4,14 +4,14 @@ import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object ForLoopParser {
 
   def parseOrFail[Unknown: P]: P[SoftAST.ForStatement] =
     P {
       Index ~
-        TokenParser.ForOrFail ~
+        TokenParser.parseOrFail(Token.For) ~
         spaceOrFail.? ~
         TokenParser.OpenParen ~
         spaceOrFail.? ~

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionParser.scala
@@ -20,7 +20,7 @@ import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object FunctionParser {
 
@@ -36,7 +36,7 @@ private object FunctionParser {
         AnnotationParser.parseOrFail.rep ~
         spaceOrFail.? ~
         AccessModifierParser.parseOrFail.? ~
-        TokenParser.FnOrFail ~
+        TokenParser.parseOrFail(Token.Fn) ~
         space ~
         signature ~
         spaceOrFail.? ~

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionParser.scala
@@ -83,7 +83,7 @@ private object FunctionParser {
    *         type or an error indicating that the return type is expected.
    */
   private def returnSignature[Unknown: P]: P[SoftAST.FunctionReturnAST] =
-    P(Index ~ (TokenParser.ForwardArrow ~ spaceOrFail.? ~ TypeParser.parse).? ~ Index) map {
+    P(Index ~ (TokenParser.parse(Token.ForwardArrow) ~ spaceOrFail.? ~ TypeParser.parse).? ~ Index) map {
       case (from, Some((forwardArrow, space, tpe)), to) =>
         SoftAST.FunctionReturn(
           index = range(from, to),

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MethodCallParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MethodCallParser.scala
@@ -4,7 +4,7 @@ import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 case object MethodCallParser {
 
@@ -28,7 +28,7 @@ case object MethodCallParser {
   private def dotCall[Unknown: P]: P[SoftAST.DotCall] =
     P {
       Index ~
-        TokenParser.DotOrFail ~
+        TokenParser.parseOrFail(Token.Dot) ~
         spaceOrFail.? ~
         ReferenceCallParser.parse ~
         Index

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReturnStatementParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReturnStatementParser.scala
@@ -4,14 +4,14 @@ import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object ReturnStatementParser {
 
   def parseOrFail[Unknown: P]: P[SoftAST.ReturnStatement] =
     P {
       Index ~
-        TokenParser.ReturnOrFail ~
+        TokenParser.parseOrFail(Token.Return) ~
         space ~
         ExpressionParser.parse ~
         Index

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateParser.scala
@@ -4,7 +4,7 @@ import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object TemplateParser {
 
@@ -39,7 +39,7 @@ private object TemplateParser {
   private def inheritance[Unknown: P]: P[SoftAST.TemplateInheritance] =
     P {
       Index ~
-        (TokenParser.ImplementsOrFail | TokenParser.ExtendsOrFail) ~
+        (TokenParser.parseOrFail(Token.Implements) | TokenParser.parseOrFail(Token.Extends)) ~
         space ~
         (ReferenceCallParser.parseOrFail | identifier) ~
         spaceOrFail.? ~

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateParser.scala
@@ -11,7 +11,7 @@ private object TemplateParser {
   def parseOrFail[Unknown: P]: P[SoftAST.Template] =
     P {
       Index ~
-        (TokenParser.ContractOrFail | TokenParser.TxScriptOrFail) ~
+        (TokenParser.parseOrFail(Token.Contract) | TokenParser.parseOrFail(Token.TxScript) | TokenParser.parseOrFail(Token.AssetScript)) ~
         space ~
         identifier ~
         spaceOrFail.? ~

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -31,7 +31,7 @@ private object TokenParser {
         token
 
       case (from, None) =>
-        SoftAST.TokenExpected(SoftAST.CodeToken(point(from), token))
+        SoftAST.TokenExpected(point(from), token)
     }
 
   def parseOrFail[Unknown: P, T <: Token](token: T): P[SoftAST.TokenDocumented[T]] =
@@ -148,25 +148,6 @@ private object TokenParser {
     P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.CloseCurly.lexeme.!) ~ Index) map {
       case (from, documentation, text, to) =>
         SoftAST.CloseCurly(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
-  def ForwardArrow[Unknown: P]: P[SoftAST.ForwardArrowAST] =
-    P(Index ~ ForwardArrowOrFail.?) map {
-      case (_, Some(forwardArrow)) =>
-        forwardArrow
-
-      case (from, None) =>
-        SoftAST.ForwardArrowExpected(point(from))
-    }
-
-  def ForwardArrowOrFail[Unknown: P]: P[SoftAST.ForwardArrowAST] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.ForwardArrow.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.ForwardArrow(
           index = range(from, to),
           documentation = documentation,
           code = text

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -44,6 +44,9 @@ private object TokenParser {
         )
     }
 
+  def parseOrFailUndocumented[Unknown: P, T <: Token](token: T): P[SoftAST.TokenUndocumented[T]] =
+    P(CodeParser.parseOrFail(token)) map (SoftAST.TokenUndocumented(_))
+
   def Colon[Unknown: P]: P[SoftAST.ColonAST] =
     P(Index ~ ColonOrFail.?) map {
       case (_, Some(colon)) =>
@@ -189,12 +192,6 @@ private object TokenParser {
         )
     }
 
-  def DoubleForwardSlashOrFail[Unknown: P]: P[SoftAST.DoubleForwardSlash] =
-    P(toCodeOrFail(Token.DoubleForwardSlash.lexeme.!)) map {
-      text =>
-        SoftAST.DoubleForwardSlash(text)
-    }
-
   def ContractOrFail[Unknown: P]: P[SoftAST.Contract] =
     P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Contract.lexeme.!) ~ Index) map {
       case (from, documentation, text, to) =>
@@ -259,16 +256,6 @@ private object TokenParser {
     P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Extends.lexeme.!) ~ Index) map {
       case (from, documentation, text, to) =>
         SoftAST.Extends(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
-  def EqualOrFail[Unknown: P]: P[SoftAST.Equal] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Equal.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.Equal(
           index = range(from, to),
           documentation = documentation,
           code = text

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -170,16 +170,6 @@ private object TokenParser {
         )
     }
 
-  def CommaOrFail[Unknown: P]: P[SoftAST.Comma] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Comma.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.Comma(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
   def ForwardArrow[Unknown: P]: P[SoftAST.ForwardArrowAST] =
     P(Index ~ ForwardArrowOrFail.?) map {
       case (_, Some(forwardArrow)) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -20,7 +20,6 @@ import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.{point, range}
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
-import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
 import org.alephium.ralph.lsp.access.util.ParserUtil
 
 private object TokenParser {
@@ -54,26 +53,6 @@ private object TokenParser {
 
   def parseOrFailUndocumented[Unknown: P, T <: Token](token: T): P[SoftAST.TokenUndocumented[T]] =
     P(CodeParser.parseOrFail(token)) map (SoftAST.TokenUndocumented(_))
-
-  def LetOrFail[Unknown: P]: P[SoftAST.Let] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Let.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.Let(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
-  def MutOrFail[Unknown: P]: P[SoftAST.Mut] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Mut.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.Mut(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
 
   /**
    * Parses all reserved tokens defined in [[Token.reserved]] and returns the first match.

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -192,36 +192,6 @@ private object TokenParser {
         )
     }
 
-  def StructOrFail[Unknown: P]: P[SoftAST.Struct] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Struct.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.Struct(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
-  def EnumOrFail[Unknown: P]: P[SoftAST.Enum] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Enum.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.Enum(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
-  def EventOrFail[Unknown: P]: P[SoftAST.Event] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Event.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.Event(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
   def LetOrFail[Unknown: P]: P[SoftAST.Let] =
     P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Let.lexeme.!) ~ Index) map {
       case (from, documentation, text, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -74,50 +74,6 @@ private object TokenParser {
         )
     }
 
-  def OpenCurly[Unknown: P](required: Boolean): P[SoftAST.OpenCurlyAST] =
-    if (required)
-      OpenCurly
-    else
-      OpenCurlyOrFail
-
-  def OpenCurly[Unknown: P]: P[SoftAST.OpenCurlyAST] =
-    P(Index ~ OpenCurlyOrFail.?) map {
-      case (_, Some(openCurly)) =>
-        openCurly
-
-      case (from, None) =>
-        SoftAST.OpenCurlyExpected(point(from))
-    }
-
-  def OpenCurlyOrFail[Unknown: P]: P[SoftAST.OpenCurly] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.OpenCurly.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.OpenCurly(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
-  def CloseCurly[Unknown: P]: P[SoftAST.CloseCurlyAST] =
-    P(Index ~ CloseCurlyOrFail.?) map {
-      case (_, Some(closeCurly)) =>
-        closeCurly
-
-      case (from, None) =>
-        SoftAST.CloseCurlyExpected(point(from))
-    }
-
-  def CloseCurlyOrFail[Unknown: P]: P[SoftAST.CloseCurlyAST] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.CloseCurly.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.CloseCurly(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
   def LetOrFail[Unknown: P]: P[SoftAST.Let] =
     P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Let.lexeme.!) ~ Index) map {
       case (from, documentation, text, to) =>
@@ -149,11 +105,10 @@ private object TokenParser {
    */
   def InfixOperatorOrFail[Unknown: P]: P[SoftAST.TokenDocumented[Token.InfixOperator]] = {
     val infixOps =
-      ParserUtil
-        .orCombinator(
-          items = Token.infix.iterator.filter(_ != Token.ForwardSlash), // remove forward-slash
-          parser = TokenParser.parseOrFail(_: Token.InfixOperator)
-        )
+      ParserUtil.orCombinator(
+        items = Token.infix.iterator.filter(_ != Token.ForwardSlash), // remove forward-slash
+        parser = TokenParser.parseOrFail(_: Token.InfixOperator)
+      )
 
     // Forward-slash followed by another forward-slash is not an Operator.
     // `//` is reserved as a comment prefix.

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -265,16 +265,6 @@ private object TokenParser {
         )
     }
 
-  def WhileOrFail[Unknown: P]: P[SoftAST.While] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.While.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.While(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
   def EqualOrFail[Unknown: P]: P[SoftAST.Equal] =
     P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Equal.lexeme.!) ~ Index) map {
       case (from, documentation, text, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -275,16 +275,6 @@ private object TokenParser {
         )
     }
 
-  def DotOrFail[Unknown: P]: P[SoftAST.Dot] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Dot.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.Dot(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
   def ReturnOrFail[Unknown: P]: P[SoftAST.Return] =
     P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Return.lexeme.!) ~ Index) map {
       case (from, documentation, text, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -25,6 +25,14 @@ import org.alephium.ralph.lsp.access.util.ParserUtil
 
 private object TokenParser {
 
+  def parse[Unknown: P, T <: Token](
+      required: Boolean,
+      token: T): P[SoftAST.TokenExpectedAST[T]] =
+    if (required)
+      parse(token)
+    else
+      parseOrFail(token)
+
   def parse[Unknown: P, T <: Token](token: T): P[SoftAST.TokenExpectedAST[T]] =
     P(Index ~ parseOrFail(token).?) map {
       case (_, Some(token)) =>
@@ -60,50 +68,6 @@ private object TokenParser {
     P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Semicolon.lexeme.!) ~ Index) map {
       case (from, documentation, text, to) =>
         SoftAST.Semicolon(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
-  def OpenParen[Unknown: P](required: Boolean): P[SoftAST.OpenParenAST] =
-    if (required)
-      OpenParen
-    else
-      OpenParenOrFail
-
-  def OpenParen[Unknown: P]: P[SoftAST.OpenParenAST] =
-    P(Index ~ OpenParenOrFail.?) map {
-      case (_, Some(openParen)) =>
-        openParen
-
-      case (from, None) =>
-        SoftAST.OpenParenExpected(point(from))
-    }
-
-  def OpenParenOrFail[Unknown: P]: P[SoftAST.OpenParen] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.OpenParen.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.OpenParen(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
-  def CloseParen[Unknown: P]: P[SoftAST.CloseParenAST] =
-    P(Index ~ CloseParenOrFail.?) map {
-      case (_, Some(closeParen)) =>
-        closeParen
-
-      case (from, None) =>
-        SoftAST.CloseParenExpected(point(from))
-    }
-
-  def CloseParenOrFail[Unknown: P]: P[SoftAST.CloseParenAST] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.CloseParen.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.CloseParen(
           index = range(from, to),
           documentation = documentation,
           code = text

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -47,25 +47,6 @@ private object TokenParser {
   def parseOrFailUndocumented[Unknown: P, T <: Token](token: T): P[SoftAST.TokenUndocumented[T]] =
     P(CodeParser.parseOrFail(token)) map (SoftAST.TokenUndocumented(_))
 
-  def Colon[Unknown: P]: P[SoftAST.ColonAST] =
-    P(Index ~ ColonOrFail.?) map {
-      case (_, Some(colon)) =>
-        colon
-
-      case (from, None) =>
-        SoftAST.ColonExpected(point(from))
-    }
-
-  def ColonOrFail[Unknown: P]: P[SoftAST.ColonAST] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Colon.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.Colon(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
   def Semicolon[Unknown: P]: P[SoftAST.SemicolonAST] =
     P(Index ~ SemicolonOrFail.?) map {
       case (_, Some(semicolon)) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -265,16 +265,6 @@ private object TokenParser {
         )
     }
 
-  def ReturnOrFail[Unknown: P]: P[SoftAST.Return] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Return.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.Return(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
   def ForOrFail[Unknown: P]: P[SoftAST.For] =
     P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.For.lexeme.!) ~ Index) map {
       case (from, documentation, text, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -265,16 +265,6 @@ private object TokenParser {
         )
     }
 
-  def ForOrFail[Unknown: P]: P[SoftAST.For] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.For.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.For(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
   def WhileOrFail[Unknown: P]: P[SoftAST.While] =
     P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.While.lexeme.!) ~ Index) map {
       case (from, documentation, text, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -282,26 +282,6 @@ private object TokenParser {
         )
     }
 
-  def PubOrFail[Unknown: P]: P[SoftAST.Pub] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Pub.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.Pub(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
-  def AtOrFail[Unknown: P]: P[SoftAST.At] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.At.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.At(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
   /**
    * Parses all reserved tokens defined in [[Token.reserved]] and returns the first match.
    */

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -255,16 +255,6 @@ private object TokenParser {
         )
     }
 
-  def FnOrFail[Unknown: P]: P[SoftAST.Fn] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Fn.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.Fn(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
   def ImplementsOrFail[Unknown: P]: P[SoftAST.Implements] =
     P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Implements.lexeme.!) ~ Index) map {
       case (from, documentation, text, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -26,13 +26,13 @@ private object TokenParser {
 
   def parse[Unknown: P, T <: Token](
       required: Boolean,
-      token: T): P[SoftAST.TokenExpectedAST[T]] =
+      token: T): P[SoftAST.TokenDocExpectedAST[T]] =
     if (required)
       parse(token)
     else
       parseOrFail(token)
 
-  def parse[Unknown: P, T <: Token](token: T): P[SoftAST.TokenExpectedAST[T]] =
+  def parse[Unknown: P, T <: Token](token: T): P[SoftAST.TokenDocExpectedAST[T]] =
     P(Index ~ parseOrFail(token).?) map {
       case (_, Some(token)) =>
         token

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -242,26 +242,6 @@ private object TokenParser {
         )
     }
 
-  def ImplementsOrFail[Unknown: P]: P[SoftAST.Implements] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Implements.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.Implements(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
-  def ExtendsOrFail[Unknown: P]: P[SoftAST.Extends] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Extends.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.Extends(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
   def LetOrFail[Unknown: P]: P[SoftAST.Let] =
     P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Let.lexeme.!) ~ Index) map {
       case (from, documentation, text, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -192,26 +192,6 @@ private object TokenParser {
         )
     }
 
-  def ContractOrFail[Unknown: P]: P[SoftAST.Contract] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Contract.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.Contract(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
-  def TxScriptOrFail[Unknown: P]: P[SoftAST.TxScript] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.TxScript.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.TxScript(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
   def StructOrFail[Unknown: P]: P[SoftAST.Struct] =
     P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Struct.lexeme.!) ~ Index) map {
       case (from, documentation, text, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -55,25 +55,6 @@ private object TokenParser {
   def parseOrFailUndocumented[Unknown: P, T <: Token](token: T): P[SoftAST.TokenUndocumented[T]] =
     P(CodeParser.parseOrFail(token)) map (SoftAST.TokenUndocumented(_))
 
-  def Semicolon[Unknown: P]: P[SoftAST.SemicolonAST] =
-    P(Index ~ SemicolonOrFail.?) map {
-      case (_, Some(semicolon)) =>
-        semicolon
-
-      case (from, None) =>
-        SoftAST.SemicolonExpected(point(from))
-    }
-
-  def SemicolonOrFail[Unknown: P]: P[SoftAST.SemicolonAST] =
-    P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Semicolon.lexeme.!) ~ Index) map {
-      case (from, documentation, text, to) =>
-        SoftAST.Semicolon(
-          index = range(from, to),
-          documentation = documentation,
-          code = text
-        )
-    }
-
   def LetOrFail[Unknown: P]: P[SoftAST.Let] =
     P(Index ~ CommentParser.parseOrFail.? ~ toCodeOrFail(Token.Let.lexeme.!) ~ Index) map {
       case (from, documentation, text, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TupleParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TupleParser.scala
@@ -20,7 +20,7 @@ import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.{point, range}
 import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object TupleParser {
 
@@ -84,7 +84,7 @@ private object TupleParser {
   private def tailParams[Unknown: P]: P[SoftAST.TupleTail] =
     P {
       Index ~
-        TokenParser.CommaOrFail ~
+        TokenParser.parseOrFail(Token.Comma) ~
         spaceOrFail.? ~
         ExpressionParser.parse ~
         spaceOrFail.? ~

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TupleParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TupleParser.scala
@@ -44,13 +44,13 @@ private object TupleParser {
   private def tuple[Unknown: P](required: Boolean): P[SoftAST.Tuple] =
     P {
       Index ~
-        TokenParser.OpenParen(required) ~
+        TokenParser.parse(required, Token.OpenParen) ~
         spaceOrFail.? ~
         Index ~
         ExpressionParser.parseOrFail.? ~
         spaceOrFail.? ~
         tailParams.rep ~
-        TokenParser.CloseParen ~
+        TokenParser.parse(Token.CloseParen) ~
         Index
     } map {
       case (from, openParen, preHeadSpace, headParamIndex, headExpression, postHeadSpace, tailParams, closeParen, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeAssignmentParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeAssignmentParser.scala
@@ -4,7 +4,7 @@ import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object TypeAssignmentParser {
 
@@ -14,7 +14,7 @@ private object TypeAssignmentParser {
         AssignmentAccessModifierParser.parseOrFail.rep ~
         identifierOrFail ~
         spaceOrFail.? ~
-        TokenParser.ColonOrFail ~
+        TokenParser.parseOrFail(Token.Colon) ~
         spaceOrFail.? ~
         TypeParser.parse ~
         Index

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/WhileLoopParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/WhileLoopParser.scala
@@ -13,11 +13,11 @@ private object WhileLoopParser {
       Index ~
         TokenParser.parseOrFail(Token.While) ~
         spaceOrFail.? ~
-        TokenParser.OpenParen ~
+        TokenParser.parse(Token.OpenParen) ~
         spaceOrFail.? ~
         ExpressionParser.parse ~
         spaceOrFail.? ~
-        TokenParser.CloseParen ~
+        TokenParser.parse(Token.CloseParen) ~
         spaceOrFail.? ~
         BlockParser.clause(required = true) ~
         Index

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/WhileLoopParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/WhileLoopParser.scala
@@ -4,14 +4,14 @@ import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.CommonParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object WhileLoopParser {
 
   def parseOrFail[Unknown: P]: P[SoftAST.WhileStatement] =
     P {
       Index ~
-        TokenParser.WhileOrFail ~
+        TokenParser.parseOrFail(Token.While) ~
         spaceOrFail.? ~
         TokenParser.OpenParen ~
         spaceOrFail.? ~

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -102,7 +102,7 @@ object SoftAST {
   abstract class ExpectedErrorAST(element: String)   extends ErrorAST(s"$element expected")
   abstract class TokenExpectedErrorAST(token: Token) extends ExpectedErrorAST(s"'${token.lexeme}'")
 
-  sealed trait TokenExpectedAST[+T <: Token] extends SoftAST
+  sealed trait TokenDocExpectedAST[+T <: Token] extends SoftAST
 
   /**
    * Represents a token that may contain code comments or documentation.
@@ -116,7 +116,7 @@ object SoftAST {
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeToken[T])
-    extends TokenExpectedAST[T]
+    extends TokenDocExpectedAST[T]
        with CodeDocumentedAST
 
   case class TokenUndocumented[+T <: Token](code: CodeToken[T]) extends TokenAST[T] {
@@ -130,7 +130,7 @@ object SoftAST {
       index: SourceIndex,
       token: T)
     extends TokenExpectedErrorAST(token)
-       with TokenExpectedAST[T]
+       with TokenDocExpectedAST[T]
 
   case class Template(
       index: SourceIndex,
@@ -164,11 +164,11 @@ object SoftAST {
 
   case class BlockClause(
       index: SourceIndex,
-      openCurly: TokenExpectedAST[Token.OpenCurly.type],
+      openCurly: TokenDocExpectedAST[Token.OpenCurly.type],
       preBodySpace: Option[Space],
       body: BlockBody,
       postBodySpace: Option[Space],
-      closeCurly: TokenExpectedAST[Token.CloseCurly.type])
+      closeCurly: TokenDocExpectedAST[Token.CloseCurly.type])
     extends ExpressionAST
 
   case class BlockBody(
@@ -209,12 +209,12 @@ object SoftAST {
   /** Multiple arguments. Syntax: (arg1, (arg2, arg3)) */
   case class Tuple(
       index: SourceIndex,
-      openParen: TokenExpectedAST[Token.OpenParen.type],
+      openParen: TokenDocExpectedAST[Token.OpenParen.type],
       preHeadExpressionSpace: Option[Space],
       headExpression: Option[ExpressionAST],
       postHeadExpressionSpace: Option[Space],
       tailExpressions: Seq[TupleTail],
-      closeParen: TokenExpectedAST[Token.CloseParen.type])
+      closeParen: TokenDocExpectedAST[Token.CloseParen.type])
     extends ExpressionAST
        with TypeAST
 
@@ -231,7 +231,7 @@ object SoftAST {
 
   case class FunctionReturn(
       index: SourceIndex,
-      forwardArrow: TokenExpectedAST[Token.ForwardArrow.type],
+      forwardArrow: TokenDocExpectedAST[Token.ForwardArrow.type],
       space: Option[Space],
       tpe: TypeAST)
     extends FunctionReturnAST
@@ -323,19 +323,19 @@ object SoftAST {
       index: SourceIndex,
       forToken: TokenDocumented[Token.For.type],
       postForSpace: Option[Space],
-      openParen: TokenExpectedAST[Token.OpenParen.type],
+      openParen: TokenDocExpectedAST[Token.OpenParen.type],
       postOpenParenSpace: Option[Space],
       expression1: ExpressionAST,
       postExpression1Space: Option[Space],
-      postExpression1Semicolon: TokenExpectedAST[Token.Semicolon.type],
+      postExpression1Semicolon: TokenDocExpectedAST[Token.Semicolon.type],
       postExpression1SemicolonSpace: Option[Space],
       expression2: ExpressionAST,
       postExpression2Space: Option[Space],
-      postExpression2Semicolon: TokenExpectedAST[Token.Semicolon.type],
+      postExpression2Semicolon: TokenDocExpectedAST[Token.Semicolon.type],
       postExpression2SemicolonSpace: Option[Space],
       expression3: ExpressionAST,
       postExpression3Space: Option[Space],
-      closeParen: TokenExpectedAST[Token.CloseParen.type],
+      closeParen: TokenDocExpectedAST[Token.CloseParen.type],
       postCloseParenSpace: Option[SoftAST.Space],
       block: SoftAST.BlockClause)
     extends ExpressionAST
@@ -344,11 +344,11 @@ object SoftAST {
       index: SourceIndex,
       whileToken: TokenDocumented[Token.While.type],
       postWhileSpace: Option[Space],
-      openParen: TokenExpectedAST[Token.OpenParen.type],
+      openParen: TokenDocExpectedAST[Token.OpenParen.type],
       postOpenParenSpace: Option[Space],
       expression: ExpressionAST,
       postExpressionSpace: Option[Space],
-      closeParen: TokenExpectedAST[Token.CloseParen.type],
+      closeParen: TokenDocExpectedAST[Token.CloseParen.type],
       postCloseParenSpace: Option[SoftAST.Space],
       block: SoftAST.BlockClause)
     extends ExpressionAST

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -137,20 +137,6 @@ object SoftAST {
     extends TokenExpectedErrorAST(token)
        with TokenExpectedAST[T]
 
-  sealed trait SemicolonAST extends SoftAST
-
-  case class Semicolon(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-       with SemicolonAST
-
-  case class SemicolonExpected(
-      index: SourceIndex)
-    extends TokenExpectedErrorAST(Token.Semicolon)
-       with SemicolonAST
-
   sealed abstract class AssignmentControlToken extends TokenDocumentedAST[Token]
 
   case class Let(
@@ -360,11 +346,11 @@ object SoftAST {
       postOpenParenSpace: Option[Space],
       expression1: ExpressionAST,
       postExpression1Space: Option[Space],
-      postExpression1Semicolon: SemicolonAST,
+      postExpression1Semicolon: TokenExpectedAST[Token.Semicolon.type],
       postExpression1SemicolonSpace: Option[Space],
       expression2: ExpressionAST,
       postExpression2Space: Option[Space],
-      postExpression2Semicolon: SemicolonAST,
+      postExpression2Semicolon: TokenExpectedAST[Token.Semicolon.type],
       postExpression2SemicolonSpace: Option[Space],
       expression3: ExpressionAST,
       postExpression3Space: Option[Space],

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -138,22 +138,6 @@ object SoftAST {
 
   }
 
-  sealed trait InheritanceType extends SoftAST
-
-  case class Implements(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-       with InheritanceType
-
-  case class Extends(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-       with InheritanceType
-
   sealed trait TemplateToken extends TokenDocumentedAST[Token]
 
   case class Contract(
@@ -324,7 +308,7 @@ object SoftAST {
   /** Syntax: `implements or extends contract(arg1, arg2 ...)` */
   case class TemplateInheritance(
       index: SourceIndex,
-      inheritanceType: InheritanceType,
+      inheritanceType: TokenDocumented[Token.Inheritance],
       preConstructorCallSpace: SpaceAST,
       reference: ReferenceCallOrIdentifier,
       postConstructorCallSpace: Option[Space])

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -92,7 +92,11 @@ object SoftAST {
   /**
    * Has an [[Token]] type associates with it.
    */
-  sealed trait TokenAST extends CodeAST
+  sealed trait TokenAST extends CodeAST {
+
+    // def code: CodeToken[T]
+
+  }
 
   /**
    * [[TokenAST]] instances that can contain documentation.
@@ -103,49 +107,80 @@ object SoftAST {
   abstract class ExpectedErrorAST(element: String)   extends ErrorAST(s"$element expected")
   abstract class TokenExpectedErrorAST(token: Token) extends ExpectedErrorAST(s"'${token.lexeme}'")
 
+  sealed trait TokenExpectedAST[T <: Token] extends TokenAST
+
+  /**
+   * Represents a token that may code comments or documentation.
+   *
+   * @param index         Source index of the token, including its documentation.
+   * @param documentation Optional documentation (e.g. comments) preceding the token
+   * @param code          The token itself.
+   * @tparam T The specific type of token.
+   */
+  case class TokenDocumented[T <: Token](
+      index: SourceIndex,
+      documentation: Option[Comments],
+      code: CodeToken[T])
+    extends TokenExpectedAST[T]
+       with CodeDocumentedAST
+
+  case class TokenUndocumented[T <: Token](code: CodeToken[T]) extends TokenAST {
+
+    override def index: SourceIndex =
+      code.index
+
+  }
+
+  case class TokenExpected[T <: Token](code: CodeToken[T]) extends TokenExpectedErrorAST(code.token) with TokenExpectedAST[T] {
+
+    override def index: SourceIndex =
+      code.index
+
+  }
+
   case class Fn(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
 
   case class Dot(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
 
   case class Comma(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
 
   case class Return(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
 
   case class For(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
 
   case class While(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
 
   case class Equal(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
 
-  case class DoubleForwardSlash(code: Code) extends TokenAST {
+  case class DoubleForwardSlash(code: CodeString) extends TokenAST {
 
     override def index: SourceIndex =
       code.index
@@ -155,25 +190,25 @@ object SoftAST {
   case class Const(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
 
   case class Pub(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
 
   case class At(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
 
   case class Operator(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
 
   sealed trait InheritanceType extends SoftAST
@@ -181,14 +216,14 @@ object SoftAST {
   case class Implements(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
        with InheritanceType
 
   case class Extends(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
        with InheritanceType
 
@@ -197,13 +232,13 @@ object SoftAST {
   case class Contract(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TemplateToken
 
   case class TxScript(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TemplateToken
 
   sealed trait DataTemplateToken extends TokenDocumentedAST
@@ -211,19 +246,19 @@ object SoftAST {
   case class Struct(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends DataTemplateToken
 
   case class Enum(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends DataTemplateToken
 
   case class Event(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends DataTemplateToken
 
   sealed trait ColonAST extends SoftAST
@@ -231,7 +266,7 @@ object SoftAST {
   case class Colon(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
        with ColonAST
 
@@ -245,7 +280,7 @@ object SoftAST {
   case class ForwardArrow(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
        with ForwardArrowAST
 
@@ -259,7 +294,7 @@ object SoftAST {
   case class OpenParen(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
        with OpenParenAST
 
@@ -273,7 +308,7 @@ object SoftAST {
   case class CloseParen(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
        with CloseParenAST
 
@@ -287,7 +322,7 @@ object SoftAST {
   case class OpenCurly(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
        with OpenCurlyAST
 
@@ -301,7 +336,7 @@ object SoftAST {
   case class CloseCurly(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
        with CloseCurlyAST
 
@@ -315,7 +350,7 @@ object SoftAST {
   case class Semicolon(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends TokenDocumentedAST
        with SemicolonAST
 
@@ -329,13 +364,13 @@ object SoftAST {
   case class Let(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends AssignmentControlToken
 
   case class Mut(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends AssignmentControlToken
 
   case class Template(
@@ -452,7 +487,7 @@ object SoftAST {
   case class Identifier(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends IdentifierAST
        with CodeDocumentedAST
        with ExpressionAST
@@ -473,14 +508,14 @@ object SoftAST {
       index: SourceIndex,
       doubleForwardSlash: DoubleForwardSlash,
       preTextSpace: Option[Space],
-      text: Option[Code],
+      text: Option[CodeString],
       postTextSpace: Option[Space])
     extends BodyPartAST
 
   case class Unresolved(
       index: SourceIndex,
       documentation: Option[Comments],
-      code: Code)
+      code: CodeString)
     extends ErrorAST(s"Cannot resolve '$code'")
        with CodeDocumentedAST
        with BodyPartAST
@@ -604,7 +639,7 @@ object SoftAST {
   sealed trait SpaceAST extends SoftAST
 
   case class Space(
-      code: Code)
+      code: CodeString)
     extends SpaceAST
        with CodeAST {
 
@@ -618,10 +653,9 @@ object SoftAST {
     extends ExpectedErrorAST("Space")
        with SpaceAST
 
-  case class Code(
-      index: SourceIndex,
-      text: String)
-    extends SoftAST {
+  sealed trait Code extends SoftAST {
+
+    def text: String
 
     private def textPretty: String =
       text
@@ -631,6 +665,34 @@ object SoftAST {
 
     override def toStringPretty(): String =
       s"${getClass.getSimpleName}(\"$textPretty\"): $index"
+
+  }
+
+  /**
+   * Represents a segment of code that is not tokenised.
+   *
+   * @param index Source index of the code string.
+   * @param text  String content of the code
+   */
+  case class CodeString(
+      index: SourceIndex,
+      text: String)
+    extends Code
+
+  /**
+   * Represents a tokenised segment of code.
+   *
+   * @param index Source index of the token
+   * @param token Token instance representing the parsed code
+   * @tparam T Specific type of token.
+   */
+  case class CodeToken[+T <: Token](
+      index: SourceIndex,
+      token: T)
+    extends Code {
+
+    override def text: String =
+      token.lexeme
 
   }
 

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -138,20 +138,6 @@ object SoftAST {
 
   }
 
-  sealed trait ColonAST extends SoftAST
-
-  case class Colon(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-       with ColonAST
-
-  case class ColonExpected(
-      index: SourceIndex)
-    extends TokenExpectedErrorAST(Token.Colon)
-       with ColonAST
-
   sealed trait ForwardArrowAST extends SoftAST
 
   case class ForwardArrow(
@@ -486,7 +472,7 @@ object SoftAST {
       modifiers: Seq[SoftAST.AssignmentAccessModifier],
       name: IdentifierAST,
       preColonSpace: Option[Space],
-      colon: ColonAST,
+      colon: TokenDocumented[Token.Colon.type],
       postColonSpace: Option[Space],
       tpe: TypeAST)
     extends ExpressionAST

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -92,7 +92,7 @@ object SoftAST {
   /**
    * Has an [[Token]] type associates with it.
    */
-  sealed trait TokenAST[T <: Token] extends CodeAST {
+  sealed trait TokenAST[+T <: Token] extends CodeAST {
 
 //    def code: CodeToken[T]
 
@@ -107,7 +107,7 @@ object SoftAST {
   abstract class ExpectedErrorAST(element: String)   extends ErrorAST(s"$element expected")
   abstract class TokenExpectedErrorAST(token: Token) extends ExpectedErrorAST(s"'${token.lexeme}'")
 
-  sealed trait TokenExpectedAST[T <: Token] extends TokenAST[T]
+  sealed trait TokenExpectedAST[+T <: Token] extends TokenAST[T]
 
   /**
    * Represents a token that may code comments or documentation.
@@ -117,14 +117,14 @@ object SoftAST {
    * @param code          The token itself.
    * @tparam T The specific type of token.
    */
-  case class TokenDocumented[T <: Token](
+  case class TokenDocumented[+T <: Token](
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeToken[T])
     extends TokenExpectedAST[T]
        with CodeDocumentedAST
 
-  case class TokenUndocumented[T <: Token](code: CodeToken[T]) extends TokenAST[T] {
+  case class TokenUndocumented[+T <: Token](code: CodeToken[T]) extends TokenAST[T] {
 
     override def index: SourceIndex =
       code.index
@@ -137,12 +137,6 @@ object SoftAST {
       code.index
 
   }
-
-  case class Operator(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
 
   sealed trait InheritanceType extends SoftAST
 
@@ -467,7 +461,7 @@ object SoftAST {
       index: SourceIndex,
       leftExpression: ExpressionAST,
       preOperatorSpace: Option[Space],
-      operator: Operator,
+      operator: TokenDocumented[Token.InfixOperator],
       postOperatorSpace: Option[Space],
       rightExpression: ExpressionAST)
     extends ExpressionAST

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -138,20 +138,6 @@ object SoftAST {
 
   }
 
-  sealed trait TemplateToken extends TokenDocumentedAST[Token]
-
-  case class Contract(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TemplateToken
-
-  case class TxScript(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TemplateToken
-
   sealed trait DataTemplateToken extends TokenDocumentedAST[Token]
 
   case class Struct(
@@ -286,7 +272,7 @@ object SoftAST {
 
   case class Template(
       index: SourceIndex,
-      templateType: TemplateToken,
+      templateType: TokenDocumented[Token.TemplateDefinition],
       preIdentifierSpace: SpaceAST,
       identifier: IdentifierAST,
       preParamSpace: Option[Space],

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -138,12 +138,6 @@ object SoftAST {
 
   }
 
-  case class Dot(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-
   case class Comma(
       index: SourceIndex,
       documentation: Option[Comments],
@@ -542,7 +536,7 @@ object SoftAST {
 
   case class DotCall(
       index: SourceIndex,
-      dot: Dot,
+      dot: TokenDocumented[Token.Dot.type],
       postDotSpace: Option[Space],
       rightExpression: ReferenceCall)
     extends SoftAST

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -138,19 +138,6 @@ object SoftAST {
 
   }
 
-  case class Equal(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-
-  case class DoubleForwardSlash(code: CodeString) extends TokenAST[Token] {
-
-    override def index: SourceIndex =
-      code.index
-
-  }
-
   case class Const(
       index: SourceIndex,
       documentation: Option[Comments],
@@ -470,7 +457,7 @@ object SoftAST {
 
   case class Comment(
       index: SourceIndex,
-      doubleForwardSlash: DoubleForwardSlash,
+      doubleForwardSlash: TokenUndocumented[Token.DoubleForwardSlash.type],
       preTextSpace: Option[Space],
       text: Option[CodeString],
       postTextSpace: Option[Space])
@@ -563,7 +550,7 @@ object SoftAST {
       modifiers: Seq[SoftAST.AssignmentAccessModifier],
       identifier: Identifier,
       postIdentifierSpace: Option[Space],
-      equalToken: Equal,
+      equalToken: TokenDocumented[Token.Equal.type],
       postEqualSpace: Option[Space],
       expression: ExpressionAST)
     extends ExpressionAST

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -137,34 +137,6 @@ object SoftAST {
     extends TokenExpectedErrorAST(token)
        with TokenExpectedAST[T]
 
-  sealed trait OpenCurlyAST extends SoftAST
-
-  case class OpenCurly(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-       with OpenCurlyAST
-
-  case class OpenCurlyExpected(
-      index: SourceIndex)
-    extends TokenExpectedErrorAST(Token.OpenCurly)
-       with OpenCurlyAST
-
-  sealed trait CloseCurlyAST extends SoftAST
-
-  case class CloseCurly(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-       with CloseCurlyAST
-
-  case class CloseCurlyExpected(
-      index: SourceIndex)
-    extends TokenExpectedErrorAST(Token.CloseCurly)
-       with CloseCurlyAST
-
   sealed trait SemicolonAST extends SoftAST
 
   case class Semicolon(
@@ -225,11 +197,11 @@ object SoftAST {
 
   case class BlockClause(
       index: SourceIndex,
-      openCurly: OpenCurlyAST,
+      openCurly: TokenExpectedAST[Token.OpenCurly.type],
       preBodySpace: Option[Space],
       body: BlockBody,
       postBodySpace: Option[Space],
-      closeCurly: CloseCurlyAST)
+      closeCurly: TokenExpectedAST[Token.CloseCurly.type])
     extends ExpressionAST
 
   case class BlockBody(

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -138,12 +138,6 @@ object SoftAST {
 
   }
 
-  case class While(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-
   case class Equal(
       index: SourceIndex,
       documentation: Option[Comments],
@@ -553,7 +547,7 @@ object SoftAST {
 
   case class WhileStatement(
       index: SourceIndex,
-      whileToken: While,
+      whileToken: TokenDocumented[Token.While.type],
       postWhileSpace: Option[Space],
       openParen: OpenParenAST,
       postOpenParenSpace: Option[Space],

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -138,12 +138,6 @@ object SoftAST {
 
   }
 
-  case class Return(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-
   case class For(
       index: SourceIndex,
       documentation: Option[Comments],
@@ -537,7 +531,7 @@ object SoftAST {
 
   case class ReturnStatement(
       index: SourceIndex,
-      returnToken: Return,
+      returnToken: TokenDocumented[Token.Return.type],
       preExpressionSpace: SpaceAST,
       rightExpression: ExpressionAST)
     extends ExpressionAST

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -137,34 +137,6 @@ object SoftAST {
     extends TokenExpectedErrorAST(token)
        with TokenExpectedAST[T]
 
-  sealed trait OpenParenAST extends SoftAST
-
-  case class OpenParen(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-       with OpenParenAST
-
-  case class OpenParenExpected(
-      index: SourceIndex)
-    extends TokenExpectedErrorAST(Token.OpenParen)
-       with OpenParenAST
-
-  sealed trait CloseParenAST extends SoftAST
-
-  case class CloseParen(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-       with CloseParenAST
-
-  case class CloseParenExpected(
-      index: SourceIndex)
-    extends TokenExpectedErrorAST(Token.CloseParen)
-       with CloseParenAST
-
   sealed trait OpenCurlyAST extends SoftAST
 
   case class OpenCurly(
@@ -298,12 +270,12 @@ object SoftAST {
   /** Multiple arguments. Syntax: (arg1, (arg2, arg3)) */
   case class Tuple(
       index: SourceIndex,
-      openParen: OpenParenAST,
+      openParen: TokenExpectedAST[Token.OpenParen.type],
       preHeadExpressionSpace: Option[Space],
       headExpression: Option[ExpressionAST],
       postHeadExpressionSpace: Option[Space],
       tailExpressions: Seq[TupleTail],
-      closeParen: CloseParenAST)
+      closeParen: TokenExpectedAST[Token.CloseParen.type])
     extends ExpressionAST
        with TypeAST
 
@@ -412,7 +384,7 @@ object SoftAST {
       index: SourceIndex,
       forToken: TokenDocumented[Token.For.type],
       postForSpace: Option[Space],
-      openParen: OpenParenAST,
+      openParen: TokenExpectedAST[Token.OpenParen.type],
       postOpenParenSpace: Option[Space],
       expression1: ExpressionAST,
       postExpression1Space: Option[Space],
@@ -424,7 +396,7 @@ object SoftAST {
       postExpression2SemicolonSpace: Option[Space],
       expression3: ExpressionAST,
       postExpression3Space: Option[Space],
-      closeParen: CloseParenAST,
+      closeParen: TokenExpectedAST[Token.CloseParen.type],
       postCloseParenSpace: Option[SoftAST.Space],
       block: SoftAST.BlockClause)
     extends ExpressionAST
@@ -433,11 +405,11 @@ object SoftAST {
       index: SourceIndex,
       whileToken: TokenDocumented[Token.While.type],
       postWhileSpace: Option[Space],
-      openParen: OpenParenAST,
+      openParen: TokenExpectedAST[Token.OpenParen.type],
       postOpenParenSpace: Option[Space],
       expression: ExpressionAST,
       postExpressionSpace: Option[Space],
-      closeParen: CloseParenAST,
+      closeParen: TokenExpectedAST[Token.CloseParen.type],
       postCloseParenSpace: Option[SoftAST.Space],
       block: SoftAST.BlockClause)
     extends ExpressionAST

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -94,14 +94,9 @@ object SoftAST {
    */
   sealed trait TokenAST[+T <: Token] extends CodeAST {
 
-//    def code: CodeToken[T]
+    def code: CodeToken[T]
 
   }
-
-  /**
-   * [[TokenAST]] instances that can contain documentation.
-   */
-  sealed trait TokenDocumentedAST[T <: Token] extends TokenAST[T] with CodeDocumentedAST
 
   abstract class ErrorAST(val message: String)       extends SoftAST
   abstract class ExpectedErrorAST(element: String)   extends ErrorAST(s"$element expected")
@@ -110,7 +105,7 @@ object SoftAST {
   sealed trait TokenExpectedAST[+T <: Token] extends SoftAST
 
   /**
-   * Represents a token that may code comments or documentation.
+   * Represents a token that may contain code comments or documentation.
    *
    * @param index         Source index of the token, including its documentation.
    * @param documentation Optional documentation (e.g. comments) preceding the token

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -138,12 +138,6 @@ object SoftAST {
 
   }
 
-  case class For(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-
   case class While(
       index: SourceIndex,
       documentation: Option[Comments],
@@ -538,7 +532,7 @@ object SoftAST {
 
   case class ForStatement(
       index: SourceIndex,
-      forToken: For,
+      forToken: TokenDocumented[Token.For.type],
       postForSpace: Option[Space],
       openParen: OpenParenAST,
       postOpenParenSpace: Option[Space],

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -137,20 +137,6 @@ object SoftAST {
     extends TokenExpectedErrorAST(token)
        with TokenExpectedAST[T]
 
-  sealed abstract class AssignmentControlToken extends TokenDocumentedAST[Token]
-
-  case class Let(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends AssignmentControlToken
-
-  case class Mut(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends AssignmentControlToken
-
   case class Template(
       index: SourceIndex,
       templateType: TokenDocumented[Token.TemplateDefinition],
@@ -394,7 +380,7 @@ object SoftAST {
 
   case class AssignmentAccessModifier(
       index: SourceIndex,
-      token: AssignmentControlToken,
+      token: TokenDocumented[Token.DataDefinition],
       postTokenSpace: Option[Space])
     extends ExpressionAST
 
@@ -447,7 +433,7 @@ object SoftAST {
   }
 
   /**
-   * Represents a segment of code that is not tokenised.
+   * Represents a string within a segment of code.
    *
    * @param index Source index of the code string.
    * @param text  String content of the code
@@ -458,7 +444,7 @@ object SoftAST {
     extends Code
 
   /**
-   * Represents a tokenised segment of code.
+   * Represents a token within a segment of code.
    *
    * @param index Source index of the token
    * @param token Token instance representing the parsed code

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -138,24 +138,6 @@ object SoftAST {
 
   }
 
-  case class Const(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-
-  case class Pub(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-
-  case class At(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-
   case class Operator(
       index: SourceIndex,
       documentation: Option[Comments],
@@ -573,13 +555,13 @@ object SoftAST {
 
   case class AccessModifier(
       index: SourceIndex,
-      pub: Pub,
+      pub: TokenDocumented[Token.Pub.type],
       postTokenSpace: Option[Space])
     extends ExpressionAST
 
   case class Annotation(
       index: SourceIndex,
-      at: At,
+      at: TokenDocumented[Token.At.type],
       preIdentifierSpace: Option[Space],
       identifier: IdentifierAST,
       postIdentifierSpace: Option[Space],

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -138,12 +138,6 @@ object SoftAST {
 
   }
 
-  case class Comma(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-
   case class Return(
       index: SourceIndex,
       documentation: Option[Comments],
@@ -450,7 +444,7 @@ object SoftAST {
   /** Syntax: (arg1, >>arg2, (arg3, arg4)<<) */
   case class TupleTail(
       index: SourceIndex,
-      comma: Comma,
+      comma: TokenDocumented[Token.Comma.type],
       preExpressionSpace: Option[Space],
       expression: ExpressionAST,
       postExpressionSpace: Option[Space])

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -138,26 +138,6 @@ object SoftAST {
 
   }
 
-  sealed trait DataTemplateToken extends TokenDocumentedAST[Token]
-
-  case class Struct(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends DataTemplateToken
-
-  case class Enum(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends DataTemplateToken
-
-  case class Event(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends DataTemplateToken
-
   sealed trait ColonAST extends SoftAST
 
   case class Colon(
@@ -284,7 +264,7 @@ object SoftAST {
 
   case class DataTemplate(
       index: SourceIndex,
-      dataType: DataTemplateToken,
+      dataType: TokenDocumented[Token.DataTemplate],
       preIdentifierSpace: SpaceAST,
       identifier: IdentifierAST,
       preParamSpace: Option[Space],

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -107,7 +107,7 @@ object SoftAST {
   abstract class ExpectedErrorAST(element: String)   extends ErrorAST(s"$element expected")
   abstract class TokenExpectedErrorAST(token: Token) extends ExpectedErrorAST(s"'${token.lexeme}'")
 
-  sealed trait TokenExpectedAST[+T <: Token] extends TokenAST[T]
+  sealed trait TokenExpectedAST[+T <: Token] extends SoftAST
 
   /**
    * Represents a token that may code comments or documentation.
@@ -131,26 +131,11 @@ object SoftAST {
 
   }
 
-  case class TokenExpected[T <: Token](code: CodeToken[T]) extends TokenExpectedErrorAST(code.token) with TokenExpectedAST[T] {
-
-    override def index: SourceIndex =
-      code.index
-
-  }
-
-  sealed trait ForwardArrowAST extends SoftAST
-
-  case class ForwardArrow(
+  case class TokenExpected[T <: Token](
       index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-       with ForwardArrowAST
-
-  case class ForwardArrowExpected(
-      index: SourceIndex)
-    extends TokenExpectedErrorAST(Token.ForwardArrow)
-       with ForwardArrowAST
+      token: T)
+    extends TokenExpectedErrorAST(token)
+       with TokenExpectedAST[T]
 
   sealed trait OpenParenAST extends SoftAST
 
@@ -335,7 +320,7 @@ object SoftAST {
 
   case class FunctionReturn(
       index: SourceIndex,
-      forwardArrow: ForwardArrowAST,
+      forwardArrow: TokenExpectedAST[Token.ForwardArrow.type],
       space: Option[Space],
       tpe: TypeAST)
     extends FunctionReturnAST

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -92,22 +92,22 @@ object SoftAST {
   /**
    * Has an [[Token]] type associates with it.
    */
-  sealed trait TokenAST extends CodeAST {
+  sealed trait TokenAST[T <: Token] extends CodeAST {
 
-    // def code: CodeToken[T]
+//    def code: CodeToken[T]
 
   }
 
   /**
    * [[TokenAST]] instances that can contain documentation.
    */
-  sealed trait TokenDocumentedAST extends TokenAST with CodeDocumentedAST
+  sealed trait TokenDocumentedAST[T <: Token] extends TokenAST[T] with CodeDocumentedAST
 
   abstract class ErrorAST(val message: String)       extends SoftAST
   abstract class ExpectedErrorAST(element: String)   extends ErrorAST(s"$element expected")
   abstract class TokenExpectedErrorAST(token: Token) extends ExpectedErrorAST(s"'${token.lexeme}'")
 
-  sealed trait TokenExpectedAST[T <: Token] extends TokenAST
+  sealed trait TokenExpectedAST[T <: Token] extends TokenAST[T]
 
   /**
    * Represents a token that may code comments or documentation.
@@ -124,7 +124,7 @@ object SoftAST {
     extends TokenExpectedAST[T]
        with CodeDocumentedAST
 
-  case class TokenUndocumented[T <: Token](code: CodeToken[T]) extends TokenAST {
+  case class TokenUndocumented[T <: Token](code: CodeToken[T]) extends TokenAST[T] {
 
     override def index: SourceIndex =
       code.index
@@ -142,45 +142,45 @@ object SoftAST {
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
 
   case class Dot(
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
 
   case class Comma(
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
 
   case class Return(
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
 
   case class For(
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
 
   case class While(
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
 
   case class Equal(
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
 
-  case class DoubleForwardSlash(code: CodeString) extends TokenAST {
+  case class DoubleForwardSlash(code: CodeString) extends TokenAST[Token] {
 
     override def index: SourceIndex =
       code.index
@@ -191,25 +191,25 @@ object SoftAST {
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
 
   case class Pub(
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
 
   case class At(
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
 
   case class Operator(
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
 
   sealed trait InheritanceType extends SoftAST
 
@@ -217,17 +217,17 @@ object SoftAST {
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
        with InheritanceType
 
   case class Extends(
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
        with InheritanceType
 
-  sealed trait TemplateToken extends TokenDocumentedAST
+  sealed trait TemplateToken extends TokenDocumentedAST[Token]
 
   case class Contract(
       index: SourceIndex,
@@ -241,7 +241,7 @@ object SoftAST {
       code: CodeString)
     extends TemplateToken
 
-  sealed trait DataTemplateToken extends TokenDocumentedAST
+  sealed trait DataTemplateToken extends TokenDocumentedAST[Token]
 
   case class Struct(
       index: SourceIndex,
@@ -267,7 +267,7 @@ object SoftAST {
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
        with ColonAST
 
   case class ColonExpected(
@@ -281,7 +281,7 @@ object SoftAST {
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
        with ForwardArrowAST
 
   case class ForwardArrowExpected(
@@ -295,7 +295,7 @@ object SoftAST {
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
        with OpenParenAST
 
   case class OpenParenExpected(
@@ -309,7 +309,7 @@ object SoftAST {
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
        with CloseParenAST
 
   case class CloseParenExpected(
@@ -323,7 +323,7 @@ object SoftAST {
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
        with OpenCurlyAST
 
   case class OpenCurlyExpected(
@@ -337,7 +337,7 @@ object SoftAST {
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
        with CloseCurlyAST
 
   case class CloseCurlyExpected(
@@ -351,7 +351,7 @@ object SoftAST {
       index: SourceIndex,
       documentation: Option[Comments],
       code: CodeString)
-    extends TokenDocumentedAST
+    extends TokenDocumentedAST[Token]
        with SemicolonAST
 
   case class SemicolonExpected(
@@ -359,7 +359,7 @@ object SoftAST {
     extends TokenExpectedErrorAST(Token.Semicolon)
        with SemicolonAST
 
-  sealed abstract class AssignmentControlToken extends TokenDocumentedAST
+  sealed abstract class AssignmentControlToken extends TokenDocumentedAST[Token]
 
   case class Let(
       index: SourceIndex,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -138,12 +138,6 @@ object SoftAST {
 
   }
 
-  case class Fn(
-      index: SourceIndex,
-      documentation: Option[Comments],
-      code: CodeString)
-    extends TokenDocumentedAST[Token]
-
   case class Dot(
       index: SourceIndex,
       documentation: Option[Comments],
@@ -429,7 +423,7 @@ object SoftAST {
       annotations: Seq[Annotation],
       postAnnotationSpace: Option[Space],
       pub: Option[AccessModifier],
-      fn: Fn,
+      fn: TokenDocumented[Token.Fn.type],
       preSignatureSpace: SpaceAST,
       signature: FunctionSignature,
       postSignatureSpace: Option[Space],

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
@@ -95,9 +95,11 @@ object Token {
   case object Quote                                             extends Punctuator("\"") with Reserved
 
   sealed abstract class Data(override val lexeme: String) extends Token
-  case object Let                                         extends Data("let") with Reserved
-  case object Mut                                         extends Data("mut") with Reserved
   case object Const                                       extends Data("const") with Reserved
+
+  sealed abstract class DataDefinition(override val lexeme: String) extends Data(lexeme)
+  case object Let                                                   extends DataDefinition("let") with Reserved
+  case object Mut                                                   extends DataDefinition("mut") with Reserved
 
   sealed abstract class DataTemplate(override val lexeme: String) extends Data(lexeme)
   case object Struct                                              extends DataTemplate("struct") with Reserved

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
@@ -115,11 +115,13 @@ object Token {
   sealed abstract class Definition(override val lexeme: String) extends Token
   case object Fn                                                extends Definition("fn") with Reserved
   case object Import                                            extends Definition("import") with Reserved
-  case object Contract                                          extends Definition("Contract") with Reserved
   case object Abstract                                          extends Definition("Abstract") with Reserved
-  case object TxScript                                          extends Definition("TxScript") with Reserved
-  case object AssetScript                                       extends Definition("AssetScript") with Reserved
   case object Interface                                         extends Definition("Interface") with Reserved
+
+  sealed abstract class TemplateDefinition(override val lexeme: String) extends Definition(lexeme)
+  case object Contract                                                  extends TemplateDefinition("Contract") with Reserved
+  case object TxScript                                                  extends TemplateDefinition("TxScript") with Reserved
+  case object AssetScript                                               extends TemplateDefinition("AssetScript") with Reserved
 
   sealed abstract class Inheritance(override val lexeme: String) extends Token
   case object Extends                                            extends Inheritance("extends") with Reserved

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
@@ -97,10 +97,12 @@ object Token {
   sealed abstract class Data(override val lexeme: String) extends Token
   case object Let                                         extends Data("let") with Reserved
   case object Mut                                         extends Data("mut") with Reserved
-  case object Struct                                      extends Data("struct") with Reserved
   case object Const                                       extends Data("const") with Reserved
-  case object Enum                                        extends Data("enum") with Reserved
-  case object Event                                       extends Data("event") with Reserved
+
+  sealed abstract class DataTemplate(override val lexeme: String) extends Data(lexeme)
+  case object Struct                                              extends DataTemplate("struct") with Reserved
+  case object Enum                                                extends DataTemplate("enum") with Reserved
+  case object Event                                               extends DataTemplate("event") with Reserved
 
   sealed abstract class Control(override val lexeme: String) extends Token
   case object If                                             extends Control("if") with Reserved

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AnnotationSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AnnotationSpec.scala
@@ -51,7 +51,7 @@ class AnnotationSpec extends AnyWordSpec with Matchers {
       // opening paren is parsed
       annotation.tuple.value.openParen shouldBe OpenParen(indexOf("@anno>>(<<"))
       // closing paren is reported as expected
-      annotation.tuple.value.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("@anno(>><<"))
+      annotation.tuple.value.closeParen shouldBe SoftAST.TokenExpected(indexOf("@anno(>><<"), Token.CloseParen)
     }
 
     "reject reserved keyword as annotation identifier" in {

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AnnotationSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AnnotationSpec.scala
@@ -148,7 +148,7 @@ class AnnotationSpec extends AnyWordSpec with Matchers {
             |@anno
             |<<""".stripMargin
         },
-        at = SoftAST.At(
+        at = SoftAST.TokenDocumented(
           indexOf {
             """>>// documentation
               |@<<anno
@@ -157,9 +157,9 @@ class AnnotationSpec extends AnyWordSpec with Matchers {
           documentation =
             // The actual Comments AST is not tested here.
             // These test-cases are for annotations.
-            // The behaviour of Comments is tests in CommentsSpec
+            // The behaviour of Comments is tested in CommentsSpec
             Some(expectedComment),
-          code = Code(
+          code = SoftAST.CodeToken(
             index = indexOf {
               """// documentation
                 |>>@<<anno

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommentSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommentSpec.scala
@@ -93,7 +93,7 @@ class CommentSpec extends AnyWordSpec with Matchers {
               doubleForwardSlash = DoubleForwardSlash(indexOf(s">>//<< my comment $newLine")),
               preTextSpace = Some(SpaceOne(indexOf(s"//>> <<my comment $newLine"))),
               text = Some(
-                SoftAST.Code(
+                SoftAST.CodeString(
                   index = indexOf(s"// >>my comment <<$newLine"),
                   text = "my comment "
                 )
@@ -126,7 +126,7 @@ class CommentSpec extends AnyWordSpec with Matchers {
               doubleForwardSlash = DoubleForwardSlash(indexOf(">>//<< fn function()")),
               preTextSpace = Some(SpaceOne(indexOf("//>> <<fn function()"))),
               text = Some(
-                SoftAST.Code(
+                SoftAST.CodeString(
                   index = indexOf("// >>fn function()<<"),
                   text = "fn function()"
                 )

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommentsSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommentsSpec.scala
@@ -42,7 +42,7 @@ class CommentsSpec extends AnyWordSpec with Matchers {
           )
         ),
         text = Some(
-          SoftAST.Code(
+          SoftAST.CodeString(
             index = indexOf {
               """// >>one<<
                 |// two
@@ -89,7 +89,7 @@ class CommentsSpec extends AnyWordSpec with Matchers {
           )
         ),
         text = Some(
-          SoftAST.Code(
+          SoftAST.CodeString(
             index = indexOf {
               """// one
                 |// >>two<<
@@ -144,7 +144,7 @@ class CommentsSpec extends AnyWordSpec with Matchers {
                 doubleForwardSlash = DoubleForwardSlash(indexOf(s">>//<< //")),
                 preTextSpace = Some(SpaceOne(indexOf(s"//>> <<//"))),
                 text = Some(
-                  SoftAST.Code(
+                  SoftAST.CodeString(
                     index = indexOf(s"// >>//<<"),
                     text = "//"
                   )
@@ -188,7 +188,7 @@ class CommentsSpec extends AnyWordSpec with Matchers {
                   )
                 ),
                 text = Some(
-                  SoftAST.Code(
+                  SoftAST.CodeString(
                     index = indexOf {
                       """//
                         |>>//<<""".stripMargin

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionBlockSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionBlockSpec.scala
@@ -17,7 +17,7 @@
 package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -74,7 +74,7 @@ class FunctionBlockSpec extends AnyWordSpec with Matchers {
         )
 
       block.closeCurly shouldBe
-        SoftAST.CloseCurlyExpected(indexOf("fn -> {>><<"))
+        SoftAST.TokenExpected(indexOf("fn -> {>><<"), Token.CloseCurly)
     }
 
   }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionNameSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionNameSpec.scala
@@ -17,7 +17,7 @@
 package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
@@ -167,7 +167,7 @@ class FunctionNameSpec extends AnyWordSpec with Matchers {
     function
       .signature
       .params
-      .closeParen shouldBe SoftAST.CloseParenExpected(indexOf("fn abcd(>><<"))
+      .closeParen shouldBe SoftAST.TokenExpected(indexOf("fn abcd(>><<"), Token.CloseParen)
   }
 
   "missing opening parentheses" in {
@@ -183,7 +183,7 @@ class FunctionNameSpec extends AnyWordSpec with Matchers {
     function
       .signature
       .params
-      .openParen shouldBe SoftAST.OpenParenExpected(indexOf("fn abcd>><<)"))
+      .openParen shouldBe SoftAST.TokenExpected(indexOf("fn abcd>><<)"), Token.OpenParen)
   }
 
 }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionReturnClauseSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionReturnClauseSpec.scala
@@ -49,7 +49,7 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
           forwardArrow = ForwardArrow(indexOf("fn >>-><< type")),
           space = Some(
             SoftAST.Space(
-              SoftAST.Code(
+              SoftAST.CodeString(
                 index = indexOf("fn __>> <<type"),
                 text = " "
               )

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionReturnClauseSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionReturnClauseSpec.scala
@@ -17,7 +17,7 @@
 package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
@@ -120,7 +120,7 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
       function.signature.params.openParen shouldBe OpenParen(indexOf("fn function>>(<<-> "))
 
       function.signature.params.closeParen shouldBe
-        SoftAST.CloseParenExpected(indexOf("fn function(>><<-> "))
+        SoftAST.TokenExpected(indexOf("fn function(>><<-> "), Token.CloseParen)
 
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
@@ -142,7 +142,7 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
         )
 
       function.signature.params.openParen shouldBe OpenParen(indexOf("fn function>>(<<-> Type"))
-      function.signature.params.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("fn function(>><<-> Type"))
+      function.signature.params.closeParen shouldBe SoftAST.TokenExpected(indexOf("fn function(>><<-> Type"), Token.CloseParen)
 
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateSpec.scala
@@ -64,8 +64,8 @@ class TemplateSpec extends AnyWordSpec with Matchers {
         template.preParamSpace shouldBe None
         template.params shouldBe empty
         template.postParamSpace shouldBe None
-        template.block.openCurly shouldBe SoftAST.OpenCurlyExpected(indexOf(s"$templateToken>><<"))
-        template.block.closeCurly shouldBe SoftAST.CloseCurlyExpected(indexOf(s"$templateToken>><<"))
+        template.block.openCurly shouldBe SoftAST.TokenExpected(indexOf(s"$templateToken>><<"), Token.OpenCurly)
+        template.block.closeCurly shouldBe SoftAST.TokenExpected(indexOf(s"$templateToken>><<"), Token.CloseCurly)
       }
 
       "lowercase" in {
@@ -88,8 +88,8 @@ class TemplateSpec extends AnyWordSpec with Matchers {
         template.preParamSpace shouldBe empty
         template.params shouldBe empty
         template.postParamSpace shouldBe empty
-        template.block.openCurly shouldBe SoftAST.OpenCurlyExpected(indexOf(s"$templateToken>><<"))
-        template.block.closeCurly shouldBe SoftAST.CloseCurlyExpected(indexOf(s"$templateToken>><<"))
+        template.block.openCurly shouldBe SoftAST.TokenExpected(indexOf(s"$templateToken>><<"), Token.OpenCurly)
+        template.block.closeCurly shouldBe SoftAST.TokenExpected(indexOf(s"$templateToken>><<"), Token.CloseCurly)
       }
 
       "lowercase" in {
@@ -135,7 +135,7 @@ class TemplateSpec extends AnyWordSpec with Matchers {
         parseTemplate("Contract mycontract }")
 
       template.block.closeCurly shouldBe CloseCurly(indexOf("Contract mycontract >>}<<"))
-      template.block.openCurly shouldBe SoftAST.OpenCurlyExpected(indexOf("Contract mycontract >><<}"))
+      template.block.openCurly shouldBe SoftAST.TokenExpected(indexOf("Contract mycontract >><<}"), Token.OpenCurly)
     }
 
     "close brace and identifier are missing" in {
@@ -147,7 +147,7 @@ class TemplateSpec extends AnyWordSpec with Matchers {
       template.preIdentifierSpace shouldBe SpaceOne(indexOf("Contract>> <<{"))
 
       template.block.openCurly shouldBe OpenCurly(indexOf("Contract >>{<<"))
-      template.block.closeCurly shouldBe SoftAST.CloseCurlyExpected(indexOf("Contract {>><<"))
+      template.block.closeCurly shouldBe SoftAST.TokenExpected(indexOf("Contract {>><<"), Token.CloseCurly)
     }
 
     "a function is defined" in {
@@ -165,13 +165,14 @@ class TemplateSpec extends AnyWordSpec with Matchers {
       template.block.openCurly shouldBe OpenCurly(indexOf("Contract >>{<<"))
 
       template.block.closeCurly shouldBe
-        SoftAST.CloseCurlyExpected(
-          indexOf {
+        SoftAST.TokenExpected(
+          index = indexOf {
             """Contract {
               |  fn function( ->
               |
               |>><<""".stripMargin
-          }
+          },
+          token = Token.CloseCurly
         )
 
       /**
@@ -217,13 +218,14 @@ class TemplateSpec extends AnyWordSpec with Matchers {
       template.block.openCurly shouldBe OpenCurly(indexOf("Contract >>{<<"))
 
       template.block.closeCurly shouldBe
-        SoftAST.CloseCurlyExpected(
-          indexOf {
+        SoftAST.TokenExpected(
+          index = indexOf {
             """Contract {
               |  TxScript myScript
               |
               |>><<""".stripMargin
-          }
+          },
+          token = Token.CloseCurly
         )
 
       /**

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateSpec.scala
@@ -17,7 +17,7 @@
 package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
@@ -116,7 +116,7 @@ class TemplateSpec extends AnyWordSpec with Matchers {
 
       val params = template.params.value
       params.openParen shouldBe OpenParen(indexOf("Contract mycontract>>(<<"))
-      params.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("Contract mycontract(>><<"))
+      params.closeParen shouldBe SoftAST.TokenExpected(indexOf("Contract mycontract(>><<"), Token.CloseParen)
     }
 
     "params are empty" in {

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
@@ -54,7 +54,7 @@ object TestParser {
   def parseReservedToken(code: String): Token.Reserved =
     runAnyParser(TokenParser.Reserved(_))(code)
 
-  def parseInfixOperatorOrFail(code: String): SoftAST.Operator =
+  def parseInfixOperatorOrFail(code: String): SoftAST.TokenDocumented[Token.InfixOperator] =
     runAnyParser(TokenParser.InfixOperatorOrFail(_))(code)
 
   def parseReservedTokenOrError(code: String): Either[Parsed.Failure, Token.Reserved] =

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParserSpec.scala
@@ -26,7 +26,7 @@ class TokenParserSpec extends AnyWordSpec {
         infixOperators foreach {
           infix =>
             parseInfixOperatorOrFail(infix.lexeme) shouldBe
-              InfixOperator(
+              TokenDocumented(
                 index = range(0, infix.lexeme.length),
                 token = infix
               )

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TupleSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TupleSpec.scala
@@ -17,7 +17,7 @@
 package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
@@ -30,7 +30,7 @@ class TupleSpec extends AnyWordSpec with Matchers {
     val tuple =
       parseTuple(")")
 
-    tuple.openParen shouldBe SoftAST.OpenParenExpected(indexOf(">><<)"))
+    tuple.openParen shouldBe SoftAST.TokenExpected(indexOf(">><<)"), Token.OpenParen)
     tuple.closeParen shouldBe CloseParen(indexOf(">>)<<"))
   }
 
@@ -39,7 +39,7 @@ class TupleSpec extends AnyWordSpec with Matchers {
       parseTuple("(")
 
     tuple.openParen shouldBe OpenParen(indexOf(">>(<<"))
-    tuple.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("(>><<"))
+    tuple.closeParen shouldBe SoftAST.TokenExpected(indexOf("(>><<"), Token.CloseParen)
   }
 
   "empty tuple" when {
@@ -98,7 +98,7 @@ class TupleSpec extends AnyWordSpec with Matchers {
         text = "aaa"
       )
 
-    tuple.closeParen shouldBe SoftAST.CloseParenExpected(indexOf("(aaa >><<typename"))
+    tuple.closeParen shouldBe SoftAST.TokenExpected(indexOf("(aaa >><<typename"), Token.CloseParen)
 
     /**
      * Second body part is an Identifier

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -4,11 +4,11 @@ import org.alephium.ralph.SourceIndex
 
 object TestSoftAST {
 
-  def Fn(index: SourceIndex): SoftAST.Fn =
-    SoftAST.Fn(
+  def Fn(index: SourceIndex): SoftAST.TokenDocumented[Token.Fn.type] =
+    SoftAST.TokenDocumented(
       index = index,
       documentation = None,
-      code = Code(
+      code = SoftAST.CodeToken(
         index = index,
         token = Token.Fn
       )

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -42,14 +42,10 @@ object TestSoftAST {
       token = Token.TxScript
     )
 
-  def Colon(index: SourceIndex): SoftAST.Colon =
-    SoftAST.Colon(
+  def Colon(index: SourceIndex): SoftAST.TokenDocumented[Token.Colon.type] =
+    TokenDocumented(
       index = index,
-      documentation = None,
-      code = Code(
-        index = index,
-        token = Token.Colon
-      )
+      token = Token.Colon
     )
 
   def ForwardArrow(index: SourceIndex): SoftAST.ForwardArrow =

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -30,18 +30,6 @@ object TestSoftAST {
       token = Token.At
     )
 
-  def InfixOperator(
-      index: SourceIndex,
-      token: Token.InfixOperator): SoftAST.Operator =
-    SoftAST.Operator(
-      index = index,
-      documentation = None,
-      code = Code(
-        index = index,
-        token = token
-      )
-    )
-
   def Contract(index: SourceIndex): SoftAST.Contract =
     SoftAST.Contract(
       index = index,

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -48,14 +48,10 @@ object TestSoftAST {
       token = Token.Colon
     )
 
-  def ForwardArrow(index: SourceIndex): SoftAST.ForwardArrow =
-    SoftAST.ForwardArrow(
+  def ForwardArrow(index: SourceIndex): SoftAST.TokenDocumented[Token.ForwardArrow.type] =
+    TokenDocumented(
       index = index,
-      documentation = None,
-      code = Code(
-        index = index,
-        token = Token.ForwardArrow
-      )
+      token = Token.ForwardArrow
     )
 
   def OpenParen(index: SourceIndex): SoftAST.OpenParen =

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -30,24 +30,16 @@ object TestSoftAST {
       token = Token.At
     )
 
-  def Contract(index: SourceIndex): SoftAST.Contract =
-    SoftAST.Contract(
+  def Contract(index: SourceIndex): SoftAST.TokenDocumented[Token.Contract.type] =
+    TokenDocumented(
       index = index,
-      documentation = None,
-      code = Code(
-        index = index,
-        token = Token.Contract
-      )
+      token = Token.Contract
     )
 
-  def TxScript(index: SourceIndex): SoftAST.TxScript =
-    SoftAST.TxScript(
+  def TxScript(index: SourceIndex): SoftAST.TokenDocumented[Token.TxScript.type] =
+    TokenDocumented(
       index = index,
-      documentation = None,
-      code = Code(
-        index = index,
-        token = Token.TxScript
-      )
+      token = Token.TxScript
     )
 
   def Colon(index: SourceIndex): SoftAST.Colon =

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -5,23 +5,15 @@ import org.alephium.ralph.SourceIndex
 object TestSoftAST {
 
   def Fn(index: SourceIndex): SoftAST.TokenDocumented[Token.Fn.type] =
-    SoftAST.TokenDocumented(
+    TokenDocumented(
       index = index,
-      documentation = None,
-      code = SoftAST.CodeToken(
-        index = index,
-        token = Token.Fn
-      )
+      token = Token.Fn
     )
 
-  def Comma(index: SourceIndex): SoftAST.Comma =
-    SoftAST.Comma(
+  def Comma(index: SourceIndex): SoftAST.TokenDocumented[Token.Comma.type] =
+    TokenDocumented(
       index = index,
-      documentation = None,
-      code = Code(
-        index = index,
-        token = Token.Comma
-      )
+      token = Token.Comma
     )
 
   def DoubleForwardSlash(index: SourceIndex): SoftAST.DoubleForwardSlash =
@@ -190,6 +182,18 @@ object TestSoftAST {
     SoftAST.CodeString(
       index = index,
       text = token.lexeme
+    )
+
+  def TokenDocumented[T <: Token](
+      index: SourceIndex,
+      token: T): SoftAST.TokenDocumented[T] =
+    SoftAST.TokenDocumented(
+      index = index,
+      documentation = None,
+      code = SoftAST.CodeToken(
+        index = index,
+        token = token
+      )
     )
 
 }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -140,7 +140,7 @@ object TestSoftAST {
     SoftAST.Identifier(
       index = index,
       documentation = None,
-      code = SoftAST.Code(
+      code = SoftAST.CodeString(
         index = index,
         text = text
       )
@@ -152,7 +152,7 @@ object TestSoftAST {
     SoftAST.Unresolved(
       index = index,
       documentation = None,
-      code = SoftAST.Code(
+      code = SoftAST.CodeString(
         index = index,
         text = text
       )
@@ -162,7 +162,7 @@ object TestSoftAST {
       index: SourceIndex,
       text: String): SoftAST.Space =
     SoftAST.Space(
-      code = SoftAST.Code(
+      code = SoftAST.CodeString(
         index = index,
         text = text
       )
@@ -170,7 +170,7 @@ object TestSoftAST {
 
   def SpaceOne(index: SourceIndex): SoftAST.Space =
     SoftAST.Space(
-      code = SoftAST.Code(
+      code = SoftAST.CodeString(
         index = index,
         text = " "
       )
@@ -186,8 +186,8 @@ object TestSoftAST {
 
   def Code(
       index: SourceIndex,
-      token: Token): SoftAST.Code =
-    SoftAST.Code(
+      token: Token): SoftAST.CodeString =
+    SoftAST.CodeString(
       index = index,
       text = token.lexeme
     )

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -24,14 +24,10 @@ object TestSoftAST {
       )
     )
 
-  def At(index: SourceIndex): SoftAST.At =
-    SoftAST.At(
+  def At(index: SourceIndex): SoftAST.TokenDocumented[Token.At.type] =
+    TokenDocumented(
       index = index,
-      documentation = None,
-      code = Code(
-        index = index,
-        token = Token.At
-      )
+      token = Token.At
     )
 
   def InfixOperator(

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -16,9 +16,9 @@ object TestSoftAST {
       token = Token.Comma
     )
 
-  def DoubleForwardSlash(index: SourceIndex): SoftAST.DoubleForwardSlash =
-    SoftAST.DoubleForwardSlash(
-      code = Code(
+  def DoubleForwardSlash(index: SourceIndex): SoftAST.TokenUndocumented[Token.DoubleForwardSlash.type] =
+    SoftAST.TokenUndocumented(
+      SoftAST.CodeToken(
         index = index,
         token = Token.DoubleForwardSlash
       )

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -54,24 +54,16 @@ object TestSoftAST {
       token = Token.ForwardArrow
     )
 
-  def OpenParen(index: SourceIndex): SoftAST.OpenParen =
-    SoftAST.OpenParen(
+  def OpenParen(index: SourceIndex): SoftAST.TokenDocumented[Token.OpenParen.type] =
+    TokenDocumented(
       index = index,
-      documentation = None,
-      code = Code(
-        index = index,
-        token = Token.OpenParen
-      )
+      token = Token.OpenParen
     )
 
-  def CloseParen(index: SourceIndex): SoftAST.CloseParen =
-    SoftAST.CloseParen(
+  def CloseParen(index: SourceIndex): SoftAST.TokenDocumented[Token.CloseParen.type] =
+    TokenDocumented(
       index = index,
-      documentation = None,
-      code = Code(
-        index = index,
-        token = Token.CloseParen
-      )
+      token = Token.CloseParen
     )
 
   def OpenCurly(index: SourceIndex): SoftAST.OpenCurly =

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -66,24 +66,16 @@ object TestSoftAST {
       token = Token.CloseParen
     )
 
-  def OpenCurly(index: SourceIndex): SoftAST.OpenCurly =
-    SoftAST.OpenCurly(
+  def OpenCurly(index: SourceIndex): SoftAST.TokenDocumented[Token.OpenCurly.type] =
+    TokenDocumented(
       index = index,
-      documentation = None,
-      code = Code(
-        index = index,
-        token = Token.OpenCurly
-      )
+      token = Token.OpenCurly
     )
 
-  def CloseCurly(index: SourceIndex): SoftAST.CloseCurly =
-    SoftAST.CloseCurly(
+  def CloseCurly(index: SourceIndex): SoftAST.TokenDocumented[Token.CloseCurly.type] =
+    TokenDocumented(
       index = index,
-      documentation = None,
-      code = Code(
-        index = index,
-        token = Token.CloseCurly
-      )
+      token = Token.CloseCurly
     )
 
   def Identifier(


### PR DESCRIPTION
- Towards #104.
- Implements common AST type for `Token`s.
- It reduces classes required in `SoftAST` by 50%. 
  -  ![image](https://github.com/user-attachments/assets/8aad5f5f-2951-4e95-b09c-f57e6fa4b248)


The following few PRs are towards minor refactoring. After that, parsers incoming.