### PR TITLE
Fix build: `sbt` missing from ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: sbt
+      - uses: sbt/setup-sbt@v1
 
       - name: Get the version
         id: get_version

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -20,6 +20,7 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: sbt
+      - uses: sbt/setup-sbt@v1
       - run: sbt "compile;test;doc;stage"
 
   styling:
@@ -31,4 +32,5 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: sbt
+      - uses: sbt/setup-sbt@v1
       - run: sbt "scalafmtCheckAll; scalafmtSbtCheck"


### PR DESCRIPTION
`sbt` missing from ubuntu-latest. Windows [builds ok](https://github.com/alephium/ralph-lsp/pull/357).

[Error: `sbt: command not found`](https://github.com/alephium/ralph-lsp/actions/runs/12776803287/job/35684124014#step:4:8).