### PR TITLE
`VariableDeclarationParser` & `AssignmentSpec`

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentAccessModifierParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentAccessModifierParser.scala
@@ -27,7 +27,7 @@ private object AssignmentAccessModifierParser {
     P {
       Index ~
         (TokenParser.parseOrFail(Token.Let) | TokenParser.parseOrFail(Token.Mut)) ~
-        SpaceParser.parseOrFail.? ~
+        SpaceParser.parseOrFail ~
         Index
     } map {
       case (from, dataAssignment, space, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentParser.scala
@@ -10,7 +10,6 @@ private object AssignmentParser {
   def parseOrFail[Unknown: P]: P[SoftAST.Assignment] =
     P {
       Index ~
-        AssignmentAccessModifierParser.parseOrFail.rep ~
         IdentifierParser.parseOrFail ~
         SpaceParser.parseOrFail.? ~
         TokenParser.parseOrFail(Token.Equal) ~
@@ -18,10 +17,9 @@ private object AssignmentParser {
         ExpressionParser.parse ~
         Index
     } map {
-      case (from, control, identifier, postIdentifierSpace, equalToken, postEqualSpace, expression, to) =>
+      case (from, identifier, postIdentifierSpace, equalToken, postEqualSpace, expression, to) =>
         SoftAST.Assignment(
           index = range(from, to),
-          modifiers = control,
           identifier = identifier,
           postIdentifierSpace = postIdentifierSpace,
           equalToken = equalToken,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentParser.scala
@@ -5,12 +5,12 @@ import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
-private object AssignmentParser {
+private case object AssignmentParser {
 
   def parseOrFail[Unknown: P]: P[SoftAST.Assignment] =
     P {
       Index ~
-        IdentifierParser.parseOrFail ~
+        ExpressionParser.parseOrFailSelective(parseInfix = true, parseMethodCall = true, parseAssignment = false) ~
         SpaceParser.parseOrFail.? ~
         TokenParser.parseOrFail(Token.Equal) ~
         SpaceParser.parseOrFail.? ~
@@ -20,11 +20,11 @@ private object AssignmentParser {
       case (from, identifier, postIdentifierSpace, equalToken, postEqualSpace, expression, to) =>
         SoftAST.Assignment(
           index = range(from, to),
-          identifier = identifier,
+          expressionLeft = identifier,
           postIdentifierSpace = postIdentifierSpace,
           equalToken = equalToken,
           postEqualSpace = postEqualSpace,
-          expression = expression
+          expressionRight = expression
         )
     }
 

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala
@@ -33,6 +33,14 @@ object Demo extends App {
         |       // infix assignment
         |       let sum = 1 + 2
         |     }
+        |
+        |     // complex assignment
+        |     object.function(1).value = cache.getValue()
+        |
+        |     // complex equality check
+        |     while(cache.getValue() == objectB.read().value) {
+        |        // do something
+        |     }
         |  }
         |
         |  🚀

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ExpressionParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ExpressionParser.scala
@@ -77,6 +77,7 @@ private object ExpressionParser {
       ReturnStatementParser.parseOrFail |
         ForLoopParser.parseOrFail |
         WhileLoopParser.parseOrFail |
+        VariableDeclarationParser.parseOrFail |
         AssignmentParser.parseOrFail |
         TypeAssignmentParser.parseOrFail |
         BlockParser.clause(required = false) |

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/InfixCallParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/InfixCallParser.scala
@@ -10,7 +10,7 @@ case object InfixCallParser {
   def parseOrFail[Unknown: P]: P[SoftAST.InfixExpression] =
     P {
       Index ~
-        ExpressionParser.parseOrFailSelective(parseInfix = false, parseMethodCall = true) ~
+        ExpressionParser.parseOrFailSelective(parseInfix = false, parseMethodCall = true, parseAssignment = false) ~
         SpaceParser.parseOrFail.? ~
         TokenParser.InfixOperatorOrFail ~
         SpaceParser.parseOrFail.? ~

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MethodCallParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MethodCallParser.scala
@@ -10,7 +10,7 @@ case object MethodCallParser {
   def parseOrFail[Unknown: P]: P[SoftAST.MethodCall] =
     P {
       Index ~
-        ExpressionParser.parseOrFailSelective(parseInfix = false, parseMethodCall = false) ~
+        ExpressionParser.parseOrFailSelective(parseInfix = false, parseMethodCall = false, parseAssignment = false) ~
         SpaceParser.parseOrFail.? ~
         dotCall.rep(1) ~
         Index
@@ -29,7 +29,7 @@ case object MethodCallParser {
       Index ~
         TokenParser.parseOrFail(Token.Dot) ~
         SpaceParser.parseOrFail.? ~
-        ReferenceCallParser.parse ~
+        (ReferenceCallParser.parseOrFail | IdentifierParser.parse) ~
         Index
     } map {
       case (from, dot, postDotSpace, rightExpression, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/UnresolvedParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/UnresolvedParser.scala
@@ -33,8 +33,8 @@ private object UnresolvedParser {
       case (from, text, tailComment, to) =>
         SoftAST.Unresolved(
           index = range(from, to),
-          code = text,
-          documentation = tailComment
+          documentation = tailComment,
+          code = text
         )
     }
 

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/VariableDeclarationParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/VariableDeclarationParser.scala
@@ -1,0 +1,26 @@
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse._
+import fastparse.NoWhitespace.noWhitespaceImplicit
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+
+private object VariableDeclarationParser {
+
+  /** Syntax: let mut variable = some_expression */
+  def parseOrFail[Unknown: P]: P[SoftAST.VariableDeclaration] =
+    P {
+      Index ~
+        AssignmentAccessModifierParser.parseOrFail.rep(1) ~
+        AssignmentParser.parseOrFail ~
+        Index
+    } map {
+      case (from, modifier, assignment, to) =>
+        SoftAST.VariableDeclaration(
+          index = range(from, to),
+          modifiers = modifier,
+          assignment = assignment
+        )
+    }
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -322,7 +322,7 @@ object SoftAST {
       index: SourceIndex,
       dot: TokenDocumented[Token.Dot.type],
       postDotSpace: Option[Space],
-      rightExpression: ReferenceCall)
+      rightExpression: ReferenceCallOrIdentifier)
     extends SoftAST
 
   case class ReturnStatement(
@@ -368,11 +368,11 @@ object SoftAST {
 
   case class Assignment(
       index: SourceIndex,
-      identifier: Identifier,
+      expressionLeft: ExpressionAST,
       postIdentifierSpace: Option[Space],
       equalToken: TokenDocumented[Token.Equal.type],
       postEqualSpace: Option[Space],
-      expression: ExpressionAST)
+      expressionRight: ExpressionAST)
     extends ExpressionAST
 
   case class TypeAssignment(

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -368,7 +368,6 @@ object SoftAST {
 
   case class Assignment(
       index: SourceIndex,
-      modifiers: Seq[SoftAST.AssignmentAccessModifier],
       identifier: Identifier,
       postIdentifierSpace: Option[Space],
       equalToken: TokenDocumented[Token.Equal.type],
@@ -389,13 +388,19 @@ object SoftAST {
   case class AssignmentAccessModifier(
       index: SourceIndex,
       token: TokenDocumented[Token.DataDefinition],
-      postTokenSpace: Option[Space])
+      postTokenSpace: Space)
     extends ExpressionAST
 
   case class AccessModifier(
       index: SourceIndex,
       pub: TokenDocumented[Token.Pub.type],
       postTokenSpace: Option[Space])
+    extends ExpressionAST
+
+  case class VariableDeclaration(
+      index: SourceIndex,
+      modifiers: Seq[AssignmentAccessModifier],
+      assignment: Assignment)
     extends ExpressionAST
 
   case class Annotation(

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentSpec.scala
@@ -1,0 +1,84 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class AssignmentSpec extends AnyWordSpec with Matchers {
+
+  "report ExpressionExpected" when {
+    "a variable is assigned without initialisation" in {
+      val annotation =
+        parseAssignment("variable =")
+
+      annotation shouldBe
+        SoftAST.Assignment(
+          index = indexOf(">>variable =<<"),
+          identifier = Identifier(indexOf(">>variable<<="), "variable"),
+          postIdentifierSpace = Some(SpaceOne(indexOf("variable>> <<="))),
+          equalToken = Equal(indexOf("variable >>=<<")),
+          postEqualSpace = None,
+          expression = SoftAST.ExpressionExpected(indexOf("variable =>><<"))
+        )
+    }
+  }
+
+  "succeed" when {
+    "full assignment syntax is defined" in {
+      val assigment =
+        parseAssignment("variable = 1")
+
+      assigment shouldBe
+        SoftAST.Assignment(
+          index = indexOf(">>variable = 1<<"),
+          identifier = Identifier(indexOf(">>variable<< = 1"), "variable"),
+          postIdentifierSpace = Some(SpaceOne(indexOf("variable>> <<= 1"))),
+          equalToken = Equal(indexOf("variable >>=<< 1")),
+          postEqualSpace = Some(SpaceOne(indexOf("variable =>> <<1"))),
+          expression = Number(indexOf("variable = >>1<<"), "1")
+        )
+    }
+
+    "expression is another expression" in {
+      val assigment =
+        parseAssignment("variable = variable + 1")
+
+      assigment shouldBe
+        SoftAST.Assignment(
+          index = indexOf(">>variable = variable + 1<<"),
+          identifier = Identifier(indexOf(">>variable<< = variable + 1"), "variable"),
+          postIdentifierSpace = Some(SpaceOne(indexOf("variable>> <<= variable + 1"))),
+          equalToken = Equal(indexOf("variable >>=<< variable + 1")),
+          postEqualSpace = Some(SpaceOne(indexOf("variable =>> << variable + 1"))),
+          expression = SoftAST.InfixExpression(
+            index = indexOf("variable = >>variable + 1<<"),
+            leftExpression = Identifier(indexOf("variable = >>variable<< + 1"), "variable"),
+            preOperatorSpace = Some(SpaceOne(indexOf("variable = variable>> <<+ 1"))),
+            operator = Plus(indexOf("variable = variable >>+<< 1")),
+            postOperatorSpace = Some(SpaceOne(indexOf("variable = variable +>> <<1"))),
+            rightExpression = Number(indexOf("variable = variable + >>1<<"), "1")
+          )
+        )
+    }
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentSpec.scala
@@ -25,59 +25,118 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class AssignmentSpec extends AnyWordSpec with Matchers {
 
-  "report ExpressionExpected" when {
-    "a variable is assigned without initialisation" in {
-      val annotation =
-        parseAssignment("variable =")
+  "assignments to an identifier" should {
+    "report ExpressionExpected" when {
+      "a variable is assigned without initialisation" in {
+        val assignment =
+          parseAssignment("variable =")
 
-      annotation shouldBe
-        SoftAST.Assignment(
-          index = indexOf(">>variable =<<"),
-          identifier = Identifier(indexOf(">>variable<<="), "variable"),
-          postIdentifierSpace = Some(SpaceOne(indexOf("variable>> <<="))),
-          equalToken = Equal(indexOf("variable >>=<<")),
-          postEqualSpace = None,
-          expression = SoftAST.ExpressionExpected(indexOf("variable =>><<"))
-        )
+        assignment shouldBe
+          SoftAST.Assignment(
+            index = indexOf(">>variable =<<"),
+            expressionLeft = Identifier(indexOf(">>variable<<="), "variable"),
+            postIdentifierSpace = Some(SpaceOne(indexOf("variable>> <<="))),
+            equalToken = Equal(indexOf("variable >>=<<")),
+            postEqualSpace = None,
+            expressionRight = SoftAST.ExpressionExpected(indexOf("variable =>><<"))
+          )
+      }
+    }
+
+    "succeed" when {
+      "full assignment syntax is defined" in {
+        val assigment =
+          parseAssignment("variable = 1")
+
+        assigment shouldBe
+          SoftAST.Assignment(
+            index = indexOf(">>variable = 1<<"),
+            expressionLeft = Identifier(indexOf(">>variable<< = 1"), "variable"),
+            postIdentifierSpace = Some(SpaceOne(indexOf("variable>> <<= 1"))),
+            equalToken = Equal(indexOf("variable >>=<< 1")),
+            postEqualSpace = Some(SpaceOne(indexOf("variable =>> <<1"))),
+            expressionRight = Number(indexOf("variable = >>1<<"), "1")
+          )
+      }
+
+      "expression is another expression" in {
+        val assigment =
+          parseAssignment("variable = variable + 1")
+
+        assigment shouldBe
+          SoftAST.Assignment(
+            index = indexOf(">>variable = variable + 1<<"),
+            expressionLeft = Identifier(indexOf(">>variable<< = variable + 1"), "variable"),
+            postIdentifierSpace = Some(SpaceOne(indexOf("variable>> <<= variable + 1"))),
+            equalToken = Equal(indexOf("variable >>=<< variable + 1")),
+            postEqualSpace = Some(SpaceOne(indexOf("variable =>> << variable + 1"))),
+            expressionRight = SoftAST.InfixExpression(
+              index = indexOf("variable = >>variable + 1<<"),
+              leftExpression = Identifier(indexOf("variable = >>variable<< + 1"), "variable"),
+              preOperatorSpace = Some(SpaceOne(indexOf("variable = variable>> <<+ 1"))),
+              operator = Plus(indexOf("variable = variable >>+<< 1")),
+              postOperatorSpace = Some(SpaceOne(indexOf("variable = variable +>> <<1"))),
+              rightExpression = Number(indexOf("variable = variable + >>1<<"), "1")
+            )
+          )
+      }
     }
   }
 
-  "succeed" when {
-    "full assignment syntax is defined" in {
-      val assigment =
-        parseAssignment("variable = 1")
+  "assignments to an expression" should {
+    "succeed" when {
+      "left expression is a method call" in {
+        val assignment =
+          parseAssignment("obj.func(param).counter = 0")
 
-      assigment shouldBe
-        SoftAST.Assignment(
-          index = indexOf(">>variable = 1<<"),
-          identifier = Identifier(indexOf(">>variable<< = 1"), "variable"),
-          postIdentifierSpace = Some(SpaceOne(indexOf("variable>> <<= 1"))),
-          equalToken = Equal(indexOf("variable >>=<< 1")),
-          postEqualSpace = Some(SpaceOne(indexOf("variable =>> <<1"))),
-          expression = Number(indexOf("variable = >>1<<"), "1")
-        )
+        // left expression is a method call
+        val methodCall = assignment.expressionLeft.asInstanceOf[SoftAST.MethodCall]
+        methodCall.index shouldBe indexOf(">>obj.func(param).counter<< = 0")
+        val objectName = methodCall.leftExpression.asInstanceOf[SoftAST.Identifier]
+        objectName.code.text shouldBe "obj"
+
+        // right expression is a number
+        val number = assignment.expressionRight.asInstanceOf[SoftAST.Number]
+        number shouldBe
+          Number(
+            index = indexOf("obj.func(param).counter = >>0<<"),
+            text = "0"
+          )
+      }
+
+      "left & right expressions both are method call" in {
+        val assignment =
+          parseAssignment("obj.func(param).counter = cache.getNumber()")
+
+        // left expression is a method call
+        val left = assignment.expressionLeft.asInstanceOf[SoftAST.MethodCall]
+        left.index shouldBe indexOf(">>obj.func(param).counter<< = cache.getNumber()")
+        val objectName = left.leftExpression.asInstanceOf[SoftAST.Identifier]
+        objectName.code.text shouldBe "obj"
+
+        // right expression is also a method call
+        val right = assignment.expressionRight.asInstanceOf[SoftAST.MethodCall]
+        right.index shouldBe indexOf("obj.func(param).counter = >>cache.getNumber()<<")
+        val cacheObject = right.leftExpression.asInstanceOf[SoftAST.Identifier]
+        cacheObject.code.text shouldBe "cache"
+      }
     }
 
-    "expression is another expression" in {
-      val assigment =
-        parseAssignment("variable = variable + 1")
+    "report missing expression" when {
+      "left expression is a method call and right expression is missing" in {
+        val assignment =
+          parseAssignment("obj.func(param).counter =")
 
-      assigment shouldBe
-        SoftAST.Assignment(
-          index = indexOf(">>variable = variable + 1<<"),
-          identifier = Identifier(indexOf(">>variable<< = variable + 1"), "variable"),
-          postIdentifierSpace = Some(SpaceOne(indexOf("variable>> <<= variable + 1"))),
-          equalToken = Equal(indexOf("variable >>=<< variable + 1")),
-          postEqualSpace = Some(SpaceOne(indexOf("variable =>> << variable + 1"))),
-          expression = SoftAST.InfixExpression(
-            index = indexOf("variable = >>variable + 1<<"),
-            leftExpression = Identifier(indexOf("variable = >>variable<< + 1"), "variable"),
-            preOperatorSpace = Some(SpaceOne(indexOf("variable = variable>> <<+ 1"))),
-            operator = Plus(indexOf("variable = variable >>+<< 1")),
-            postOperatorSpace = Some(SpaceOne(indexOf("variable = variable +>> <<1"))),
-            rightExpression = Number(indexOf("variable = variable + >>1<<"), "1")
-          )
-        )
+        // left expression is a method call
+        val methodCall = assignment.expressionLeft.asInstanceOf[SoftAST.MethodCall]
+        methodCall.index shouldBe indexOf(">>obj.func(param).counter<< = 0")
+        val objectName = methodCall.leftExpression.asInstanceOf[SoftAST.Identifier]
+        objectName.code.text shouldBe "obj"
+
+        // right expression is a number
+        assignment.expressionRight shouldBe
+          SoftAST.ExpressionExpected(indexOf("obj.func(param).counter =>><<"))
+      }
     }
   }
 

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
@@ -30,6 +30,12 @@ object TestParser {
   def parseAnnotation(code: String): SoftAST.Annotation =
     runSoftParser(AnnotationParser.parseOrFail(_))(code)
 
+  def parseVariableDeclaration(code: String): SoftAST.VariableDeclaration =
+    runSoftParser(VariableDeclarationParser.parseOrFail(_))(code)
+
+  def parseAssignment(code: String): SoftAST.Assignment =
+    runSoftParser(AssignmentParser.parseOrFail(_))(code)
+
   def parseTemplate(code: String): SoftAST.Template =
     runSoftParser(TemplateParser.parseOrFail(_))(code)
 

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/VariableDeclarationSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/VariableDeclarationSpec.scala
@@ -1,0 +1,112 @@
+// Copyright 2024 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see http://www.gnu.org/licenses/.
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.error.CompilerError
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.TryValues.convertTryToSuccessOrFailure
+
+import scala.util.Try
+
+class VariableDeclarationSpec extends AnyWordSpec with Matchers {
+
+  "succeed" when {
+    "full valid variable declaration is defined" in {
+      val assigment =
+        parseVariableDeclaration("let mut variable = 1")
+
+      assigment shouldBe
+        SoftAST.VariableDeclaration(
+          index = indexOf(">>let mut variable = 1<<"),
+          modifiers = Seq(
+            SoftAST.AssignmentAccessModifier(
+              index = indexOf(">>let <<mut variable = 1"),
+              token = Let(indexOf(">>let<< mut variable = 1")),
+              postTokenSpace = SpaceOne(indexOf("let>> <<mut variable = 1"))
+            ),
+            SoftAST.AssignmentAccessModifier(
+              index = indexOf("let >>mut <<variable = 1"),
+              token = Mut(indexOf("let >>mut<< variable = 1")),
+              postTokenSpace = SpaceOne(indexOf("let mut>> <<variable = 1"))
+            )
+          ),
+          assignment = SoftAST.Assignment(
+            index = indexOf("let mut >>variable = 1<<"),
+            identifier = Identifier(indexOf("let mut >>variable<< = 1"), "variable"),
+            postIdentifierSpace = Some(SpaceOne(indexOf("let mut variable>> <<= 1"))),
+            equalToken = Equal(indexOf("let mut variable >>=<< 1")),
+            postEqualSpace = Some(SpaceOne(indexOf("let mut variable =>> <<1"))),
+            expression = Number(indexOf("let mut variable = >>1<<"), "1")
+          )
+        )
+    }
+  }
+
+  "error" when {
+    "expression is missing" in {
+      val assigment =
+        parseVariableDeclaration("let mut variable = ")
+
+      assigment shouldBe
+        SoftAST.VariableDeclaration(
+          index = indexOf(">>let mut variable = <<"),
+          modifiers = Seq(
+            SoftAST.AssignmentAccessModifier(
+              index = indexOf(">>let <<mut variable = "),
+              token = Let(indexOf(">>let<< mut variable = ")),
+              postTokenSpace = SpaceOne(indexOf("let>> <<mut variable = "))
+            ),
+            SoftAST.AssignmentAccessModifier(
+              index = indexOf("let >>mut <<variable = "),
+              token = Mut(indexOf("let >>mut<< variable = ")),
+              postTokenSpace = SpaceOne(indexOf("let mut>> <<variable = "))
+            )
+          ),
+          assignment = SoftAST.Assignment(
+            index = indexOf("let mut >>variable = <<"),
+            identifier = Identifier(indexOf("let mut >>variable<< = "), "variable"),
+            postIdentifierSpace = Some(SpaceOne(indexOf("let mut variable>> <<= "))),
+            equalToken = Equal(indexOf("let mut variable >>=<< ")),
+            postEqualSpace = Some(SpaceOne(indexOf("let mut variable =>> << "))),
+            expression = SoftAST.ExpressionExpected(indexOf("let mut variable = >><<"))
+          )
+        )
+    }
+  }
+
+  "let" should {
+    "not be allowed as variable name" in {
+      Try(parseVariableDeclaration("let let = 1"))
+        .failure
+        .exception
+        .getCause shouldBe a[CompilerError.FastParseError]
+    }
+
+    "allow letter as variable name" in {
+      val varDec =
+        parseVariableDeclaration("let letter = 1")
+
+      varDec.assignment.identifier.code.text shouldBe "letter"
+    }
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -102,6 +102,30 @@ object TestSoftAST {
       token = Token.AlphUppercase
     )
 
+  def Let(index: SourceIndex): SoftAST.TokenDocumented[Token.Let.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Let
+    )
+
+  def Mut(index: SourceIndex): SoftAST.TokenDocumented[Token.Mut.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Mut
+    )
+
+  def Equal(index: SourceIndex): SoftAST.TokenDocumented[Token.Equal.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Equal
+    )
+
+  def Plus(index: SourceIndex): SoftAST.TokenDocumented[Token.Plus.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Plus
+    )
+
   def Identifier(
       index: SourceIndex,
       text: String): SoftAST.Identifier =


### PR DESCRIPTION
- Towards #104
- Parses:
  - Simple assignments, e.g. `variable = 1`
  - Expressions as assignment, e.g. `myStruct.object.value = 1` and other complex expressions.