### PR TITLE
Integrating `SoftParser`: Renaming

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
@@ -86,7 +86,7 @@ private object BlockParser {
   private def part[Unknown: P](stop: Seq[Token]): P[SoftAST.BodyPartAST] =
     P {
       TemplateParser.parseOrFail |
-        EventTemplateParser.parseOrFail |
+        EventParser.parseOrFail |
         StructTemplateParser.parseOrFail |
         FunctionParser.parseOrFail |
         ExpressionParser.parseOrFail |

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
@@ -87,7 +87,7 @@ private object BlockParser {
     P {
       TemplateParser.parseOrFail |
         EventParser.parseOrFail |
-        StructTemplateParser.parseOrFail |
+        StructParser.parseOrFail |
         FunctionParser.parseOrFail |
         ExpressionParser.parseOrFail |
         CommentParser.parseOrFail |

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/EventParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/EventParser.scala
@@ -5,9 +5,9 @@ import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
-private object EventTemplateParser {
+private object EventParser {
 
-  def parseOrFail[Unknown: P]: P[SoftAST.EventTemplate] =
+  def parseOrFail[Unknown: P]: P[SoftAST.Event] =
     P {
       Index ~
         TokenParser.parseOrFail(Token.Event) ~
@@ -18,7 +18,7 @@ private object EventTemplateParser {
         Index
     } map {
       case (from, eventToken, preIdentifierSpace, identifier, preParamSpace, params, to) =>
-        SoftAST.EventTemplate(
+        SoftAST.Event(
           index = range(from, to),
           eventToken = eventToken,
           preIdentifierSpace = preIdentifierSpace,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StructParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StructParser.scala
@@ -5,9 +5,9 @@ import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
-private object StructTemplateParser {
+private object StructParser {
 
-  def parseOrFail[Unknown: P]: P[SoftAST.StructTemplate] =
+  def parseOrFail[Unknown: P]: P[SoftAST.Struct] =
     P {
       Index ~
         TokenParser.parseOrFail(Token.Struct) ~
@@ -18,7 +18,7 @@ private object StructTemplateParser {
         Index
     } map {
       case (from, structToken, preIdentifierSpace, identifier, preParamSpace, params, to) =>
-        SoftAST.StructTemplate(
+        SoftAST.Struct(
           index = range(from, to),
           structToken = structToken,
           preIdentifierSpace = preIdentifierSpace,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateParser.scala
@@ -35,7 +35,7 @@ private object TemplateParser {
     }
 
   /** Syntax: `implements or extends contract(arg1, arg2 ...)` */
-  private def inheritance[Unknown: P]: P[SoftAST.TemplateInheritance] =
+  private def inheritance[Unknown: P]: P[SoftAST.Inheritance] =
     P {
       Index ~
         (TokenParser.parseOrFail(Token.Implements) | TokenParser.parseOrFail(Token.Extends)) ~
@@ -45,7 +45,7 @@ private object TemplateParser {
         Index
     } map {
       case (from, token, preConstructorCallSpace, constructorCall, postConstructorCallSpace, to) =>
-        SoftAST.TemplateInheritance(
+        SoftAST.Inheritance(
           index = range(from, to),
           inheritanceType = token,
           preConstructorCallSpace = preConstructorCallSpace,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -164,7 +164,7 @@ object SoftAST {
       block: BlockClause)
     extends BodyPartAST
 
-  case class EventTemplate(
+  case class Event(
       index: SourceIndex,
       eventToken: TokenDocumented[Token.Event.type],
       preIdentifierSpace: SpaceAST,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -284,7 +284,6 @@ object SoftAST {
       code: CodeString)
     extends IdentifierAST
        with CodeDocumentedAST
-       with ExpressionAST
 
   case class IdentifierExpected(
       index: SourceIndex)
@@ -314,15 +313,14 @@ object SoftAST {
        with CodeDocumentedAST
        with BodyPartAST
 
-  sealed trait ReferenceCallOrIdentifier extends SoftAST
+  sealed trait ReferenceCallOrIdentifier extends ExpressionAST
 
   case class ReferenceCall(
       index: SourceIndex,
       reference: IdentifierAST,
       preArgumentsSpace: Option[Space],
       arguments: Group[Token.OpenParen.type, Token.CloseParen.type])
-    extends ExpressionAST
-       with ReferenceCallOrIdentifier
+    extends ReferenceCallOrIdentifier
 
   case class InfixExpression(
       index: SourceIndex,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -173,7 +173,7 @@ object SoftAST {
       params: Group[Token.OpenParen.type, Token.CloseParen.type])
     extends BodyPartAST
 
-  case class StructTemplate(
+  case class Struct(
       index: SourceIndex,
       structToken: TokenDocumented[Token.Struct.type],
       preIdentifierSpace: SpaceAST,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -160,7 +160,7 @@ object SoftAST {
       preParamSpace: Option[Space],
       params: Option[Group[Token.OpenParen.type, Token.CloseParen.type]],
       postParamSpace: Option[Space],
-      inheritance: Seq[TemplateInheritance],
+      inheritance: Seq[Inheritance],
       block: BlockClause)
     extends BodyPartAST
 
@@ -183,7 +183,7 @@ object SoftAST {
     extends BodyPartAST
 
   /** Syntax: `implements or extends contract(arg1, arg2 ...)` */
-  case class TemplateInheritance(
+  case class Inheritance(
       index: SourceIndex,
       inheritanceType: TokenDocumented[Token.Inheritance],
       preConstructorCallSpace: SpaceAST,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
@@ -150,11 +150,6 @@ object Token {
   case object AlphLowercase                                        extends PrimitiveUnit("alph") with Reserved
   case object AlphUppercase                                        extends PrimitiveUnit("ALPH") with Reserved
 
-  sealed trait Term                        extends Token
-  case class Name(lexeme: String)          extends Term
-  case class NumberLiteral(lexeme: String) extends Term
-  case class StringLiteral(lexeme: String) extends Term
-
   val reserved: Array[Reserved] =
     EnumerationMacros
       .sealedInstancesOf[Reserved]

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/EventParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/EventParserSpec.scala
@@ -7,10 +7,10 @@ import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
 
-class EventTemplateParserSpec extends AnyWordSpec {
+class EventParserSpec extends AnyWordSpec {
 
   "successfully parse an event" in {
-    val event = parseEventTemplate("event MyEvent(varName: TypeName")
+    val event = parseEvent("event MyEvent(varName: TypeName")
 
     event.eventToken shouldBe Event(indexOf(">>event<< MyEvent(varName: TypeName"))
     event.identifier shouldBe Identifier(indexOf("event >>MyEvent<<(varName: TypeName"), "MyEvent")

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StructParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StructParserSpec.scala
@@ -7,10 +7,10 @@ import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
 
-class StructTemplateParserSpec extends AnyWordSpec {
+class StructParserSpec extends AnyWordSpec {
 
   "closing curly is missing" in {
-    val struct = parseStructTemplate("struct MyStruct{varName: TypeName")
+    val struct = parseStruct("struct MyStruct{varName: TypeName")
 
     struct.structToken shouldBe Struct(indexOf(">>struct<< MyStruct{varName: TypeName"))
     struct.identifier shouldBe Identifier(indexOf("struct >>MyStruct<<{varName: TypeName"), "MyStruct")
@@ -22,7 +22,7 @@ class StructTemplateParserSpec extends AnyWordSpec {
   }
 
   "well defined struct" in {
-    val struct = parseStructTemplate("struct Bar { z: U256, mut foo: Foo }")
+    val struct = parseStruct("struct Bar { z: U256, mut foo: Foo }")
 
     struct.structToken shouldBe Struct(indexOf(">>struct<< Bar { z: U256, mut foo: Foo }"))
     struct.identifier shouldBe Identifier(indexOf("struct >>Bar<< { z: U256, mut foo: Foo }"), "Bar")

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
@@ -79,8 +79,8 @@ object TestParser {
   def parseBString(code: String): SoftAST.BString =
     runSoftParser(BStringParser.parseOrFail(_))(code)
 
-  def parseEventTemplate(code: String): SoftAST.EventTemplate =
-    runSoftParser(EventTemplateParser.parseOrFail(_))(code)
+  def parseEvent(code: String): SoftAST.Event =
+    runSoftParser(EventParser.parseOrFail(_))(code)
 
   def parseStructTemplate(code: String): SoftAST.StructTemplate =
     runSoftParser(StructTemplateParser.parseOrFail(_))(code)

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
@@ -82,8 +82,8 @@ object TestParser {
   def parseEvent(code: String): SoftAST.Event =
     runSoftParser(EventParser.parseOrFail(_))(code)
 
-  def parseStructTemplate(code: String): SoftAST.StructTemplate =
-    runSoftParser(StructTemplateParser.parseOrFail(_))(code)
+  def parseStruct(code: String): SoftAST.Struct =
+    runSoftParser(StructParser.parseOrFail(_))(code)
 
   def parseTypeAssignment(code: String): SoftAST.TypeAssignment =
     runSoftParser(TypeAssignmentParser.parseOrFail(_))(code)

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
@@ -486,7 +486,7 @@ class RalphLangServer private (
         val character = params.getPosition.getCharacter
 
         val locations =
-          goTo[GoToDefSetting, SourceLocation.GoToDef](
+          goTo[GoToDefSetting, SourceLocation.GoToDefStrict](
             fileURI = fileURI,
             line = line,
             character = character,
@@ -518,7 +518,7 @@ class RalphLangServer private (
           )
 
         val locations =
-          goTo[GoToRefSetting, SourceLocation.GoToRef](
+          goTo[GoToRefSetting, SourceLocation.GoToRefStrict](
             fileURI = fileURI,
             line = line,
             character = character,
@@ -541,7 +541,7 @@ class RalphLangServer private (
         val character = params.getPosition.getCharacter
 
         val locations =
-          goTo[Unit, SourceLocation.GoToRename](
+          goTo[Unit, SourceLocation.GoToRenameStrict](
             fileURI = fileURI,
             line = line,
             character = character,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/CodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/CodeProvider.scala
@@ -62,15 +62,15 @@ object CodeProvider {
     CodeCompletionProvider
 
   /** The go-to definition implementation of [[CodeProvider]]. */
-  implicit val goToDefinition: CodeProvider[GoToDefSetting, SourceLocation.GoToDef] =
+  implicit val goToDefinition: CodeProvider[GoToDefSetting, SourceLocation.GoToDefStrict] =
     GoToDefinitionProvider
 
   /** The go-to references implementation of [[CodeProvider]]. */
-  implicit val goToReferences: CodeProvider[GoToRefSetting, SourceLocation.GoToRef] =
+  implicit val goToReferences: CodeProvider[GoToRefSetting, SourceLocation.GoToRefStrict] =
     GoToReferenceProvider
 
   /** The rename request implementation of [[CodeProvider]]. */
-  implicit val goToRename: CodeProvider[Unit, SourceLocation.GoToRename] =
+  implicit val goToRename: CodeProvider[Unit, SourceLocation.GoToRenameStrict] =
     GoToRenameProvider
 
   /**

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/CodeCompletionProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/CodeCompletionProvider.scala
@@ -56,7 +56,7 @@ private[search] case object CodeCompletionProvider extends CodeProvider[Unit, Su
             // request is within a contract source-code
             SourceCodeCompleter.complete(
               cursorIndex = cursorIndex,
-              sourceCode = SourceLocation.Code(tree, sourceCode),
+              sourceCode = SourceLocation.CodeStrict(tree, sourceCode),
               workspace = workspace
             )
         }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/CodeCompletionProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/CodeCompletionProvider.scala
@@ -39,7 +39,7 @@ private[search] case object CodeCompletionProvider extends CodeProvider[Unit, Su
       searchSettings: Unit
     )(implicit logger: ClientLogger): Iterator[Suggestion] =
     // find the statement where this cursorIndex sits.
-    sourceCode.ast.statements.find(_.index contains cursorIndex) match {
+    sourceCode.astStrict.statements.find(_.index contains cursorIndex) match {
       case Some(statement) =>
         statement match {
           case importStatement: Tree.Import =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/EnumFieldCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/EnumFieldCompleter.scala
@@ -34,7 +34,7 @@ object EnumFieldCompleter {
    */
   def suggest(
       enumId: Ast.TypeId,
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion.EnumFields] = {
     val trees =
       WorkspaceSearcher.collectInheritedParents(
@@ -54,7 +54,7 @@ object EnumFieldCompleter {
         sourceCode =>
           sourceCode.tree.rootNode.walkDown.collect {
             case Node(enumDef: ralph.Ast.EnumDef[_], _) if enumDef.id == enumId =>
-              Suggestion.EnumFields(SourceLocation.Node(enumDef, sourceCode))
+              Suggestion.EnumFields(SourceLocation.NodeStrict(enumDef, sourceCode))
           }
       }
   }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/FuncIdCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/FuncIdCompleter.scala
@@ -27,7 +27,7 @@ object FuncIdCompleter {
   def suggest(
       cursorIndex: Int,
       funcId: Node[Ast.FuncId, Ast.Positioned],
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware
     )(implicit logger: ClientLogger): Iterator[Suggestion] =
     funcId.parent match {

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/FunctionBodyCompleter.scala
@@ -40,7 +40,7 @@ object FunctionBodyCompleter {
   def suggest(
       cursorIndex: Int,
       closestToCursor: Node[Ast.Positioned, Ast.Positioned],
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion] =
     GoToDefFuncId.goToNearestFuncDef(closestToCursor) match {
       case Some(functionNode) =>
@@ -85,7 +85,7 @@ object FunctionBodyCompleter {
   private def suggestInFunctionBody(
       cursorIndex: Int,
       functionNode: Node[Ast.FuncDef[_], Ast.Positioned],
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion] = {
     // fetch suggestions local to this function
     val localFunctionSuggestions =
@@ -134,19 +134,19 @@ object FunctionBodyCompleter {
   private def suggestLocalFunctionVariables(
       cursorIndex: Int,
       functionNode: Node[Ast.FuncDef[_], Ast.Positioned],
-      sourceCode: SourceLocation.Code): Iterator[Suggestion.NodeAPI] =
+      sourceCode: SourceLocation.CodeStrict): Iterator[Suggestion.NodeAPI] =
     functionNode
       .walkDown
       .filter(_.data.sourceIndex.exists(_.from <= cursorIndex))
       .collect {
         case Node(argument: Ast.Argument, _) =>
           Suggestion.Argument(
-            node = SourceLocation.Node(ast = argument, source = sourceCode),
+            node = SourceLocation.NodeStrict(ast = argument, source = sourceCode),
             isTemplateArgument = false
           )
 
         case Node(data: Ast.VarDef[_], _) =>
-          Suggestion.VarDef(SourceLocation.Node(data, sourceCode))
+          Suggestion.VarDef(SourceLocation.NodeStrict(data, sourceCode))
       }
 
   /**
@@ -157,7 +157,7 @@ object FunctionBodyCompleter {
    * @return An iterator over suggestions from inherited APIs.
    */
   private def suggestInheritedAPIs(
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware): Iterator[Suggestion.InheritedAPI] =
     WorkspaceSearcher
       .collectInheritedParents(
@@ -174,7 +174,7 @@ object FunctionBodyCompleter {
    * @param sourceCode The source code that can be inherited.
    * @return An iterator over public APIs available to inherited code.
    */
-  private def suggestInheritedAPIs(sourceCode: SourceLocation.Code): Iterator[Suggestion.InheritedAPI] =
+  private def suggestInheritedAPIs(sourceCode: SourceLocation.CodeStrict): Iterator[Suggestion.InheritedAPI] =
     sourceCode
       .tree
       .rootNode
@@ -183,32 +183,32 @@ object FunctionBodyCompleter {
         case node @ Node(argument: Ast.Argument, _) if node.parent.exists(_.data.isInstanceOf[Ast.ContractWithState]) =>
           // suggest template level arguments
           Suggestion.Argument(
-            node = SourceLocation.Node(argument, sourceCode),
+            node = SourceLocation.NodeStrict(argument, sourceCode),
             isTemplateArgument = true
           )
 
         case Node(function: Ast.FuncDef[_], _) =>
           // suggest function names
           Suggestion.FuncDef(
-            node = SourceLocation.Node(function, sourceCode),
+            node = SourceLocation.NodeStrict(function, sourceCode),
             isBuiltIn = false
           )
 
         case Node(eventDef: Ast.EventDef, _) =>
           // suggest events
-          Suggestion.EventDef(SourceLocation.Node(eventDef, sourceCode))
+          Suggestion.EventDef(SourceLocation.NodeStrict(eventDef, sourceCode))
 
         case Node(enumDef: Ast.EnumDef[_], _) =>
           // suggest enums
-          Suggestion.EnumDef(SourceLocation.Node(enumDef, sourceCode))
+          Suggestion.EnumDef(SourceLocation.NodeStrict(enumDef, sourceCode))
 
         case Node(constantVarDef: Ast.ConstantVarDef[_], _) =>
           // suggest constants
-          Suggestion.ConstantVarDef(SourceLocation.Node(constantVarDef, sourceCode))
+          Suggestion.ConstantVarDef(SourceLocation.NodeStrict(constantVarDef, sourceCode))
 
         case Node(mapDef: Ast.MapDef, _) =>
           // suggest maps
-          Suggestion.MapDef(SourceLocation.Node(mapDef, sourceCode))
+          Suggestion.MapDef(SourceLocation.NodeStrict(mapDef, sourceCode))
       }
 
   /**

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/IdentCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/IdentCompleter.scala
@@ -37,7 +37,7 @@ object IdentCompleter {
   def suggest(
       cursorIndex: Int,
       ident: Node[Ast.Ident, Ast.Positioned],
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware
     )(implicit logger: ClientLogger): Iterator[Suggestion] =
     ident.parent match {

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/SourceCodeCompleter.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/SourceCodeCompleter.scala
@@ -35,7 +35,7 @@ object SourceCodeCompleter {
    */
   def complete(
       cursorIndex: Int,
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware
     )(implicit logger: ClientLogger): Iterator[Suggestion] =
     sourceCode.tree.rootNode.findLast(_.sourceIndex.exists(_ contains cursorIndex)) match { // find the node closest to this source-index

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/Suggestion.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/Suggestion.scala
@@ -33,7 +33,7 @@ object Suggestion {
   /** A suggestion that points to a node within a tree */
   sealed trait NodeAPI extends Suggestion {
 
-    def node: SourceLocation.Node[Ast.Positioned]
+    def node: SourceLocation.NodeStrict[Ast.Positioned]
 
   }
 
@@ -137,7 +137,7 @@ object Suggestion {
    *                            otherwise as a [[Completion.Field]].
    */
   case class Argument private (
-      node: SourceLocation.Node[Ast.Argument],
+      node: SourceLocation.NodeStrict[Ast.Argument],
       isTemplateArgument: Boolean)
     extends Suggestion.InheritedAPI {
 
@@ -178,7 +178,7 @@ object Suggestion {
    *
    * @param node The node representing the location where the variable was created.
    */
-  case class VarDef(node: SourceLocation.Node[Ast.VarDef[_]]) extends NodeAPI {
+  case class VarDef(node: SourceLocation.NodeStrict[Ast.VarDef[_]]) extends NodeAPI {
 
     override def toCompletion(): Seq[Completion.Variable] =
       node.ast.vars flatMap {
@@ -205,7 +205,7 @@ object Suggestion {
   }
 
   case class FuncDef(
-      node: SourceLocation.Node[Ast.FuncDef[_]],
+      node: SourceLocation.NodeStrict[Ast.FuncDef[_]],
       isBuiltIn: Boolean)
     extends Suggestion.InheritedAPI {
 
@@ -268,7 +268,7 @@ object Suggestion {
 
   }
 
-  case class EventDef(node: SourceLocation.Node[Ast.EventDef]) extends Suggestion.InheritedAPI {
+  case class EventDef(node: SourceLocation.NodeStrict[Ast.EventDef]) extends Suggestion.InheritedAPI {
 
     override def toCompletion(): Seq[Completion.Event] =
       Seq(
@@ -281,7 +281,7 @@ object Suggestion {
 
   }
 
-  case class EnumDef(node: SourceLocation.Node[Ast.EnumDef[_]]) extends Suggestion.InheritedAPI {
+  case class EnumDef(node: SourceLocation.NodeStrict[Ast.EnumDef[_]]) extends Suggestion.InheritedAPI {
 
     override def toCompletion(): Seq[Completion.Enum] =
       Seq(
@@ -294,7 +294,7 @@ object Suggestion {
 
   }
 
-  case class ConstantVarDef(node: SourceLocation.Node[Ast.ConstantVarDef[_]]) extends Suggestion.InheritedAPI {
+  case class ConstantVarDef(node: SourceLocation.NodeStrict[Ast.ConstantVarDef[_]]) extends Suggestion.InheritedAPI {
 
     override def toCompletion(): Seq[Completion.Constant] =
       Seq(
@@ -307,7 +307,7 @@ object Suggestion {
 
   }
 
-  case class MapDef(node: SourceLocation.Node[Ast.MapDef]) extends Suggestion.InheritedAPI {
+  case class MapDef(node: SourceLocation.NodeStrict[Ast.MapDef]) extends Suggestion.InheritedAPI {
 
     override def toCompletion(): Seq[Completion.Property] = {
       val label =
@@ -330,7 +330,7 @@ object Suggestion {
    *
    * @param node The node containing the enum definition.
    */
-  case class EnumFields(node: SourceLocation.Node[Ast.EnumDef[_]]) extends Suggestion.NodeAPI {
+  case class EnumFields(node: SourceLocation.NodeStrict[Ast.EnumDef[_]]) extends Suggestion.NodeAPI {
 
     override def toCompletion(): Seq[Completion.EnumMember] =
       node.ast.fields map {
@@ -349,7 +349,7 @@ object Suggestion {
    *
    * @param node The node containing the type identifier.
    */
-  case class CreatedType(node: SourceLocation.Node[Ast.TypeId]) extends Type {
+  case class CreatedType(node: SourceLocation.NodeStrict[Ast.TypeId]) extends Type {
 
     override def toCompletion(): Seq[Completion.Class] =
       Seq(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefFuncId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefFuncId.scala
@@ -37,10 +37,10 @@ private[search] object GoToDefFuncId extends StrictImplicitLogging {
    */
   def goTo(
       funcIdNode: Node[Ast.FuncId, Ast.Positioned],
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       settings: GoToDefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.Node[Ast.Positioned]] =
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     funcIdNode.parent match { // take one step up to check the type of function call.
       case Some(parent) =>
         parent match {
@@ -122,8 +122,8 @@ private[search] object GoToDefFuncId extends StrictImplicitLogging {
    */
   private def goToFunction(
       funcId: Ast.FuncId,
-      sourceCode: SourceLocation.Code,
-      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.Positioned]] = {
+      sourceCode: SourceLocation.CodeStrict,
+      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] = {
     val functions =
       if (funcId.isBuiltIn)
         workspace.build.findDependency(DependencyID.BuiltIn) match {
@@ -167,7 +167,7 @@ private[search] object GoToDefFuncId extends StrictImplicitLogging {
    *    }
    * }}}
    *
-   * The final result will always include at least one [[SourceLocation.Node]] instance,
+   * The final result will always include at least one [[SourceLocation.NodeStrict]] instance,
    * representing the input `funcId`.
    *
    * @param funcId     The [[Ast.FuncId]] of the function to locate.
@@ -177,13 +177,13 @@ private[search] object GoToDefFuncId extends StrictImplicitLogging {
    */
   private def goToFunctionDefinitions(
       funcId: Ast.FuncId,
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
-      settings: GoToDefSetting): Iterator[SourceLocation.Node[Ast.FuncId]] = {
+      settings: GoToDefSetting): Iterator[SourceLocation.NodeStrict[Ast.FuncId]] = {
     // An iterator with only the input `FuncId` as the result
     def selfOnly() =
       Iterator(
-        SourceLocation.Node(
+        SourceLocation.NodeStrict(
           ast = funcId,
           source = sourceCode
         )
@@ -211,7 +211,7 @@ private[search] object GoToDefFuncId extends StrictImplicitLogging {
           .iterator
           .map {
             funcDef =>
-              SourceLocation.Node(
+              SourceLocation.NodeStrict(
                 ast = funcDef.ast.id,
                 source = funcDef.source
               )
@@ -235,7 +235,7 @@ private[search] object GoToDefFuncId extends StrictImplicitLogging {
       functionId: Ast.FuncId,
       typeExpr: Ast.Expr[_],
       workspace: WorkspaceState.IsSourceAware
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.Node[Ast.Positioned]] =
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     typeExpr.getCachedType() match {
       case Some(types) =>
         val allFunctions =
@@ -263,12 +263,12 @@ private[search] object GoToDefFuncId extends StrictImplicitLogging {
    */
   private def findFuncSignature(
       funcId: Ast.FuncId,
-      functions: Iterator[SourceLocation.Node[Ast.FuncDef[StatefulContext]]]): Iterator[SourceLocation.Node[Ast.Positioned]] =
+      functions: Iterator[SourceLocation.NodeStrict[Ast.FuncDef[StatefulContext]]]): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     functions
       .filter(_.ast.id == funcId)
       .map {
         funcDef =>
-          SourceLocation.Node(
+          SourceLocation.NodeStrict(
             ast = funcDef.ast.id,
             source = funcDef.source
           )

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefImport.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefImport.scala
@@ -28,7 +28,7 @@ private object GoToDefImport {
   def goTo(
       cursorIndex: Int,
       dependency: Option[WorkspaceState.Compiled],
-      importStatement: Tree.Import): ArraySeq[SourceLocation.GoToDef] =
+      importStatement: Tree.Import): ArraySeq[SourceLocation.GoToDefStrict] =
     dependency match {
       case Some(dependency) =>
         goTo(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefSource.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefSource.scala
@@ -35,10 +35,10 @@ private object GoToDefSource extends StrictImplicitLogging {
    */
   def goTo(
       cursorIndex: Int,
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       settings: GoToDefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.Node[Ast.Positioned]] =
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     sourceCode.tree.rootNode.findLast(_.sourceIndex.exists(_ contains cursorIndex)) match { // find the node closest to this source-index
       case Some(closest) =>
         closest match {

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefTypeId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefTypeId.scala
@@ -35,9 +35,9 @@ private object GoToDefTypeId extends StrictImplicitLogging {
    */
   def goTo(
       typeIdNode: Node[Ast.TypeId, Ast.Positioned],
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.Node[Ast.Positioned]] =
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     typeIdNode.parent match { // take one step up to check the type of TypeId node.
       case Some(parent) =>
         parent match {
@@ -59,7 +59,7 @@ private object GoToDefTypeId extends StrictImplicitLogging {
 
           case Node(enumDef: Ast.EnumDef[_], _) if enumDef.id == typeIdNode.data =>
             Iterator(
-              SourceLocation.Node(
+              SourceLocation.NodeStrict(
                 ast = enumDef.id,
                 source = sourceCode
               )
@@ -67,7 +67,7 @@ private object GoToDefTypeId extends StrictImplicitLogging {
 
           case Node(eventDef: Ast.EventDef, _) if eventDef.id == typeIdNode.data =>
             Iterator(
-              SourceLocation.Node(
+              SourceLocation.NodeStrict(
                 ast = eventDef.id,
                 source = sourceCode
               )
@@ -80,7 +80,7 @@ private object GoToDefTypeId extends StrictImplicitLogging {
                 .merge
 
             Iterator(
-              SourceLocation.Node(
+              SourceLocation.NodeStrict(
                 ast = id,
                 source = sourceCode
               )
@@ -109,8 +109,8 @@ private object GoToDefTypeId extends StrictImplicitLogging {
    */
   private def goToEnumType(
       enumFieldSelector: Ast.EnumFieldSelector[_],
-      sourceCode: SourceLocation.Code,
-      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.TypeId]] = {
+      sourceCode: SourceLocation.CodeStrict,
+      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.NodeStrict[Ast.TypeId]] = {
     val trees =
       WorkspaceSearcher.collectInheritedParents(
         sourceCode = sourceCode,
@@ -144,7 +144,7 @@ private object GoToDefTypeId extends StrictImplicitLogging {
    */
   private def goToEnumType(
       enumSelector: Ast.EnumFieldSelector[_],
-      source: SourceLocation.Code): Iterator[SourceLocation.Node[Ast.TypeId]] =
+      source: SourceLocation.CodeStrict): Iterator[SourceLocation.NodeStrict[Ast.TypeId]] =
     source.tree.ast match {
       case contract: Ast.Contract =>
         contract
@@ -153,12 +153,12 @@ private object GoToDefTypeId extends StrictImplicitLogging {
           .filter(_.id == enumSelector.enumId)
           .map {
             enumDef =>
-              SourceLocation.Node(enumDef.id, source)
+              SourceLocation.NodeStrict(enumDef.id, source)
           }
 
       case enumDef: Ast.EnumDef[_] =>
         if (enumDef.id == enumSelector.enumId)
-          Iterator(SourceLocation.Node(enumDef.id, source))
+          Iterator(SourceLocation.NodeStrict(enumDef.id, source))
         else
           Iterator.empty
 
@@ -175,14 +175,14 @@ private object GoToDefTypeId extends StrictImplicitLogging {
    */
   private def goToEventDef(
       emitEvent: Ast.EmitEvent[_],
-      source: SourceLocation.Code): Iterator[SourceLocation.Node[Ast.TypeId]] =
+      source: SourceLocation.CodeStrict): Iterator[SourceLocation.NodeStrict[Ast.TypeId]] =
     source
       .tree
       .rootNode
       .walkDown
       .collect {
         case Node(eventDef: Ast.EventDef, _) if eventDef.id == emitEvent.id =>
-          SourceLocation.Node(eventDef.id, source)
+          SourceLocation.NodeStrict(eventDef.id, source)
       }
 
   /**
@@ -194,7 +194,7 @@ private object GoToDefTypeId extends StrictImplicitLogging {
    */
   private def goToCodeId(
       typeId: Ast.TypeId,
-      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.TypeId]] =
+      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.NodeStrict[Ast.TypeId]] =
     WorkspaceSearcher
       .collectTypes(workspace, includeNonImportedCode = false)
       .filter(_.ast == typeId)

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefinitionProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefinitionProvider.scala
@@ -25,11 +25,11 @@ import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 
 /**
- * Implements [[CodeProvider]] that provides go-to definition results of type [[SourceLocation.GoToDef]].
+ * Implements [[CodeProvider]] that provides go-to definition results of type [[SourceLocation.GoToDefStrict]].
  *
- * To execution this function invoke [[CodeProvider.search]] with [[SourceLocation.GoToDef]] as type parameter.
+ * To execution this function invoke [[CodeProvider.search]] with [[SourceLocation.GoToDefStrict]] as type parameter.
  */
-private[search] case object GoToDefinitionProvider extends CodeProvider[GoToDefSetting, SourceLocation.GoToDef] with StrictImplicitLogging {
+private[search] case object GoToDefinitionProvider extends CodeProvider[GoToDefSetting, SourceLocation.GoToDefStrict] with StrictImplicitLogging {
 
   /** @inheritdoc */
   override def search(
@@ -37,7 +37,7 @@ private[search] case object GoToDefinitionProvider extends CodeProvider[GoToDefS
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware,
       searchSettings: GoToDefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToDef] =
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToDefStrict] =
     // find the statement where this cursorIndex sits.
     sourceCode.astStrict.statements.find(_.index contains cursorIndex) match {
       case Some(statement) =>
@@ -56,7 +56,7 @@ private[search] case object GoToDefinitionProvider extends CodeProvider[GoToDefS
             // request is for source-code go-to definition
             GoToDefSource.goTo(
               cursorIndex = cursorIndex,
-              sourceCode = SourceLocation.Code(tree, sourceCode),
+              sourceCode = SourceLocation.CodeStrict(tree, sourceCode),
               workspace = workspace,
               settings = searchSettings
             )

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefinitionProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefinitionProvider.scala
@@ -39,7 +39,7 @@ private[search] case object GoToDefinitionProvider extends CodeProvider[GoToDefS
       searchSettings: GoToDefSetting
     )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToDef] =
     // find the statement where this cursorIndex sits.
-    sourceCode.ast.statements.find(_.index contains cursorIndex) match {
+    sourceCode.astStrict.statements.find(_.index contains cursorIndex) match {
       case Some(statement) =>
         statement match {
           case importStatement: Tree.Import =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefFuncId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefFuncId.scala
@@ -29,10 +29,10 @@ private object GoToRefFuncId extends StrictImplicitLogging {
 
   def goTo(
       definition: Node[Ast.FuncId, Ast.Positioned],
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       settings: GoToRefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.Node[Ast.Positioned]] =
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     definition.parent match {
       case Some(parent) =>
         parent match {
@@ -71,8 +71,8 @@ private object GoToRefFuncId extends StrictImplicitLogging {
    */
   private def goToFunctionUsage(
       funcId: Ast.FuncId,
-      sourceCode: SourceLocation.Code,
-      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.Positioned]] =
+      sourceCode: SourceLocation.CodeStrict,
+      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     if (funcId.isBuiltIn) {
       val allTrees =
         WorkspaceSearcher.collectAllTrees(workspace)
@@ -114,7 +114,7 @@ private object GoToRefFuncId extends StrictImplicitLogging {
    */
   private def goToDirectCallFunctionUsage(
       funcId: Ast.FuncId,
-      children: ArraySeq[SourceLocation.Code]): Iterator[SourceLocation.Node[Ast.Positioned]] =
+      children: ArraySeq[SourceLocation.CodeStrict]): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     children
       .iterator
       .flatMap {
@@ -135,17 +135,17 @@ private object GoToRefFuncId extends StrictImplicitLogging {
    */
   private def goToFunctionUsage(
       funcId: Ast.FuncId,
-      sourceCode: SourceLocation.Code): Iterator[SourceLocation.Node[Ast.Positioned]] =
+      sourceCode: SourceLocation.CodeStrict): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     sourceCode
       .tree
       .rootNode
       .walkDown
       .collect {
         case Node(exp: Ast.CallExpr[_], _) if exp.id == funcId =>
-          SourceLocation.Node(exp.id, sourceCode)
+          SourceLocation.NodeStrict(exp.id, sourceCode)
 
         case Node(funcCall: Ast.FuncCall[_], _) if funcCall.id == funcId =>
-          SourceLocation.Node(funcCall.id, sourceCode)
+          SourceLocation.NodeStrict(funcCall.id, sourceCode)
       }
 
   /**
@@ -157,7 +157,7 @@ private object GoToRefFuncId extends StrictImplicitLogging {
    */
   private def goToContractCallFunctionUsage(
       funcId: Ast.FuncId,
-      children: ImplementingChildrenResult): Iterator[SourceLocation.Node[Ast.Positioned]] =
+      children: ImplementingChildrenResult): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     children
       .allTrees // traverse all trees to find contract call usages, eg: `myContract.function()` or `MyContract().function()`
       .iterator
@@ -178,7 +178,7 @@ private object GoToRefFuncId extends StrictImplicitLogging {
                       .flatMap {
                         childCode =>
                           if (childCode.tree.typeId() exists thisCallTypes.contains)
-                            Some(SourceLocation.Node(call.callId, code)) // Matched! Both the `funcId` and `typeId` are a match.
+                            Some(SourceLocation.NodeStrict(call.callId, code)) // Matched! Both the `funcId` and `typeId` are a match.
                           else
                             None
                       }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefIdent.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefIdent.scala
@@ -38,10 +38,10 @@ private object GoToRefIdent extends StrictImplicitLogging {
    */
   def goTo(
       definition: Node[Ast.Ident, Ast.Positioned],
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       settings: GoToRefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.Node[Ast.Positioned]] =
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     definition.parent match {
       case Some(parent) =>
         parent match {
@@ -158,7 +158,7 @@ private object GoToRefIdent extends StrictImplicitLogging {
 
   private def goToEventFieldUsages(
       node: Node[Ast.EventField, Ast.Positioned],
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       settings: GoToRefSetting) =
     if (settings.includeEventFieldReferences)
@@ -198,8 +198,8 @@ private object GoToRefIdent extends StrictImplicitLogging {
    */
   private def goToEnumFieldUsage(
       node: Node[Ast.EnumField[_], Ast.Positioned],
-      sourceCode: SourceLocation.Code,
-      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.Ident]] =
+      sourceCode: SourceLocation.CodeStrict,
+      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.NodeStrict[Ast.Ident]] =
     // Check the parent to find the enum type.
     node
       .parent
@@ -238,10 +238,10 @@ private object GoToRefIdent extends StrictImplicitLogging {
    */
   private def goToLocalVariableUsage(
       fromNode: Node[Ast.NamedVar, Ast.Positioned],
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       goToDefSetting: GoToDefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.Node[Ast.Ident]] =
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Ident]] =
     goToNearestBlockInScope(fromNode, sourceCode.tree)
       .iterator
       .flatMap {
@@ -265,10 +265,10 @@ private object GoToRefIdent extends StrictImplicitLogging {
    */
   private def goToArgumentUsage(
       argumentNode: Node[Ast.Argument, Ast.Positioned],
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       settings: GoToRefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.Node[Ast.Ident]] =
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Ident]] =
     goToNearestFuncDef(argumentNode) match {
       case Some(functionNode) =>
         // It's a function argument, search within this function's body.
@@ -300,10 +300,10 @@ private object GoToRefIdent extends StrictImplicitLogging {
    */
   private def goToTemplateArgumentUsage(
       argument: Ast.Argument,
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       settings: GoToRefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.Node[Ast.Ident]] = {
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Ident]] = {
     val contractInheritanceUsage =
       goToArgumentsUsageInInheritanceDefinition(
         argument = argument,
@@ -345,7 +345,7 @@ private object GoToRefIdent extends StrictImplicitLogging {
    */
   private def goToArgumentsUsageInInheritanceDefinition(
       argument: Ast.Argument,
-      sourceCode: SourceLocation.Code): Iterator[SourceLocation.Node[Ast.Ident]] =
+      sourceCode: SourceLocation.CodeStrict): Iterator[SourceLocation.NodeStrict[Ast.Ident]] =
     sourceCode
       .tree
       .rootNode
@@ -357,7 +357,7 @@ private object GoToRefIdent extends StrictImplicitLogging {
             .filter(_ == argument.ident)
             .map {
               ident =>
-                SourceLocation.Node(ident, sourceCode)
+                SourceLocation.NodeStrict(ident, sourceCode)
             }
       }
       .flatten
@@ -372,10 +372,10 @@ private object GoToRefIdent extends StrictImplicitLogging {
    */
   private def goToTemplateArgumentUsageWithinInheritance(
       argument: Ast.Argument,
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       goToDefSetting: GoToDefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.Node[Ast.Ident]] =
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Ident]] =
     WorkspaceSearcher
       .collectImplementingChildren(sourceCode, workspace)
       .childTrees
@@ -408,8 +408,8 @@ private object GoToRefIdent extends StrictImplicitLogging {
    */
   private def goToOverriddenTemplateArguments(
       argument: Ast.Argument,
-      sourceCode: SourceLocation.Code,
-      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.Ident]] =
+      sourceCode: SourceLocation.CodeStrict,
+      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.NodeStrict[Ast.Ident]] =
     WorkspaceSearcher
       .collectInheritanceHierarchy(sourceCode, workspace)
       .flatten()
@@ -433,7 +433,7 @@ private object GoToRefIdent extends StrictImplicitLogging {
   private def goToEnumFieldUsage(
       enumType: Ast.TypeId,
       enumField: Ast.EnumField[_],
-      sourceCode: SourceLocation.Code): Iterator[SourceLocation.Node[Ast.Ident]] =
+      sourceCode: SourceLocation.CodeStrict): Iterator[SourceLocation.NodeStrict[Ast.Ident]] =
     sourceCode
       .tree
       .rootNode
@@ -441,7 +441,7 @@ private object GoToRefIdent extends StrictImplicitLogging {
       .collect {
         // find all the selections matching the enum and the enum's field type.
         case Node(selector: Ast.EnumFieldSelector[_], _) if selector.enumId == enumType && selector.field == enumField.ident =>
-          SourceLocation.Node(selector.field, sourceCode)
+          SourceLocation.NodeStrict(selector.field, sourceCode)
       }
 
   /**
@@ -455,7 +455,7 @@ private object GoToRefIdent extends StrictImplicitLogging {
   private def goToEventFieldUsage(
       eventDefId: Ast.TypeId,
       eventFieldIndex: Int,
-      sourceCode: SourceLocation.Code): Iterator[SourceLocation.Node[Ast.Expr[_]]] =
+      sourceCode: SourceLocation.CodeStrict): Iterator[SourceLocation.NodeStrict[Ast.Expr[_]]] =
     sourceCode
       .tree
       .rootNode
@@ -463,7 +463,7 @@ private object GoToRefIdent extends StrictImplicitLogging {
       .collect {
         // find all the event fields usages at given eventFieldIndex.
         case Node(emitEvent: Ast.EmitEvent[_], _) if emitEvent.id == eventDefId && eventFieldIndex < emitEvent.args.length =>
-          SourceLocation.Node(emitEvent.args(eventFieldIndex), sourceCode)
+          SourceLocation.NodeStrict(emitEvent.args(eventFieldIndex), sourceCode)
       }
 
   /**
@@ -494,8 +494,8 @@ private object GoToRefIdent extends StrictImplicitLogging {
    */
   private def goToMapDefUsages(
       ident: Ast.Ident,
-      sourceCode: SourceLocation.Code,
-      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.Positioned]] =
+      sourceCode: SourceLocation.CodeStrict,
+      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     // Go-to MapDef usages.
     WorkspaceSearcher
       .collectImplementingChildren(sourceCode, workspace)
@@ -505,16 +505,16 @@ private object GoToRefIdent extends StrictImplicitLogging {
         code =>
           code.tree.rootNode.walkDown.collect {
             case Node(mapCall: Ast.MapFuncCall, _) if mapCall.ident == ident =>
-              SourceLocation.Node(mapCall.ident, code)
+              SourceLocation.NodeStrict(mapCall.ident, code)
 
             case Node(mapCall: Ast.MapContains, _) if mapCall.ident == ident =>
-              SourceLocation.Node(mapCall.ident, code)
+              SourceLocation.NodeStrict(mapCall.ident, code)
 
             case Node(Ast.LoadDataBySelectors(Ast.Variable(variableIdent), _), _) if variableIdent == ident =>
-              SourceLocation.Node(variableIdent, code)
+              SourceLocation.NodeStrict(variableIdent, code)
 
             case Node(mapCall: Ast.AssignmentSelectedTarget[_], _) if mapCall.ident == ident =>
-              SourceLocation.Node(mapCall.ident, code)
+              SourceLocation.NodeStrict(mapCall.ident, code)
           }
       }
 
@@ -528,10 +528,10 @@ private object GoToRefIdent extends StrictImplicitLogging {
    */
   private def goToConstantUsage(
       constantDef: Ast.ConstantVarDef[_],
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       goToDefSetting: GoToDefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.Node[Ast.Ident]] = {
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Ident]] = {
     val children =
       if (sourceCode.tree.ast == constantDef)
         // Is a global constant, fetch all workspace trees.
@@ -566,20 +566,20 @@ private object GoToRefIdent extends StrictImplicitLogging {
   private def goToVariableUsages(
       definition: Ast.Ident,
       from: Node[Ast.Positioned, Ast.Positioned],
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       goToDefSetting: GoToDefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.Node[Ast.Ident]] =
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Ident]] =
     from
       .walkDown
       .collect {
         // find all the selections matching the variable name.
         case Node(variable: Ast.Variable[_], _) if variable.id == definition =>
-          SourceLocation.Node(variable.id, sourceCode)
+          SourceLocation.NodeStrict(variable.id, sourceCode)
 
         // collect all assignments
         case Node(variable: Ast.AssignmentTarget[_], _) if variable.ident == definition =>
-          SourceLocation.Node(variable.ident, sourceCode)
+          SourceLocation.NodeStrict(variable.ident, sourceCode)
       }
       .filter {
         reference =>
@@ -605,8 +605,8 @@ private object GoToRefIdent extends StrictImplicitLogging {
    */
   private def isReferenceForDefinition(
       definition: Ast.Ident,
-      reference: SourceLocation.Node[Ast.Ident],
-      sourceCode: SourceLocation.Code,
+      reference: SourceLocation.NodeStrict[Ast.Ident],
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       goToDefSetting: GoToDefSetting
     )(implicit logger: ClientLogger): Boolean =
@@ -624,7 +624,7 @@ private object GoToRefIdent extends StrictImplicitLogging {
             case SourceLocation.File(_) =>
               false
 
-            case SourceLocation.Node(foundDefinition, _) =>
+            case SourceLocation.NodeStrict(foundDefinition, _) =>
               // The following could be tested with `ast eq ident`
               foundDefinition == definition && foundDefinition.sourceIndex == definition.sourceIndex
           }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefImport.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefImport.scala
@@ -36,7 +36,7 @@ private object GoToRefImport {
             .collectAllParsed(workspace)
             .flatMap {
               parsed =>
-                parsed.ast.statements.collect {
+                parsed.astStrict.statements.collect {
                   case Tree.Import(_, Some(thisPath), _) if importPath.folder.value == thisPath.folder.value =>
                     SourceLocation.ImportName(thisPath.folder, parsed)
                 }
@@ -46,7 +46,7 @@ private object GoToRefImport {
             .collectAllParsed(workspace)
             .flatMap {
               parsed =>
-                parsed.ast.statements.collect {
+                parsed.astStrict.statements.collect {
                   case Tree.Import(_, Some(thisPath), _) if importPath.folder.value == thisPath.folder.value && importPath.file.value == thisPath.file.value =>
                     SourceLocation.ImportName(thisPath.file, parsed)
                 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefSource.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefSource.scala
@@ -39,7 +39,7 @@ private object GoToRefSource extends StrictImplicitLogging {
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware,
       settings: GoToRefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.Node[Ast.Positioned]] =
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     CodeProvider
       .goToDefinition
       .search( // find definitions for the token at the given cursorIndex.
@@ -52,7 +52,7 @@ private object GoToRefSource extends StrictImplicitLogging {
         case SourceLocation.File(_) =>
           Iterator.empty
 
-        case location @ SourceLocation.Node(_, _) =>
+        case location @ SourceLocation.NodeStrict(_, _) =>
           // find references for the definitions
           goTo(
             defLocation = location,
@@ -74,10 +74,10 @@ private object GoToRefSource extends StrictImplicitLogging {
    * @return An iterator reference location(s).
    */
   def goTo(
-      defLocation: SourceLocation.Node[Ast.Positioned],
+      defLocation: SourceLocation.NodeStrict[Ast.Positioned],
       workspace: WorkspaceState.IsSourceAware,
       settings: GoToRefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.Node[Ast.Positioned]] = {
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] = {
     val defNode =
       defLocation
         .source

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefTypeId.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefTypeId.scala
@@ -36,10 +36,10 @@ private object GoToRefTypeId extends StrictImplicitLogging {
    */
   def goTo(
       definition: Node[Ast.TypeId, Ast.Positioned],
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       settings: GoToRefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.Node[Ast.Positioned]] =
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     definition.parent match {
       case Some(parent) =>
         parent match {
@@ -133,8 +133,8 @@ private object GoToRefTypeId extends StrictImplicitLogging {
    */
   private def goToEnumDefUsage(
       enumDef: Ast.EnumDef[_],
-      sourceCode: SourceLocation.Code,
-      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.TypeId]] = {
+      sourceCode: SourceLocation.CodeStrict,
+      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.NodeStrict[Ast.TypeId]] = {
     val trees =
       if (sourceCode.tree.ast == enumDef)
         WorkspaceSearcher.collectAllTrees(workspace) // It's a global enum, search all workspace trees
@@ -157,20 +157,20 @@ private object GoToRefTypeId extends StrictImplicitLogging {
    */
   private def goToEnumTypeUsage(
       enumDef: Ast.EnumDef[_],
-      source: SourceLocation.Code): Iterator[SourceLocation.Node[Ast.TypeId]] =
+      source: SourceLocation.CodeStrict): Iterator[SourceLocation.NodeStrict[Ast.TypeId]] =
     source
       .tree
       .rootNode
       .walkDown
       .collect {
         case Node(selector: Ast.EnumFieldSelector[_], _) if selector.enumId == enumDef.id =>
-          SourceLocation.Node(selector.enumId, source)
+          SourceLocation.NodeStrict(selector.enumId, source)
       }
 
   private def goToEventDefUsage(
       eventDef: Ast.EventDef,
-      sourceCode: SourceLocation.Code,
-      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.TypeId]] =
+      sourceCode: SourceLocation.CodeStrict,
+      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.NodeStrict[Ast.TypeId]] =
     // They selected an event definition. Find event usages.
     WorkspaceSearcher
       .collectImplementingChildren(sourceCode, workspace)
@@ -187,19 +187,19 @@ private object GoToRefTypeId extends StrictImplicitLogging {
    */
   private def goToEventDefUsage(
       eventDef: Ast.EventDef,
-      source: SourceLocation.Code): Iterator[SourceLocation.Node[Ast.TypeId]] =
+      source: SourceLocation.CodeStrict): Iterator[SourceLocation.NodeStrict[Ast.TypeId]] =
     source
       .tree
       .rootNode
       .walkDown
       .collect {
         case Node(emitEvent: Ast.EmitEvent[_], _) if emitEvent.id == eventDef.id =>
-          SourceLocation.Node(emitEvent.id, source)
+          SourceLocation.NodeStrict(emitEvent.id, source)
       }
 
   private def goToTypeIdUsage(
       globalDef: Ast.GlobalDefinition,
-      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.TypeId]] =
+      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.NodeStrict[Ast.TypeId]] =
     AstExtra.getTypeId(globalDef) match {
       case Some(typeId) =>
         goToTypeIdUsage(
@@ -221,7 +221,7 @@ private object GoToRefTypeId extends StrictImplicitLogging {
    */
   private def goToTypeIdUsage(
       selectedTypId: Ast.TypeId,
-      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.TypeId]] =
+      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.NodeStrict[Ast.TypeId]] =
     WorkspaceSearcher
       .collectAllTrees(workspace)
       .iterator
@@ -230,7 +230,7 @@ private object GoToRefTypeId extends StrictImplicitLogging {
           code.tree.rootNode.walkDown.collect {
             // this typeId should equal the searched typeId and a different object then itself.
             case Node(typeId: Ast.TypeId, _) if typeId == selectedTypId && typeId.ne(selectedTypId) =>
-              SourceLocation.Node(
+              SourceLocation.NodeStrict(
                 ast = typeId,
                 source = code
               )

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToReferenceProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToReferenceProvider.scala
@@ -38,7 +38,7 @@ private[search] case object GoToReferenceProvider extends CodeProvider[GoToRefSe
       searchSettings: GoToRefSetting
     )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToRef] =
     // find the statement where this cursorIndex sits.
-    sourceCode.ast.statements.find(_.index contains cursorIndex) match {
+    sourceCode.astStrict.statements.find(_.index contains cursorIndex) match {
       case Some(statement) =>
         statement match {
           case importStatement: Tree.Import =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToReferenceProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToReferenceProvider.scala
@@ -24,11 +24,11 @@ import org.alephium.ralph.lsp.pc.sourcecode.{SourceLocation, SourceCodeState}
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 
 /**
- * Implements [[CodeProvider]] that provides go-to references results of type [[SourceLocation.GoToRef]].
+ * Implements [[CodeProvider]] that provides go-to references results of type [[SourceLocation.GoToRefStrict]].
  *
- * To execution this function invoke [[CodeProvider.search]] with [[Boolean]] and [[SourceLocation.GoToRef]] as type parameter.
+ * To execution this function invoke [[CodeProvider.search]] with [[Boolean]] and [[SourceLocation.GoToRefStrict]] as type parameter.
  */
-private[search] case object GoToReferenceProvider extends CodeProvider[GoToRefSetting, SourceLocation.GoToRef] with StrictImplicitLogging {
+private[search] case object GoToReferenceProvider extends CodeProvider[GoToRefSetting, SourceLocation.GoToRefStrict] with StrictImplicitLogging {
 
   /** @inheritdoc */
   override def search(
@@ -36,7 +36,7 @@ private[search] case object GoToReferenceProvider extends CodeProvider[GoToRefSe
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware,
       searchSettings: GoToRefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToRef] =
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToRefStrict] =
     // find the statement where this cursorIndex sits.
     sourceCode.astStrict.statements.find(_.index contains cursorIndex) match {
       case Some(statement) =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/IncludeDeclaration.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/IncludeDeclaration.scala
@@ -23,9 +23,9 @@ private object IncludeDeclaration {
 
   def add(
       definitionAST: Ast.TypeId,
-      definitionSource: SourceLocation.Code,
-      result: Iterator[SourceLocation.Node[Ast.Positioned]],
-      isIncludeDeclaration: Boolean): Iterator[SourceLocation.Node[Ast.Positioned]] =
+      definitionSource: SourceLocation.CodeStrict,
+      result: Iterator[SourceLocation.NodeStrict[Ast.Positioned]],
+      isIncludeDeclaration: Boolean): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     __addIDDefinition(
       definitionAST = definitionAST,
       definitionSource = definitionSource,
@@ -35,9 +35,9 @@ private object IncludeDeclaration {
 
   def add(
       definitionAST: Ast.Ident,
-      definitionSource: SourceLocation.Code,
-      result: Iterator[SourceLocation.Node[Ast.Positioned]],
-      isIncludeDeclaration: Boolean): Iterator[SourceLocation.Node[Ast.Positioned]] =
+      definitionSource: SourceLocation.CodeStrict,
+      result: Iterator[SourceLocation.NodeStrict[Ast.Positioned]],
+      isIncludeDeclaration: Boolean): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     __addIDDefinition(
       definitionAST = definitionAST,
       definitionSource = definitionSource,
@@ -47,9 +47,9 @@ private object IncludeDeclaration {
 
   def add(
       definitionAST: Ast.FuncId,
-      definitionSource: SourceLocation.Code,
-      result: Iterator[SourceLocation.Node[Ast.Positioned]],
-      isIncludeDeclaration: Boolean): Iterator[SourceLocation.Node[Ast.Positioned]] =
+      definitionSource: SourceLocation.CodeStrict,
+      result: Iterator[SourceLocation.NodeStrict[Ast.Positioned]],
+      isIncludeDeclaration: Boolean): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     __addIDDefinition(
       definitionAST = definitionAST,
       definitionSource = definitionSource,
@@ -66,12 +66,12 @@ private object IncludeDeclaration {
    */
   @inline private def __addIDDefinition[A <: Ast.Positioned](
       definitionAST: A,
-      definitionSource: SourceLocation.Code,
-      result: Iterator[SourceLocation.Node[Ast.Positioned]],
-      isIncludeDeclaration: Boolean): Iterator[SourceLocation.Node[Ast.Positioned]] =
+      definitionSource: SourceLocation.CodeStrict,
+      result: Iterator[SourceLocation.NodeStrict[Ast.Positioned]],
+      isIncludeDeclaration: Boolean): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     if (isIncludeDeclaration) {
       val definition =
-        SourceLocation.Node(
+        SourceLocation.NodeStrict(
           ast = definitionAST,
           source = definitionSource
         )

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/rename/GoToRenameAll.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/rename/GoToRenameAll.scala
@@ -44,7 +44,7 @@ private object GoToRenameAll extends StrictImplicitLogging {
       cursorIndex: Int,
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToRename] = {
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToRenameStrict] = {
     val references =
       collectReferences(
         cursorIndex = cursorIndex,
@@ -86,10 +86,10 @@ private object GoToRenameAll extends StrictImplicitLogging {
       cursorIndex: Int,
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware
-    )(implicit logger: ClientLogger): Iterable[SourceLocation.GoToRename] = {
+    )(implicit logger: ClientLogger): Iterable[SourceLocation.GoToRenameStrict] = {
     // collects all nodes that must be renamed
     val nodesToRename =
-      ListBuffer.empty[(SourceLocation.GoToRename, SourceIndex)]
+      ListBuffer.empty[(SourceLocation.GoToRenameStrict, SourceIndex)]
 
     // settings to run go-to-references on
     val searchSettings =
@@ -117,7 +117,7 @@ private object GoToRenameAll extends StrictImplicitLogging {
             if (!nodesToRename.contains((ref, ref.name.index)))
               nodesToRename addOne (ref, ref.name.index)
 
-          case ref @ SourceLocation.Node(ast, _) =>
+          case ref @ SourceLocation.NodeStrict(ast, _) =>
             ast
               .sourceIndex // Nodes without SourceIndex cannot be renamed.
               .filter {
@@ -152,7 +152,7 @@ private object GoToRenameAll extends StrictImplicitLogging {
    * @return True if renaming is disallowed, false otherwise.
    */
   private def isRenamingDisallowed(
-      ref: SourceLocation.GoToRename,
+      ref: SourceLocation.GoToRenameStrict,
       build: BuildState.Compiled): Boolean = {
     val isOutsideWorkspace =
       !URIUtil.contains(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/rename/GoToRenameProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/rename/GoToRenameProvider.scala
@@ -22,9 +22,9 @@ import org.alephium.ralph.lsp.pc.sourcecode.{SourceLocation, SourceCodeState}
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 
 /**
- * Implements [[CodeProvider]] that provides renaming results of type [[SourceLocation.GoToRename]].
+ * Implements [[CodeProvider]] that provides renaming results of type [[SourceLocation.GoToRenameStrict]].
  */
-private[search] case object GoToRenameProvider extends CodeProvider[Unit, SourceLocation.GoToRename] {
+private[search] case object GoToRenameProvider extends CodeProvider[Unit, SourceLocation.GoToRenameStrict] {
 
   /** @inheritdoc */
   override def search(
@@ -32,7 +32,7 @@ private[search] case object GoToRenameProvider extends CodeProvider[Unit, Source
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware,
       searchSettings: Unit
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToRename] =
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToRenameStrict] =
     GoToRenameAll.rename(
       cursorIndex = cursorIndex,
       sourceCode = sourceCode,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
@@ -239,8 +239,8 @@ private[pc] object SourceCode {
    * @return Workspace-level error if an error occurred without a target source-file, or else next state for each source-code.
    */
   private def compileSource(
-      sourceTrees: ArraySeq[SourceLocation.Code],
-      importedTrees: ArraySeq[SourceLocation.Code],
+      sourceTrees: ArraySeq[SourceLocation.CodeStrict],
+      importedTrees: ArraySeq[SourceLocation.CodeStrict],
       compilerOptions: CompilerOptions,
       workspaceErrorURI: URI
     )(implicit compiler: CompilerAccess,
@@ -295,7 +295,7 @@ private[pc] object SourceCode {
    */
   private def flattenInheritance(
       toFlatten: ArraySeq[SourceCodeState.Parsed],
-      workspace: ArraySeq[SourceCodeState.Parsed]): ArraySeq[SourceLocation.Code] =
+      workspace: ArraySeq[SourceCodeState.Parsed]): ArraySeq[SourceLocation.CodeStrict] =
     if (toFlatten.isEmpty || workspace.isEmpty) {
       ArraySeq.empty
     } else {

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
@@ -96,7 +96,7 @@ private[pc] object SourceCode {
             SourceCodeState.Parsed(
               fileURI = fileURI,
               code = code,
-              ast = parsedCode
+              astStrict = parsedCode
             )
         }
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
@@ -192,7 +192,7 @@ private[pc] object SourceCode {
       compilerOptions: CompilerOptions,
       workspaceErrorURI: URI
     )(implicit compiler: CompilerAccess,
-      logger: ClientLogger): Either[CompilerMessage.AnyError, ArraySeq[SourceCodeState.IsParsed]] =
+      logger: ClientLogger): Either[CompilerMessage.AnyError, ArraySeq[SourceCodeState.IsParsedAndCompiled]] =
     Importer.typeCheck(
       sourceCode = sourceCode,
       dependency = dependency
@@ -244,7 +244,7 @@ private[pc] object SourceCode {
       compilerOptions: CompilerOptions,
       workspaceErrorURI: URI
     )(implicit compiler: CompilerAccess,
-      logger: ClientLogger): Either[CompilerMessage.AnyError, ArraySeq[SourceCodeState.IsParsed]] = {
+      logger: ClientLogger): Either[CompilerMessage.AnyError, ArraySeq[SourceCodeState.IsParsedAndCompiled]] = {
     val sourceTreesOnly =
       sourceTrees.map(_.tree)
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcher.scala
@@ -113,7 +113,7 @@ object SourceCodeSearcher {
    */
   def collectInheritedParentsForAll(
       sourceCode: ArraySeq[SourceCodeState.Parsed],
-      workspace: ArraySeq[SourceCodeState.Parsed]): ArraySeq[SourceLocation.Code] = {
+      workspace: ArraySeq[SourceCodeState.Parsed]): ArraySeq[SourceLocation.CodeStrict] = {
     val workspaceTrees = collectSourceTrees(workspace)
 
     val parents =
@@ -138,7 +138,7 @@ object SourceCodeSearcher {
    */
   def collectInheritedParentsForAllTrees(
       sourceCode: SourceCodeState.Parsed,
-      workspace: ArraySeq[SourceCodeState.Parsed]): ArraySeq[SourceLocation.Code] =
+      workspace: ArraySeq[SourceCodeState.Parsed]): ArraySeq[SourceLocation.CodeStrict] =
     collectInheritedParentsForAll(
       sourceCode = sourceCode,
       workspace = collectSourceTrees(workspace)
@@ -153,7 +153,7 @@ object SourceCodeSearcher {
    */
   def collectInheritedParentsForAll(
       sourceCode: SourceCodeState.Parsed,
-      workspace: ArraySeq[SourceLocation.Code]): ArraySeq[SourceLocation.Code] =
+      workspace: ArraySeq[SourceLocation.CodeStrict]): ArraySeq[SourceLocation.CodeStrict] =
     collectInheritedParents(
       source = collectSourceTrees(sourceCode).to(ArraySeq),
       allSource = workspace
@@ -166,7 +166,7 @@ object SourceCodeSearcher {
    * @return An sequence of source-tree and its parsed source-file mappings.
    */
   def collectSourceTrees(
-      sourceCode: ArraySeq[SourceCodeState.Parsed]): ArraySeq[SourceLocation.Code] =
+      sourceCode: ArraySeq[SourceCodeState.Parsed]): ArraySeq[SourceLocation.CodeStrict] =
     sourceCode flatMap collectSourceTrees
 
   /**
@@ -176,10 +176,10 @@ object SourceCodeSearcher {
    * @return An sequence of source-tree and the parsed source-file mappings.
    */
   def collectSourceTrees(
-      sourceCode: SourceCodeState.Parsed): Seq[SourceLocation.Code] =
+      sourceCode: SourceCodeState.Parsed): Seq[SourceLocation.CodeStrict] =
     sourceCode.astStrict.statements.collect {
       case tree: Tree.Source =>
-        SourceLocation.Code(
+        SourceLocation.CodeStrict(
           tree = tree,
           parsed = sourceCode
         )
@@ -191,12 +191,12 @@ object SourceCodeSearcher {
    * @param workspaceSource The source code to search for types.
    * @return An iterator containing type identifiers.
    */
-  def collectTypes(workspaceSource: Iterator[SourceLocation.Code]): Iterator[SourceLocation.Node[Ast.TypeId]] =
+  def collectTypes(workspaceSource: Iterator[SourceLocation.CodeStrict]): Iterator[SourceLocation.NodeStrict[Ast.TypeId]] =
     workspaceSource flatMap {
       code =>
         code.tree.typeId() map {
           typeId =>
-            SourceLocation.Node(
+            SourceLocation.NodeStrict(
               ast = typeId,
               source = code
             )
@@ -209,10 +209,10 @@ object SourceCodeSearcher {
    * @param workspaceSource The source code to search for.
    * @return An iterator containing global constants.
    */
-  def collectGlobalConstants(workspaceSource: Iterator[SourceLocation.Code]): Iterator[SourceLocation.Node[Ast.ConstantVarDef[_]]] =
+  def collectGlobalConstants(workspaceSource: Iterator[SourceLocation.CodeStrict]): Iterator[SourceLocation.NodeStrict[Ast.ConstantVarDef[_]]] =
     workspaceSource collect {
-      case source @ SourceLocation.Code(Tree.Source(ast: Ast.ConstantVarDef[_], _), _) =>
-        SourceLocation.Node(
+      case source @ SourceLocation.CodeStrict(Tree.Source(ast: Ast.ConstantVarDef[_], _), _) =>
+        SourceLocation.NodeStrict(
           ast = ast,
           source = source
         )
@@ -224,9 +224,9 @@ object SourceCodeSearcher {
    * @param workspaceSource The source code to search for global enums.
    * @return An iterator containing all global enums.
    */
-  def collectGlobalEnumsCode(workspaceSource: Iterator[SourceLocation.Code]): Iterator[SourceLocation.Code] =
+  def collectGlobalEnumsCode(workspaceSource: Iterator[SourceLocation.CodeStrict]): Iterator[SourceLocation.CodeStrict] =
     workspaceSource collect {
-      case code @ SourceLocation.Code(Tree.Source(_: Ast.EnumDef[_], _), _) =>
+      case code @ SourceLocation.CodeStrict(Tree.Source(_: Ast.EnumDef[_], _), _) =>
         code
     }
 
@@ -239,7 +239,7 @@ object SourceCodeSearcher {
    */
   def collectTypes(
       types: Seq[Type],
-      workspaceSource: ArraySeq[SourceLocation.Code]): ArraySeq[SourceLocation.Code] =
+      workspaceSource: ArraySeq[SourceLocation.CodeStrict]): ArraySeq[SourceLocation.CodeStrict] =
     workspaceSource flatMap {
       code =>
         collectTypes(
@@ -257,7 +257,7 @@ object SourceCodeSearcher {
    */
   def collectTypes(
       types: Seq[Type],
-      code: SourceLocation.Code): Seq[SourceLocation.Code] =
+      code: SourceLocation.CodeStrict): Seq[SourceLocation.CodeStrict] =
     // collect all trees with matching types
     code.tree.typeId() match {
       case Some(typeId) =>
@@ -285,7 +285,7 @@ object SourceCodeSearcher {
    */
   def collectFunctions(
       types: Seq[Type],
-      workspaceSource: ArraySeq[SourceLocation.Code]): Iterator[SourceLocation.Node[Ast.FuncDef[StatefulContext]]] = {
+      workspaceSource: ArraySeq[SourceLocation.CodeStrict]): Iterator[SourceLocation.NodeStrict[Ast.FuncDef[StatefulContext]]] = {
     // collect all trees with matching types
     val treesOfMatchingTypes =
       collectTypes(
@@ -308,8 +308,8 @@ object SourceCodeSearcher {
    * @return An iterator containing all function implementations.
    */
   def collectFunctions(
-      trees: ArraySeq[SourceLocation.Code],
-      workspaceSource: ArraySeq[SourceLocation.Code]): Iterator[SourceLocation.Node[Ast.FuncDef[StatefulContext]]] =
+      trees: ArraySeq[SourceLocation.CodeStrict],
+      workspaceSource: ArraySeq[SourceLocation.CodeStrict]): Iterator[SourceLocation.NodeStrict[Ast.FuncDef[StatefulContext]]] =
     trees
       .iterator
       .flatMap {
@@ -328,8 +328,8 @@ object SourceCodeSearcher {
    * @return An iterator containing all function implementations.
    */
   def collectFunctions(
-      tree: SourceLocation.Code,
-      workspaceSource: ArraySeq[SourceLocation.Code]): Iterator[SourceLocation.Node[Ast.FuncDef[StatefulContext]]] = {
+      tree: SourceLocation.CodeStrict,
+      workspaceSource: ArraySeq[SourceLocation.CodeStrict]): Iterator[SourceLocation.NodeStrict[Ast.FuncDef[StatefulContext]]] = {
     // the function could be within a nested parent, collect all parents.
     val parents =
       collectInheritedParents(
@@ -349,7 +349,7 @@ object SourceCodeSearcher {
               .funcs
               .map {
                 funcDef =>
-                  SourceLocation.Node(
+                  SourceLocation.NodeStrict(
                     ast = funcDef,
                     source = code
                   )
@@ -367,7 +367,7 @@ object SourceCodeSearcher {
    * @param sourceCode The source code from which to collect function definitions.
    * @return           An iterator containing all function implementations.
    */
-  def collectFunctions(sourceCode: SourceLocation.Code): Iterator[SourceLocation.Node[Ast.FuncDef[StatefulContext]]] =
+  def collectFunctions(sourceCode: SourceLocation.CodeStrict): Iterator[SourceLocation.NodeStrict[Ast.FuncDef[StatefulContext]]] =
     // TODO: Improve selection by checking function argument count and types.
     sourceCode.tree.ast match {
       case ast: Ast.ContractWithState =>
@@ -376,7 +376,7 @@ object SourceCodeSearcher {
           .iterator
           .map {
             funcDef =>
-              SourceLocation.Node(
+              SourceLocation.NodeStrict(
                 ast = funcDef,
                 source = sourceCode
               )
@@ -392,7 +392,7 @@ object SourceCodeSearcher {
    * @param source The parsed source code from which to collect function definitions.
    * @return An iterator containing all function implementations.
    */
-  def collectFunctions(source: SourceCodeState.Parsed): Iterator[SourceLocation.Node[Ast.FuncDef[StatefulContext]]] =
+  def collectFunctions(source: SourceCodeState.Parsed): Iterator[SourceLocation.NodeStrict[Ast.FuncDef[StatefulContext]]] =
     source
       .astStrict
       .statements
@@ -400,7 +400,7 @@ object SourceCodeSearcher {
       .flatMap {
         case tree: Tree.Source =>
           // search for the matching functionIds within the built-in source file.
-          collectFunctions(SourceLocation.Code(tree, source))
+          collectFunctions(SourceLocation.CodeStrict(tree, source))
 
         case _: Tree.Import =>
           Iterator.empty
@@ -412,7 +412,7 @@ object SourceCodeSearcher {
    * @param sourceCode The transaction script that may contain a `main` function.
    * @return Node representing the `main` function of the transaction script, if found, else None.
    */
-  def findTxScriptMainFunction(sourceCode: SourceLocation.Code): Option[Node[Ast.FuncDef[_], Ast.Positioned]] =
+  def findTxScriptMainFunction(sourceCode: SourceLocation.CodeStrict): Option[Node[Ast.FuncDef[_], Ast.Positioned]] =
     sourceCode.tree.ast match {
       case _: Ast.TxScript =>
         sourceCode.tree.rootNode.walkDown.collectFirst {
@@ -433,8 +433,8 @@ object SourceCodeSearcher {
    * @return All parent source implementations found.
    */
   def collectInheritedParents(
-      source: ArraySeq[SourceLocation.Code],
-      allSource: ArraySeq[SourceLocation.Code]): ArraySeq[SourceLocation.Code] =
+      source: ArraySeq[SourceLocation.CodeStrict],
+      allSource: ArraySeq[SourceLocation.CodeStrict]): ArraySeq[SourceLocation.CodeStrict] =
     source.flatMap {
       source =>
         collectInheritedParents(
@@ -452,8 +452,8 @@ object SourceCodeSearcher {
    * @return All parent source implementations found.
    */
   def collectInheritedParents(
-      source: SourceLocation.Code,
-      allSource: ArraySeq[SourceLocation.Code]): ArraySeq[SourceLocation.Code] =
+      source: SourceLocation.CodeStrict,
+      allSource: ArraySeq[SourceLocation.CodeStrict]): ArraySeq[SourceLocation.CodeStrict] =
     source.tree.ast match {
       case contract: Ast.ContractWithState =>
         collectInheritedParents(
@@ -475,8 +475,8 @@ object SourceCodeSearcher {
    * @return All child trees along with their corresponding source files.
    */
   def collectImplementingChildren(
-      source: SourceLocation.Code,
-      allSource: ArraySeq[SourceLocation.Code]): ArraySeq[SourceLocation.Code] =
+      source: SourceLocation.CodeStrict,
+      allSource: ArraySeq[SourceLocation.CodeStrict]): ArraySeq[SourceLocation.CodeStrict] =
     source.tree.ast match {
       case contract: Ast.ContractWithState =>
         collectImplementingChildren(
@@ -500,8 +500,8 @@ object SourceCodeSearcher {
    */
   private def collectInheritedParents(
       inheritances: Seq[Ast.Inheritance],
-      allSource: ArraySeq[SourceLocation.Code],
-      processedTrees: mutable.Set[SourceLocation.Code]): ArraySeq[SourceLocation.Code] =
+      allSource: ArraySeq[SourceLocation.CodeStrict],
+      processedTrees: mutable.Set[SourceLocation.CodeStrict]): ArraySeq[SourceLocation.CodeStrict] =
     allSource flatMap {
       source =>
         // collect the trees that belong to one of the inheritances
@@ -550,8 +550,8 @@ object SourceCodeSearcher {
    */
   private def collectImplementingChildren(
       contract: Ast.ContractWithState,
-      allSource: ArraySeq[SourceLocation.Code],
-      processedTrees: mutable.Set[SourceLocation.Code]): ArraySeq[SourceLocation.Code] =
+      allSource: ArraySeq[SourceLocation.CodeStrict],
+      processedTrees: mutable.Set[SourceLocation.CodeStrict]): ArraySeq[SourceLocation.CodeStrict] =
     allSource flatMap {
       source =>
         val belongs =

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcher.scala
@@ -97,7 +97,7 @@ object SourceCodeSearcher {
     sourceCode
       .flatMap {
         parsed =>
-          parsed.ast.statements.collect {
+          parsed.astStrict.statements.collect {
             case imported: Tree.Import =>
               imported
           }
@@ -177,7 +177,7 @@ object SourceCodeSearcher {
    */
   def collectSourceTrees(
       sourceCode: SourceCodeState.Parsed): Seq[SourceLocation.Code] =
-    sourceCode.ast.statements.collect {
+    sourceCode.astStrict.statements.collect {
       case tree: Tree.Source =>
         SourceLocation.Code(
           tree = tree,
@@ -394,7 +394,7 @@ object SourceCodeSearcher {
    */
   def collectFunctions(source: SourceCodeState.Parsed): Iterator[SourceLocation.Node[Ast.FuncDef[StatefulContext]]] =
     source
-      .ast
+      .astStrict
       .statements
       .iterator
       .flatMap {

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
@@ -117,7 +117,7 @@ object SourceCodeState {
   case class Parsed(
       fileURI: URI,
       code: String,
-      ast: Tree.Root)
+      astStrict: Tree.Root)
     extends IsParsed
 
   /** Represents: Error during the parser phase. */

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
@@ -67,7 +67,10 @@ object SourceCodeState {
 
   }
 
-  /** Represents: Code that is parsed and compiled. */
+  /**
+   * Represents: Code that is parsed and compiled
+   * and is the co-domain for [[IsParsed]] and [[IsCompiled]].
+   */
   sealed trait IsParsedAndCompiled extends IsCodeAware
 
   /** Represents: Code that is parsed. */

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
@@ -67,11 +67,14 @@ object SourceCodeState {
 
   }
 
+  /** Represents: Code that is parsed and compiled. */
+  sealed trait IsParsedAndCompiled extends IsCodeAware
+
   /** Represents: Code that is parsed. */
-  sealed trait IsParsed extends IsCodeAware
+  sealed trait IsParsed extends IsParsedAndCompiled
 
   /** Represents: Code that is compiled. */
-  sealed trait IsCompiled extends IsParsed {
+  sealed trait IsCompiled extends IsParsedAndCompiled {
 
     // Compilation can only be executed if a parsed state was successfully created.
     // Therefore, the parsed states is always known during compilation.
@@ -118,7 +121,7 @@ object SourceCodeState {
       fileURI: URI,
       code: String,
       astStrict: Tree.Root)
-    extends IsParsed
+    extends IsParsedAndCompiled
 
   /** Represents: Error during the parser phase. */
   case class ErrorParser(
@@ -126,7 +129,7 @@ object SourceCodeState {
       code: String,
       errors: Seq[CompilerMessage.AnyError])
     extends IsParserOrCompilationError
-       with IsParsed
+       with IsParsedAndCompiled
 
   /** Represents: Code is successfully compiled */
   case class Compiled(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeStateBuilder.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeStateBuilder.scala
@@ -42,7 +42,7 @@ private object SourceCodeStateBuilder {
       parsedCode: ArraySeq[SourceCodeState.Parsed],
       workspaceErrorURI: URI,
       compilationResult: Either[CompilerMessage.AnyError, (Array[CompiledContract], Array[CompiledScript], Array[Warning])]
-    )(implicit logger: ClientLogger): Either[CompilerMessage.AnyError, ArraySeq[SourceCodeState.IsParsed]] =
+    )(implicit logger: ClientLogger): Either[CompilerMessage.AnyError, ArraySeq[SourceCodeState.IsParsedAndCompiled]] =
     compilationResult match {
       case Left(error) =>
         // update the error to SourceCodeState
@@ -82,7 +82,7 @@ private object SourceCodeStateBuilder {
    */
   private def toCompilationError(
       parsedCode: ArraySeq[SourceCodeState.Parsed],
-      error: CompilerMessage.AnyError): Option[ArraySeq[SourceCodeState.IsParsed]] =
+      error: CompilerMessage.AnyError): Option[ArraySeq[SourceCodeState.IsParsedAndCompiled]] =
     error
       .index
       .fileURI

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeStateBuilder.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeStateBuilder.scala
@@ -181,7 +181,7 @@ private object SourceCodeStateBuilder {
       compiledScripts: Array[CompiledScript],
       workspaceErrorURI: URI): Seq[Either[StringError, Either[CompiledContract, CompiledScript]]] =
     sourceCodeState
-      .ast
+      .astStrict
       .statements
       .collect {
         case statement: Tree.Source => // collect only the source-code, ignoring import statements.

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceLocation.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceLocation.scala
@@ -25,7 +25,7 @@ import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
 /** Represents a position within a source-file in parsed state. */
 sealed trait SourceLocation {
 
-  def parsed: SourceCodeState.IsParsed
+  def parsed: SourceCodeState.IsParsedAndCompiled
 
 }
 
@@ -68,7 +68,7 @@ object SourceLocation {
    * @param parsed The source file containing the positioned node.
    */
   case class File(
-      parsed: SourceCodeState.IsParsed)
+      parsed: SourceCodeState.IsParsedAndCompiled)
     extends GoToDefStrict
        with GoToDefSoft {
 
@@ -134,14 +134,14 @@ object SourceLocation {
     def toLineRange(): Option[LineRange] =
       Some(ast.index.toLineRange(source.parsed.code))
 
-    override def parsed: SourceCodeState.IsParsed =
+    override def parsed: SourceCodeState.IsParsedAndCompiled =
       source.parsed
 
   }
 
   sealed trait Code extends SourceLocation {
 
-    def parsed: SourceCodeState.IsParsed
+    def parsed: SourceCodeState.IsParsedAndCompiled
 
   }
 
@@ -159,7 +159,7 @@ object SourceLocation {
 
   case class CodeSoft(
       body: SoftAST.BlockBodyPart,
-      parsed: SourceCodeState.IsParsed)
+      parsed: SourceCodeState.IsParsedAndCompiled)
     extends Code
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceLocation.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceLocation.scala
@@ -20,11 +20,12 @@ import org.alephium.ralph.Ast
 import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.message.LineRange
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.SourceIndexExtension
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
 
 /** Represents a position within a source-file in parsed state. */
 sealed trait SourceLocation {
 
-  def parsed: SourceCodeState.Parsed
+  def parsed: SourceCodeState.IsParsed
 
 }
 
@@ -42,17 +43,23 @@ object SourceLocation {
   /**
    * Result types for GoTo definition location search results.
    */
-  sealed trait GoToDef extends GoTo
+  sealed trait GoToDef       extends GoTo
+  sealed trait GoToDefStrict extends GoToDef
+  sealed trait GoToDefSoft   extends GoToDef
 
   /**
    * Result types for renaming location search results.
    */
-  sealed trait GoToRename extends GoTo
+  sealed trait GoToRename       extends GoTo
+  sealed trait GoToRenameStrict extends GoToRename
+  sealed trait GoToRenameSoft   extends GoToRename
 
   /**
    * Result types for GoTo references location search results.
    */
-  sealed trait GoToRef extends GoTo
+  sealed trait GoToRef       extends GoTo
+  sealed trait GoToRefStrict extends GoToRef
+  sealed trait GoToRefSoft   extends GoToRef
 
   /**
    * Represents a source file ([[SourceCodeState.Parsed]]) without
@@ -60,7 +67,10 @@ object SourceLocation {
    *
    * @param parsed The source file containing the positioned node.
    */
-  case class File(parsed: SourceCodeState.Parsed) extends GoToDef {
+  case class File(
+      parsed: SourceCodeState.IsParsed)
+    extends GoToDefStrict
+       with GoToDefSoft {
 
     def lineRange(): LineRange =
       LineRange.zero
@@ -79,8 +89,8 @@ object SourceLocation {
   case class ImportName(
       name: Tree.Name,
       parsed: SourceCodeState.Parsed)
-    extends GoToRef
-       with GoToRename {
+    extends GoToRefStrict
+       with GoToRenameStrict {
 
     def lineRange(): LineRange =
       name.index.toLineRange(parsed.code)
@@ -92,17 +102,17 @@ object SourceLocation {
 
   /**
    * Represents a single positioned AST ([[org.alephium.ralph.Ast.Positioned]])
-   * within a source tree ([[SourceLocation.Code]]),
+   * within a source tree ([[SourceLocation.CodeStrict]]),
    *
    * @param ast    The positioned node within the parsed source file.
    * @param source The source tree containing the positioned node.
    */
-  case class Node[+A <: Ast.Positioned](
+  case class NodeStrict[+A <: Ast.Positioned](
       ast: A,
-      source: SourceLocation.Code)
-    extends GoToDef
-       with GoToRef
-       with GoToRename {
+      source: CodeStrict)
+    extends GoToDefStrict
+       with GoToRefStrict
+       with GoToRenameStrict {
 
     def toLineRange(): Option[LineRange] =
       ast
@@ -114,6 +124,27 @@ object SourceLocation {
 
   }
 
+  case class NodeSoft[+A <: SoftAST](
+      ast: A,
+      source: CodeSoft)
+    extends GoToDefSoft
+       with GoToRefSoft
+       with GoToRenameSoft {
+
+    def toLineRange(): Option[LineRange] =
+      Some(ast.index.toLineRange(source.parsed.code))
+
+    override def parsed: SourceCodeState.IsParsed =
+      source.parsed
+
+  }
+
+  sealed trait Code extends SourceLocation {
+
+    def parsed: SourceCodeState.IsParsed
+
+  }
+
   /**
    * Represents a single source tree ([[Tree.Source]]) within a source file ([[SourceCodeState.Parsed]]),
    * which can contain multiple source trees such as contracts, scripts etc.
@@ -121,9 +152,14 @@ object SourceLocation {
    * @param tree   The source tree within the parsed source file.
    * @param parsed The source file containing the source tree.
    */
-  case class Code(
+  case class CodeStrict(
       tree: Tree.Source,
       parsed: SourceCodeState.Parsed)
-    extends SourceLocation
+    extends Code
+
+  case class CodeSoft(
+      body: SoftAST.BlockBodyPart,
+      parsed: SourceCodeState.IsParsed)
+    extends Code
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/Importer.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/Importer.scala
@@ -72,7 +72,7 @@ object Importer {
       sourceCode: SourceCodeState.Parsed,
       dependency: ArraySeq[SourceCodeState.Compiled]): Either[SourceCodeState.ErrorCompilation, Seq[SourceCodeState.Compiled]] = {
     val imported =
-      sourceCode.ast.statements collect {
+      sourceCode.astStrict.statements collect {
         case imported: Tree.Import => // type all import statements
           // TODO: Build a cached Map stored in BuildState instead of doing this linear search.
           // import statement should exists in dependant code.

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/ImplementingChildrenResult.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/ImplementingChildrenResult.scala
@@ -27,5 +27,5 @@ import scala.collection.immutable.ArraySeq
  * @param allTrees   All trees in scope within the current workspace.
  */
 case class ImplementingChildrenResult(
-    childTrees: ArraySeq[SourceLocation.Code],
-    allTrees: ArraySeq[SourceLocation.Code])
+    childTrees: ArraySeq[SourceLocation.CodeStrict],
+    allTrees: ArraySeq[SourceLocation.CodeStrict])

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/InheritanceHierarchyResult.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/InheritanceHierarchyResult.scala
@@ -22,12 +22,12 @@ import scala.collection.immutable.ArraySeq
 
 /** All inheritance data for the [[self]] */
 case class InheritanceHierarchyResult(
-    parentTrees: ArraySeq[SourceLocation.Code],
-    childTrees: ArraySeq[SourceLocation.Code],
-    allTrees: ArraySeq[SourceLocation.Code],
-    self: SourceLocation.Code) {
+    parentTrees: ArraySeq[SourceLocation.CodeStrict],
+    childTrees: ArraySeq[SourceLocation.CodeStrict],
+    allTrees: ArraySeq[SourceLocation.CodeStrict],
+    self: SourceLocation.CodeStrict) {
 
-  def flatten(): ArraySeq[SourceLocation.Code] =
+  def flatten(): ArraySeq[SourceLocation.CodeStrict] =
     ((parentTrees :+ self) ++ childTrees).distinct
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/InheritedParentsResult.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/InheritedParentsResult.scala
@@ -27,5 +27,5 @@ import scala.collection.immutable.ArraySeq
  * @param allTrees   All trees in scope within the current workspace.
  */
 case class InheritedParentsResult(
-    parentTrees: ArraySeq[SourceLocation.Code],
-    allTrees: ArraySeq[SourceLocation.Code])
+    parentTrees: ArraySeq[SourceLocation.CodeStrict],
+    allTrees: ArraySeq[SourceLocation.CodeStrict])

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
@@ -63,7 +63,7 @@ object WorkspaceSearcher {
    * @return The source trees within the scope.
    */
   def collectInheritanceHierarchy(
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware): InheritanceHierarchyResult = {
     val allInScopeCode =
       collectTrees(workspace = workspace, includeNonImportedCode = false)
@@ -96,7 +96,7 @@ object WorkspaceSearcher {
    * @return The source trees within the scope.
    */
   def collectInheritedParents(
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware): InheritedParentsResult = {
     val allInScopeCode =
       collectTrees(workspace = workspace, includeNonImportedCode = false)
@@ -126,7 +126,7 @@ object WorkspaceSearcher {
    *         child source trees and all trees in scope of the current workspace.
    */
   def collectImplementingChildren(
-      sourceCode: SourceLocation.Code,
+      sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware): ImplementingChildrenResult = {
     val allInScopeCode =
       collectTrees(workspace, includeNonImportedCode = false)
@@ -154,7 +154,7 @@ object WorkspaceSearcher {
    */
   def collectFunctions(
       types: Seq[Type],
-      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.FuncDef[StatefulContext]]] = {
+      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.NodeStrict[Ast.FuncDef[StatefulContext]]] = {
     val workspaceTrees =
       collectTrees(workspace, includeNonImportedCode = false)
 
@@ -173,7 +173,7 @@ object WorkspaceSearcher {
    *       because all built-in functions are available throughout the workspace.
    *       Consider using other [[collectFunctions]] functions for more targeted collections.
    */
-  def collectFunctions(workspace: WorkspaceState.Parsed): Iterator[SourceLocation.Node[Ast.FuncDef[StatefulContext]]] =
+  def collectFunctions(workspace: WorkspaceState.Parsed): Iterator[SourceLocation.NodeStrict[Ast.FuncDef[StatefulContext]]] =
     collectAllFunctions(workspace)
 
   /**
@@ -184,7 +184,7 @@ object WorkspaceSearcher {
    * @param workspace The parsed workspace state from which to collect function definitions.
    * @return An iterator containing all function implementations.
    */
-  def collectAllFunctions(workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.FuncDef[StatefulContext]]] =
+  def collectAllFunctions(workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.NodeStrict[Ast.FuncDef[StatefulContext]]] =
     collectTrees(workspace, includeNonImportedCode = false)
       .iterator
       .flatMap(SourceCodeSearcher.collectFunctions)
@@ -197,8 +197,8 @@ object WorkspaceSearcher {
    * @return An iterator containing all function implementations, including inherited ones.
    */
   def collectFunctions(
-      sourceCode: SourceLocation.Code,
-      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.FuncDef[StatefulContext]]] =
+      sourceCode: SourceLocation.CodeStrict,
+      workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.NodeStrict[Ast.FuncDef[StatefulContext]]] =
     collectInheritedParents(sourceCode, workspace)
       .parentTrees
       .iterator
@@ -212,7 +212,7 @@ object WorkspaceSearcher {
    */
   def collectTypes(
       workspace: WorkspaceState.IsSourceAware,
-      includeNonImportedCode: Boolean): Iterator[SourceLocation.Node[Ast.TypeId]] = {
+      includeNonImportedCode: Boolean): Iterator[SourceLocation.NodeStrict[Ast.TypeId]] = {
     val trees = collectTrees(workspace, includeNonImportedCode)
     SourceCodeSearcher.collectTypes(trees.iterator)
   }
@@ -223,7 +223,7 @@ object WorkspaceSearcher {
    * @param workspace The parsed workspace state from which to collect global constants.
    * @return An iterator containing all global constants.
    */
-  def collectGlobalConstants(workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.Node[Ast.ConstantVarDef[_]]] = {
+  def collectGlobalConstants(workspace: WorkspaceState.IsSourceAware): Iterator[SourceLocation.NodeStrict[Ast.ConstantVarDef[_]]] = {
     val trees = collectTrees(workspace, includeNonImportedCode = false)
     SourceCodeSearcher.collectGlobalConstants(trees.iterator)
   }
@@ -234,7 +234,7 @@ object WorkspaceSearcher {
    * @param workspace The workspace to collect source trees for.
    * @return Parsed source files in scope.
    */
-  def collectAllTrees(workspace: WorkspaceState.IsSourceAware): ArraySeq[SourceLocation.Code] =
+  def collectAllTrees(workspace: WorkspaceState.IsSourceAware): ArraySeq[SourceLocation.CodeStrict] =
     collectTrees(
       workspace = workspace,
       includeNonImportedCode = false
@@ -264,7 +264,7 @@ object WorkspaceSearcher {
    */
   private def collectTrees(
       workspace: WorkspaceState.IsSourceAware,
-      includeNonImportedCode: Boolean): ArraySeq[SourceLocation.Code] = {
+      includeNonImportedCode: Boolean): ArraySeq[SourceLocation.CodeStrict] = {
     // fetch the `std` dependency
     val stdSourceParsedCode =
       workspace

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
@@ -310,7 +310,7 @@ object WorkspaceSearcher {
     val allImportedCode =
       (SourceCodeSearcher.collectSourceTrees(importedCode) ++ importedInheritedParentTrees).distinct
 
-    // The entire local local dev workspace source-code is available.
+    // The entire local dev workspace source-code is available.
     val workspaceTrees =
       SourceCodeSearcher.collectSourceTrees(workspaceCode)
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceState.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceState.scala
@@ -91,7 +91,7 @@ object WorkspaceState {
    * @param parsed          Previous valid parsed state (used for code completion in-case the file has error)
    */
   case class Errored(
-      sourceCode: ArraySeq[SourceCodeState.IsParsed],
+      sourceCode: ArraySeq[SourceCodeState.IsParsedAndCompiled],
       workspaceErrors: ArraySeq[CompilerMessage.AnyError],
       parsed: WorkspaceState.Parsed)
     extends IsCompiled

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceStateBuilder.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceStateBuilder.scala
@@ -26,7 +26,7 @@ private object WorkspaceStateBuilder {
   /** @see [[org.alephium.ralph.lsp.pc.sourcecode.SourceCodeStateBuilder.toSourceCodeState]] */
   def toWorkspaceState(
       currentState: WorkspaceState.Parsed,
-      compilationResult: Either[CompilerMessage.AnyError, ArraySeq[SourceCodeState.IsParsed]]): WorkspaceState.IsCompiled =
+      compilationResult: Either[CompilerMessage.AnyError, ArraySeq[SourceCodeState.IsParsedAndCompiled]]): WorkspaceState.IsCompiled =
     compilationResult match {
       case Left(workspaceError) =>
         // File or sourcePosition position information is not available for this error,

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
@@ -76,7 +76,7 @@ object TestCodeProvider {
    * @param code The containing `@@` and `>>...<<` symbols.
    */
   def goToDefinition(settings: GoToDefSetting = testGoToDefSetting)(code: String): List[(URI, LineRange)] =
-    goTo[GoToDefSetting, SourceLocation.GoToDef](
+    goTo[GoToDefSetting, SourceLocation.GoToDefStrict](
       code = code,
       searchSettings = settings
     )
@@ -86,7 +86,7 @@ object TestCodeProvider {
       referenceReplacement: String,
       settings: GoToDefSetting = testGoToDefSetting
     )(code: String): Unit =
-    goToForAll[GoToDefSetting, SourceLocation.GoToDef](
+    goToForAll[GoToDefSetting, SourceLocation.GoToDefStrict](
       finder = referencesFinder,
       replacer = referenceReplacement,
       settings = settings,
@@ -94,13 +94,13 @@ object TestCodeProvider {
     )
 
   def goToReferences(settings: GoToRefSetting = testGoToRefSetting)(code: String): List[(URI, LineRange)] =
-    goTo[GoToRefSetting, SourceLocation.GoToRef](
+    goTo[GoToRefSetting, SourceLocation.GoToRefStrict](
       code = code,
       searchSettings = settings
     )
 
   def goToRename(code: String): List[(URI, LineRange)] =
-    goTo[Unit, SourceLocation.GoToRename](
+    goTo[Unit, SourceLocation.GoToRenameStrict](
       code = code,
       searchSettings = ()
     )
@@ -122,7 +122,7 @@ object TestCodeProvider {
       referenceReplacement: String,
       settings: GoToRefSetting = testGoToRefSetting
     )(code: String): Unit =
-    goToForAll[GoToRefSetting, SourceLocation.GoToRef](
+    goToForAll[GoToRefSetting, SourceLocation.GoToRefStrict](
       finder = referencesFinder,
       replacer = referenceReplacement,
       settings = settings,
@@ -133,7 +133,7 @@ object TestCodeProvider {
       renameFinder: Regex,
       renameReplacer: String
     )(code: String): Unit =
-    goToForAll[Unit, SourceLocation.GoToRename](
+    goToForAll[Unit, SourceLocation.GoToRenameStrict](
       finder = renameFinder,
       replacer = renameReplacer,
       settings = (),
@@ -321,7 +321,7 @@ object TestCodeProvider {
       dependency: String,
       workspace: String,
       settings: GoToRefSetting = testGoToRefSetting): Unit =
-    goTo[GoToRefSetting, SourceLocation.GoToRef](
+    goTo[GoToRefSetting, SourceLocation.GoToRefStrict](
       dependencyId = dependencyId,
       dependency = dependency,
       workspace = workspace,
@@ -333,7 +333,7 @@ object TestCodeProvider {
       dependency: String,
       workspace: String,
       setting: GoToDefSetting = testGoToDefSetting): Unit =
-    goTo[GoToDefSetting, SourceLocation.GoToDef](
+    goTo[GoToDefSetting, SourceLocation.GoToDefStrict](
       dependencyId = dependencyId,
       dependency = dependency,
       workspace = workspace,
@@ -476,7 +476,7 @@ object TestCodeProvider {
 
     // Execute go-to definition.
     val (searchResult, _, workspace) =
-      TestCodeProvider[GoToDefSetting, SourceLocation.GoToDef](
+      TestCodeProvider[GoToDefSetting, SourceLocation.GoToDefStrict](
         code = codeWithoutGoToSymbols,
         searchSettings = testGoToDefSetting,
         dependencyDownloaders = ArraySeq(downloader)

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
@@ -75,7 +75,7 @@ object TestCodeProvider {
    *
    * @param code The containing `@@` and `>>...<<` symbols.
    */
-  def goToDefinition(settings: GoToDefSetting = testGoToDefSetting)(code: String): List[(URI, LineRange)] =
+  def goToDefinitionStrict(settings: GoToDefSetting = testGoToDefSetting)(code: String): List[(URI, LineRange)] =
     goTo[GoToDefSetting, SourceLocation.GoToDefStrict](
       code = code,
       searchSettings = settings

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArgumentSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArgumentSpec.scala
@@ -24,7 +24,7 @@ class GoToArgumentSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "argument does not exists" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract GoToField(interface: MyInterface) {
           |  pub fn local_function(boolean: Bool) -> () {
@@ -39,7 +39,7 @@ class GoToArgumentSpec extends AnyWordSpec with Matchers {
 
   "return self" when {
     "template argument is selected" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
             |Contract Test(>>interfa@@ce<<: MyInterface,
             |              interface2: MyInterface) {
@@ -52,7 +52,7 @@ class GoToArgumentSpec extends AnyWordSpec with Matchers {
     }
 
     "function argument  is selected" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
             |Contract Test(interface2: MyInterface) {
             |
@@ -66,7 +66,7 @@ class GoToArgumentSpec extends AnyWordSpec with Matchers {
     "function and template argument exist with duplicate names" should {
       "select only itself" when {
         "function argument is selected" in {
-          goToDefinition()(
+          goToDefinitionStrict()(
             """
                 |Contract Test(interface: MyInterface) {
                 |
@@ -78,7 +78,7 @@ class GoToArgumentSpec extends AnyWordSpec with Matchers {
         }
 
         "template argument is selected" in {
-          goToDefinition()(
+          goToDefinitionStrict()(
             """
                 |Contract Test(>>interfa@@ce<<: MyInterface) {
                 |
@@ -94,7 +94,7 @@ class GoToArgumentSpec extends AnyWordSpec with Matchers {
 
   "return non-empty" when {
     "initial character is selected" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract GoToField(>>interface<<: MyInterface) {
           |  pub fn local_function(boolean: Bool) -> () {
@@ -107,7 +107,7 @@ class GoToArgumentSpec extends AnyWordSpec with Matchers {
     }
 
     "mid character is selected" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract GoToField(>>interface<<: MyInterface) {
           |  pub fn local_function(boolean: Bool) -> () {
@@ -120,7 +120,7 @@ class GoToArgumentSpec extends AnyWordSpec with Matchers {
     }
 
     "last character is selected" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract GoToField(>>interface<<: MyInterface) {
           |  pub fn local_function(boolean: Bool) -> () {
@@ -133,7 +133,7 @@ class GoToArgumentSpec extends AnyWordSpec with Matchers {
     }
 
     "function and the argument have the same name" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract MyContract(interface: MyInterface) {
           |
@@ -152,7 +152,7 @@ class GoToArgumentSpec extends AnyWordSpec with Matchers {
     }
 
     "there are multiple arguments with the same name" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |// the furthest argument
           |Contract GoToField(>>interface<<: MyInterface) {
@@ -167,7 +167,7 @@ class GoToArgumentSpec extends AnyWordSpec with Matchers {
     }
 
     "there are duplicate arguments within inheritance" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Abstract Contract Parent3(>>param<<: MyParam,
           |                          >>param<<: MyParam) { }
@@ -194,7 +194,7 @@ class GoToArgumentSpec extends AnyWordSpec with Matchers {
 
     "template arguments are passed as inheritance parameter" when {
       "there are no duplicates" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Abstract Contract SomeType() { }
             |
@@ -207,7 +207,7 @@ class GoToArgumentSpec extends AnyWordSpec with Matchers {
 
       "duplicates exist" when {
         "template parameter is duplicated" in {
-          goToDefinition()(
+          goToDefinitionStrict()(
             """
               |Abstract Contract SomeType() { }
               |
@@ -221,7 +221,7 @@ class GoToArgumentSpec extends AnyWordSpec with Matchers {
 
         "function parameter is duplicated" should {
           "not be included in search result" in {
-            goToDefinition()(
+            goToDefinitionStrict()(
               """
                 |Abstract Contract SomeType() { }
                 |

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArraySpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArraySpec.scala
@@ -24,7 +24,7 @@ class GoToArraySpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "there is no array definition" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract Test()  {
           |  fn main() -> () {
@@ -38,7 +38,7 @@ class GoToArraySpec extends AnyWordSpec with Matchers {
 
   "return non-empty" when {
     "there is a single array definition" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract Test(>>array<<: [U256; 2])  {
           |  fn main() -> () {
@@ -51,7 +51,7 @@ class GoToArraySpec extends AnyWordSpec with Matchers {
 
     "there are duplicate array definitions" when {
       "without inheritance" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract Test(>>array<<: [U256; 2])  {
             |  fn main(>>array<<: [U256; 2]) -> () {
@@ -63,7 +63,7 @@ class GoToArraySpec extends AnyWordSpec with Matchers {
       }
 
       "within inheritance" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract Parent(>>array<<: [U256; 2])  {
             |  fn main(array: [U256; 2]) -> () {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToAssignmentsInContractSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToAssignmentsInContractSpec.scala
@@ -24,7 +24,7 @@ class GoToAssignmentsInContractSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "assigned variable does not exist" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract GoToAssignment() {
           |
@@ -40,7 +40,7 @@ class GoToAssignmentsInContractSpec extends AnyWordSpec with Matchers {
   "return non-empty" when {
     "assigned variables exist" when {
       "locally in the function" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract GoToAssignment() {
             |
@@ -54,7 +54,7 @@ class GoToAssignmentsInContractSpec extends AnyWordSpec with Matchers {
       }
 
       "as function argument" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract GoToAssignment() {
             |
@@ -67,7 +67,7 @@ class GoToAssignmentsInContractSpec extends AnyWordSpec with Matchers {
       }
 
       "as template argument" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract GoToAssignment(mut >>counter<<: U256) {
             |
@@ -80,7 +80,7 @@ class GoToAssignmentsInContractSpec extends AnyWordSpec with Matchers {
       }
 
       "at multiple locations" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Abstract Contract Parent2(mut >>counter<<: U256) { }
             |

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToAssignmentsInTxScriptSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToAssignmentsInTxScriptSpec.scala
@@ -24,7 +24,7 @@ class GoToAssignmentsInTxScriptSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "assigned variable does not exist" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |TxScript GoToAssignment() {
           |  counte@@r = counter + 1
@@ -36,7 +36,7 @@ class GoToAssignmentsInTxScriptSpec extends AnyWordSpec with Matchers {
 
   "return non-empty" when {
     "assigned variables exist" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |TxScript GoToAssignment(>>counter<<: U256) {
           |  let mut >>counter<< = 0

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToCodeSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToCodeSpec.scala
@@ -8,7 +8,7 @@ class GoToCodeSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "typeId does not exist" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract GoToConstant() {
           |
@@ -23,7 +23,7 @@ class GoToCodeSpec extends AnyWordSpec with Matchers {
 
   "return self" when {
     "type definition is selected" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract >>Te@@st<<() {
           |
@@ -36,7 +36,7 @@ class GoToCodeSpec extends AnyWordSpec with Matchers {
 
     "duplicate type definition exists" when {
       "second duplicate is selected" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract Test() {
             |  pub fn function() -> () { }
@@ -78,7 +78,7 @@ class GoToCodeSpec extends AnyWordSpec with Matchers {
         |""".stripMargin
 
     "type is an inheritance" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         s"""
           |$types
           |
@@ -90,7 +90,7 @@ class GoToCodeSpec extends AnyWordSpec with Matchers {
     }
 
     "type is a function parameter" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         s"""
            |$types
            |
@@ -102,7 +102,7 @@ class GoToCodeSpec extends AnyWordSpec with Matchers {
     }
 
     "type is a template parameter" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         s"""
            |$types
            |
@@ -114,7 +114,7 @@ class GoToCodeSpec extends AnyWordSpec with Matchers {
     }
 
     "type is a constructor" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         s"""
            |$types
            |

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToConstantSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToConstantSpec.scala
@@ -24,7 +24,7 @@ class GoToConstantSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "constant does not exist" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract GoToConstant() {
           |
@@ -39,7 +39,7 @@ class GoToConstantSpec extends AnyWordSpec with Matchers {
 
   "return self" when {
     "constant definition is selected" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract Test() {
           |
@@ -52,7 +52,7 @@ class GoToConstantSpec extends AnyWordSpec with Matchers {
     }
 
     "duplicate constant definitions exist" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract Test() {
           |
@@ -68,7 +68,7 @@ class GoToConstantSpec extends AnyWordSpec with Matchers {
 
   "return non-empty" when {
     "constant exists" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |const >>MyConstant<< = 1
           |
@@ -89,7 +89,7 @@ class GoToConstantSpec extends AnyWordSpec with Matchers {
     }
 
     "duplicate constants exists" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |const >>MyConstant<< = 0
           |const >>MyConstant<< = 1
@@ -115,7 +115,7 @@ class GoToConstantSpec extends AnyWordSpec with Matchers {
     }
 
     "constant and the Contract have the same name" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Abstract Contract MyConstant() {
           |
@@ -137,7 +137,7 @@ class GoToConstantSpec extends AnyWordSpec with Matchers {
     }
 
     "only a global constant exists" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |const >>MyConstant<< = 0
           |
@@ -152,7 +152,7 @@ class GoToConstantSpec extends AnyWordSpec with Matchers {
     }
 
     "constants with expression" in {
-      goToDefinition() {
+      goToDefinitionStrict() {
         """
           |const ONE = 1
           |const TWO = 2
@@ -168,7 +168,7 @@ class GoToConstantSpec extends AnyWordSpec with Matchers {
     }
 
     "constants is defined after its usage" in {
-      goToDefinition() {
+      goToDefinitionStrict() {
         """
           |Contract Test() {
           |  pub fn main() -> () {
@@ -183,7 +183,7 @@ class GoToConstantSpec extends AnyWordSpec with Matchers {
 
     "Issue #254: Global constant has no tail newline" in {
       // https://github.com/alephium/ralph-lsp/issues/254
-      goToDefinition() {
+      goToDefinitionStrict() {
         """
           |Contract Test() {
           |  pub fn main() -> () {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumFieldSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumFieldSpec.scala
@@ -24,7 +24,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "enum type does not exist" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract MyContract() {
           |  pub fn function() -> () {
@@ -38,7 +38,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
 
   "return self" when {
     "enum field definition is selected" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |// This parent is not inherited
           |Abstract Contract ParentNotUsed() {
@@ -60,7 +60,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
 
   "return non-empty" when {
     "user selects the first enum field" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |// This parent is not inherited
           |Abstract Contract ParentNotUsed() {
@@ -106,7 +106,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
     }
 
     "user selects the second enum field" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |enum EnumType {
           |  Field0 = 0
@@ -145,7 +145,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
 
     "there are duplicate enum types and fields" when {
       "user selects the first enum field" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |enum EnumType {
             |  >>Field0<< = 0
@@ -191,7 +191,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
       }
 
       "user selects the second enum field" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |enum EnumType {
             |  Field0 = 0
@@ -222,7 +222,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
 
     "there are duplicate enum types with distinct fields" when {
       "user selects the first enum field" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |enum EnumType {
             |  >>Field0<< = 0
@@ -253,7 +253,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
       }
 
       "user selects the third enum field" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract MyContract() {
             |
@@ -279,7 +279,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
       }
 
       "an enum field is selected that's implemented within a parent" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Abstract Contract Parent2() {
             |  enum EnumType {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumTypeSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumTypeSpec.scala
@@ -24,7 +24,7 @@ class GoToEnumTypeSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "enum type does not exist" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract MyContract() {
           |  pub fn function() -> () {
@@ -38,7 +38,7 @@ class GoToEnumTypeSpec extends AnyWordSpec with Matchers {
 
   "return self" when {
     "EnumType definition is selected" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |enum >>En@@umType<< {
           |  Field0 = 0
@@ -51,7 +51,7 @@ class GoToEnumTypeSpec extends AnyWordSpec with Matchers {
 
   "return non-empty" when {
     "user selects the enum type of the first field" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |enum >>EnumType<< {
           |  Field0 = 0
@@ -93,7 +93,7 @@ class GoToEnumTypeSpec extends AnyWordSpec with Matchers {
     }
 
     "user selects the enum type of the second field" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |enum >>EnumType<< {
           |  Field0 = 0
@@ -130,7 +130,7 @@ class GoToEnumTypeSpec extends AnyWordSpec with Matchers {
     }
 
     "there are multiple enum types with duplicate names" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |enum >>EnumType<< {
           |  Field0 = 0

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEventSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEventSpec.scala
@@ -24,7 +24,7 @@ class GoToEventSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "event does not exists" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract Test() {
           |
@@ -40,7 +40,7 @@ class GoToEventSpec extends AnyWordSpec with Matchers {
 
   "return self" when {
     "an event definition is selected" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract Test() extends Parent() {
           |
@@ -53,7 +53,7 @@ class GoToEventSpec extends AnyWordSpec with Matchers {
     }
 
     "duplicate event definitions exist" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract Test() extends Parent() {
           |
@@ -69,7 +69,7 @@ class GoToEventSpec extends AnyWordSpec with Matchers {
 
   "return non-empty" when {
     "an event exists" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Abstract Contract Parent() {
           |
@@ -92,7 +92,7 @@ class GoToEventSpec extends AnyWordSpec with Matchers {
     }
 
     "duplicate events exist" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Abstract Contract Parent() {
           |

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToExternalFuncCallSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToExternalFuncCallSpec.scala
@@ -24,7 +24,7 @@ class GoToExternalFuncCallSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "external function does not exist" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract Main(action: Action) {
           |  pub fn main() -> () {
@@ -39,7 +39,7 @@ class GoToExternalFuncCallSpec extends AnyWordSpec with Matchers {
   "return non-empty" when {
     "external abstract function exists" should {
       "go from template parameter" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Abstract Contract Action() {
             |  fn >>function<<() -> Bool
@@ -55,7 +55,7 @@ class GoToExternalFuncCallSpec extends AnyWordSpec with Matchers {
       }
 
       "go from function parameter" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Abstract Contract Action() {
             |  fn >>function<<() -> Bool
@@ -73,7 +73,7 @@ class GoToExternalFuncCallSpec extends AnyWordSpec with Matchers {
 
     "external function exists" should {
       "go from template parameter" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract Action() {
             |  fn >>function<<() -> Bool {
@@ -91,7 +91,7 @@ class GoToExternalFuncCallSpec extends AnyWordSpec with Matchers {
       }
 
       "go from function parameter" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract Action() {
             |  fn >>function<<() -> Bool {
@@ -110,7 +110,7 @@ class GoToExternalFuncCallSpec extends AnyWordSpec with Matchers {
     }
 
     "external function exists in nested hierarchy" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
             |Interface Parent2 {
             |  fn not_used2() -> ()

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFunctionSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToFunctionSpec.scala
@@ -24,7 +24,7 @@ class GoToFunctionSpec extends AnyWordSpec with Matchers {
 
   "return in empty" when {
     "function does not exist" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract MyContract(interface: MyInterface) {
           |  pub fn function_a(boolean: Bool) -> () {
@@ -39,7 +39,7 @@ class GoToFunctionSpec extends AnyWordSpec with Matchers {
 
   "return self" when {
     "the function itself is selected" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Abstract Contract Action() {
           |  fn >>funct@@ion<<() -> Bool
@@ -52,7 +52,7 @@ class GoToFunctionSpec extends AnyWordSpec with Matchers {
     "duplicate functions exist" when {
       "second duplicate is selected" should {
         "still select only itself" in {
-          goToDefinition()(
+          goToDefinitionStrict()(
             """
               |Abstract Contract Action() {
               |  fn function() -> Bool
@@ -69,7 +69,7 @@ class GoToFunctionSpec extends AnyWordSpec with Matchers {
 
   "go to the function" when {
     "function exists" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract MyContract(interface: MyInterface) {
           |  pub fn function_a(boolean: Bool) -> () {
@@ -86,7 +86,7 @@ class GoToFunctionSpec extends AnyWordSpec with Matchers {
     }
 
     "function and argument have same names" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Abstract Contract Parent2() {
           |
@@ -116,7 +116,7 @@ class GoToFunctionSpec extends AnyWordSpec with Matchers {
 
     "function is an interface function" should {
       "highlight the entire function signature" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Abstract Contract Test() {
             |

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToLocalVariableSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToLocalVariableSpec.scala
@@ -24,7 +24,7 @@ class GoToLocalVariableSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "variable does not exist" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract GoToTest() {
           |
@@ -41,7 +41,7 @@ class GoToLocalVariableSpec extends AnyWordSpec with Matchers {
 
   "return self" when {
     "variable itself is selected" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract Test() {
           |
@@ -56,7 +56,7 @@ class GoToLocalVariableSpec extends AnyWordSpec with Matchers {
 
     "duplicate variables exists" when {
       "first var is selected" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract Test() {
             |
@@ -71,7 +71,7 @@ class GoToLocalVariableSpec extends AnyWordSpec with Matchers {
       }
 
       "second var is selected" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract Test() {
             |
@@ -89,7 +89,7 @@ class GoToLocalVariableSpec extends AnyWordSpec with Matchers {
 
   "return non-empty" when {
     "single local variable exists" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract GoToTest() {
           |
@@ -104,7 +104,7 @@ class GoToLocalVariableSpec extends AnyWordSpec with Matchers {
     }
 
     "multiple local variables exists" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract GoToTest() {
           |
@@ -120,7 +120,7 @@ class GoToLocalVariableSpec extends AnyWordSpec with Matchers {
     }
 
     "local variable and arguments have the same name" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract GoToTest(>>varA<<: Bool) {
           |
@@ -137,7 +137,7 @@ class GoToLocalVariableSpec extends AnyWordSpec with Matchers {
     }
 
     "variable is in an ApproveAsset expression" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract GoToTest() {
           |
@@ -153,7 +153,7 @@ class GoToLocalVariableSpec extends AnyWordSpec with Matchers {
 
     "variable is a tuple" when {
       "first tuple is queried" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract Test() {
             |  fn test() -> () {
@@ -170,7 +170,7 @@ class GoToLocalVariableSpec extends AnyWordSpec with Matchers {
       }
 
       "second tuple is queried" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract Test() {
             |  fn test() -> () {
@@ -187,7 +187,7 @@ class GoToLocalVariableSpec extends AnyWordSpec with Matchers {
       }
 
       "there are duplicate tuples" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract Test() {
             |  fn test() -> () {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToMapSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToMapSpec.scala
@@ -24,7 +24,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "map does not exist" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract Test() {
           |
@@ -39,7 +39,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
 
   "return self" when {
     "map definition itself is selected" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Abstract Contract Parent() {
           |  mapping[Address, U256] >>coun@@ters<<
@@ -50,7 +50,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
 
     "duplicate maps exist" when {
       "first map is selected" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Abstract Contract Parent() {
             |  mapping[Address, U256] >>coun@@ters<<
@@ -61,7 +61,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
       }
 
       "second map is selected" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Abstract Contract Parent() {
             |  mapping[Address, U256] counters
@@ -75,7 +75,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
 
   "return non-empty" when {
     "map value is extracted" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Abstract Contract Parent() {
           |  mapping[Address, U256] >>counters<<
@@ -94,7 +94,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
     }
 
     "map value is set" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Abstract Contract Parent() {
           |  mapping[Address, U256] >>counters<<
@@ -113,7 +113,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
     }
 
     "map is inserted" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Abstract Contract Parent() {
           |  mapping[Address, U256] >>counters<<
@@ -132,7 +132,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
     }
 
     "map item is remove" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Abstract Contract Parent() {
           |  mapping[Address, U256] >>counters<<
@@ -151,7 +151,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
     }
 
     "map is checked for contains" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Abstract Contract Parent() {
           |  mapping[Address, U256] >>counters<<
@@ -170,7 +170,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
     }
 
     "map function is returned" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Abstract Contract Parent() {
           |  mapping[Address, U256] >>counters<<

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToNamedVarSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToNamedVarSpec.scala
@@ -24,7 +24,7 @@ class GoToNamedVarSpec extends AnyWordSpec with Matchers {
 
   "return self" when {
     "variable definition is selected" in {
-      goToDefinition()(
+      goToDefinitionStrict()(
         """
           |Contract Test() {
           |
@@ -38,7 +38,7 @@ class GoToNamedVarSpec extends AnyWordSpec with Matchers {
 
     "duplicates exist" when {
       "first duplicate is selected" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract Test() {
             |
@@ -52,7 +52,7 @@ class GoToNamedVarSpec extends AnyWordSpec with Matchers {
       }
 
       "second duplicate is selected" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract Test() {
             |

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/ScopeWalkerSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/ScopeWalkerSpec.scala
@@ -26,7 +26,7 @@ class ScopeWalkerSpec extends AnyWordSpec with Matchers {
   "allow variable access" when {
     "defined outside the scope of a block" when {
       "defined before usage" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
               |Contract Test() {
               |
@@ -45,7 +45,7 @@ class ScopeWalkerSpec extends AnyWordSpec with Matchers {
 
       "defined after usage" should {
         "go-to the first definition" in {
-          goToDefinition()(
+          goToDefinitionStrict()(
             """
                 |Contract Test() {
                 |
@@ -63,7 +63,7 @@ class ScopeWalkerSpec extends AnyWordSpec with Matchers {
         }
 
         "prioritise local definition over outside definition" in {
-          goToDefinition()(
+          goToDefinitionStrict()(
             """
               |Contract Test() {
               |
@@ -83,7 +83,7 @@ class ScopeWalkerSpec extends AnyWordSpec with Matchers {
       }
 
       "defined in a for loop" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract Test() {
             |
@@ -103,7 +103,7 @@ class ScopeWalkerSpec extends AnyWordSpec with Matchers {
 
     "defined within one of the nested blocks and accessed in another" when {
       "define before usage" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
               |Contract Test() {
               |
@@ -130,7 +130,7 @@ class ScopeWalkerSpec extends AnyWordSpec with Matchers {
       }
 
       "define after usage" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
               |Contract Test() {
               |
@@ -155,7 +155,7 @@ class ScopeWalkerSpec extends AnyWordSpec with Matchers {
       }
 
       "define in while loop and accessed in for loop" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract Test() {
             |
@@ -185,7 +185,7 @@ class ScopeWalkerSpec extends AnyWordSpec with Matchers {
   "disallow variable access" when {
     "definition is in a different scope" when {
       "defined before usage" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract Test() {
             |
@@ -204,7 +204,7 @@ class ScopeWalkerSpec extends AnyWordSpec with Matchers {
       }
 
       "defined after usage" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract Test() {
             |
@@ -223,7 +223,7 @@ class ScopeWalkerSpec extends AnyWordSpec with Matchers {
       }
 
       "defined after usage but in an inner scope" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract Test() {
             |
@@ -242,7 +242,7 @@ class ScopeWalkerSpec extends AnyWordSpec with Matchers {
       }
 
       "defined in a for loop" in {
-        goToDefinition()(
+        goToDefinitionStrict()(
           """
             |Contract Test() {
             |

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeParseSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeParseSpec.scala
@@ -163,7 +163,7 @@ class SourceCodeParseSpec extends AnyWordSpec with Matchers with ScalaCheckDrive
                   SourceCodeState.Parsed(
                     fileURI = currentState.fileURI,
                     code = goodCode,
-                    ast = compiler.parseContracts(currentState.fileURI, goodCode).value
+                    astStrict = compiler.parseContracts(currentState.fileURI, goodCode).value
                   )
 
                 // read the code written on disk

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectImplementingChildrenSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectImplementingChildrenSpec.scala
@@ -48,7 +48,7 @@ class SourceCodeSearcherCollectImplementingChildrenSpec extends AnyWordSpec with
         parsed.astStrict.statements.head.asInstanceOf[Tree.Source]
 
       SourceCodeSearcher.collectImplementingChildren(
-        source = SourceLocation.Code(tree, parsed),
+        source = SourceLocation.CodeStrict(tree, parsed),
         allSource = ArraySeq.empty
       ) shouldBe empty
 
@@ -79,14 +79,14 @@ class SourceCodeSearcherCollectImplementingChildrenSpec extends AnyWordSpec with
 
       // expect parent to be returned
       val expected =
-        SourceLocation.Code(
+        SourceLocation.CodeStrict(
           tree = child,
           parsed = parsed
         )
 
       val actual =
         SourceCodeSearcher.collectImplementingChildren(
-          source = SourceLocation.Code(parent, parsed),
+          source = SourceLocation.CodeStrict(parent, parsed),
           allSource = parsedTrees
         )
 
@@ -188,7 +188,7 @@ class SourceCodeSearcherCollectImplementingChildrenSpec extends AnyWordSpec with
           }
           .map {
             child =>
-              SourceLocation.Code(
+              SourceLocation.CodeStrict(
                 tree = child,
                 parsed = file1 // file1 is in scope
               )
@@ -202,7 +202,7 @@ class SourceCodeSearcherCollectImplementingChildrenSpec extends AnyWordSpec with
           }
           .map {
             child =>
-              SourceLocation.Code(
+              SourceLocation.CodeStrict(
                 tree = child,
                 parsed = file2 // file2 is in scope
               )
@@ -218,7 +218,7 @@ class SourceCodeSearcherCollectImplementingChildrenSpec extends AnyWordSpec with
       // actual trees returned
       val actual =
         SourceCodeSearcher.collectImplementingChildren(
-          source = SourceLocation.Code(parent, file2),
+          source = SourceLocation.CodeStrict(parent, file2),
           allSource = allTrees
         )
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectImplementingChildrenSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectImplementingChildrenSpec.scala
@@ -45,7 +45,7 @@ class SourceCodeSearcherCollectImplementingChildrenSpec extends AnyWordSpec with
           .get
 
       val tree =
-        parsed.ast.statements.head.asInstanceOf[Tree.Source]
+        parsed.astStrict.statements.head.asInstanceOf[Tree.Source]
 
       SourceCodeSearcher.collectImplementingChildren(
         source = SourceLocation.Code(tree, parsed),
@@ -70,11 +70,11 @@ class SourceCodeSearcherCollectImplementingChildrenSpec extends AnyWordSpec with
           .to(ArraySeq)
 
       // first statement is Parent()
-      val parent = parsed.ast.statements.head.asInstanceOf[Tree.Source]
+      val parent = parsed.astStrict.statements.head.asInstanceOf[Tree.Source]
       parent.ast.name shouldBe "Parent"
 
       // second statement is Child()
-      val child = parsed.ast.statements.last.asInstanceOf[Tree.Source]
+      val child = parsed.astStrict.statements.last.asInstanceOf[Tree.Source]
       child.ast.name shouldBe "Child"
 
       // expect parent to be returned
@@ -169,11 +169,11 @@ class SourceCodeSearcherCollectImplementingChildrenSpec extends AnyWordSpec with
 
       // collect all trees from file1
       val treesFromFile1 =
-        file1.ast.statements.map(_.asInstanceOf[Tree.Source])
+        file1.astStrict.statements.map(_.asInstanceOf[Tree.Source])
 
       // collect all trees from file2
       val treesFromFile2 =
-        file2.ast.statements.map(_.asInstanceOf[Tree.Source])
+        file2.astStrict.statements.map(_.asInstanceOf[Tree.Source])
 
       // the first statement in file2 is Parent6()
       val parent = treesFromFile2.head

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectInheritedParentsSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectInheritedParentsSpec.scala
@@ -45,7 +45,7 @@ class SourceCodeSearcherCollectInheritedParentsSpec extends AnyWordSpec with Mat
           .get
 
       val tree =
-        parsed.ast.statements.head.asInstanceOf[Tree.Source]
+        parsed.astStrict.statements.head.asInstanceOf[Tree.Source]
 
       SourceCodeSearcher.collectInheritedParents(
         source = SourceLocation.Code(tree, parsed),
@@ -65,11 +65,11 @@ class SourceCodeSearcherCollectInheritedParentsSpec extends AnyWordSpec with Mat
           .get
 
       // first statement is Parent()
-      val parent = parsed.ast.statements.head.asInstanceOf[Tree.Source]
+      val parent = parsed.astStrict.statements.head.asInstanceOf[Tree.Source]
       parent.ast.name shouldBe "Parent"
 
       // second statement is Child()
-      val child = parsed.ast.statements.last.asInstanceOf[Tree.Source]
+      val child = parsed.astStrict.statements.last.asInstanceOf[Tree.Source]
       child.ast.name shouldBe "Child"
 
       // expect parent to be returned
@@ -170,11 +170,11 @@ class SourceCodeSearcherCollectInheritedParentsSpec extends AnyWordSpec with Mat
 
       // collect all tree from file1
       val treesFromFile1 =
-        file1.ast.statements.map(_.asInstanceOf[Tree.Source])
+        file1.astStrict.statements.map(_.asInstanceOf[Tree.Source])
 
       // collect all tree from file2
       val treesFromFile2 =
-        file2.ast.statements.map(_.asInstanceOf[Tree.Source])
+        file2.astStrict.statements.map(_.asInstanceOf[Tree.Source])
 
       // the last statement in file1 is Child()
       val child = treesFromFile1.last

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectInheritedParentsSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeSearcherCollectInheritedParentsSpec.scala
@@ -48,7 +48,7 @@ class SourceCodeSearcherCollectInheritedParentsSpec extends AnyWordSpec with Mat
         parsed.astStrict.statements.head.asInstanceOf[Tree.Source]
 
       SourceCodeSearcher.collectInheritedParents(
-        source = SourceLocation.Code(tree, parsed),
+        source = SourceLocation.CodeStrict(tree, parsed),
         allSource = ArraySeq.empty
       ) shouldBe empty
 
@@ -74,7 +74,7 @@ class SourceCodeSearcherCollectInheritedParentsSpec extends AnyWordSpec with Mat
 
       // expect parent to be returned
       val expected =
-        SourceLocation.Code(
+        SourceLocation.CodeStrict(
           tree = parent,
           parsed = parsed
         )
@@ -87,7 +87,7 @@ class SourceCodeSearcherCollectInheritedParentsSpec extends AnyWordSpec with Mat
 
       val actual =
         SourceCodeSearcher.collectInheritedParents(
-          source = SourceLocation.Code(child, parsed),
+          source = SourceLocation.CodeStrict(child, parsed),
           allSource = allTrees
         )
 
@@ -189,7 +189,7 @@ class SourceCodeSearcherCollectInheritedParentsSpec extends AnyWordSpec with Mat
           }
           .map {
             parent =>
-              SourceLocation.Code(
+              SourceLocation.CodeStrict(
                 tree = parent,
                 parsed = file1 // file1 is in scope
               )
@@ -199,7 +199,7 @@ class SourceCodeSearcherCollectInheritedParentsSpec extends AnyWordSpec with Mat
         treesFromFile2
           .map {
             parent =>
-              SourceLocation.Code(
+              SourceLocation.CodeStrict(
                 tree = parent,
                 parsed = file2 // file2 is in scope
               )
@@ -216,7 +216,7 @@ class SourceCodeSearcherCollectInheritedParentsSpec extends AnyWordSpec with Mat
       // actual trees returned
       val actual =
         SourceCodeSearcher.collectInheritedParents(
-          source = SourceLocation.Code(child, file1),
+          source = SourceLocation.CodeStrict(child, file1),
           allSource = allTrees
         )
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
@@ -216,7 +216,7 @@ object TestSourceCode {
       fileURI: Gen[URI] = genFileURI()
     )(implicit file: FileAccess,
       compiler: CompilerAccess,
-      logger: ClientLogger): Gen[SourceCodeState.IsParsed] = {
+      logger: ClientLogger): Gen[SourceCodeState.IsParsedAndCompiled] = {
     val parsed =
       genParsedOK(
         code = code,
@@ -229,13 +229,13 @@ object TestSourceCode {
   def genCompiled(
       parsed: Gen[SourceCodeState.Parsed]
     )(implicit compiler: CompilerAccess,
-      logger: ClientLogger): Gen[SourceCodeState.IsParsed] =
+      logger: ClientLogger): Gen[SourceCodeState.IsParsedAndCompiled] =
     parsed map compile
 
   def compile(
       parsed: SourceCodeState.Parsed
     )(implicit compiler: CompilerAccess,
-      logger: ClientLogger): SourceCodeState.IsParsed = {
+      logger: ClientLogger): SourceCodeState.IsParsedAndCompiled = {
     val result =
       SourceCode.compile(
         sourceCode = ArraySeq(parsed),

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcherCollectInheritedParentsSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcherCollectInheritedParentsSpec.scala
@@ -103,7 +103,7 @@ class WorkspaceSearcherCollectInheritedParentsSpec extends AnyWordSpec with Matc
     val file1Trees =
       sourceFile1.astStrict.statements.collect {
         case source: Tree.Source =>
-          SourceLocation.Code(source, sourceFile1)
+          SourceLocation.CodeStrict(source, sourceFile1)
       }
 
     // We need to test to find in-scope inheritance for the Child contract.
@@ -114,7 +114,7 @@ class WorkspaceSearcherCollectInheritedParentsSpec extends AnyWordSpec with Matc
     val file2Trees =
       sourceFile2.astStrict.statements.collect {
         case source: Tree.Source =>
-          SourceLocation.Code(source, sourceFile2)
+          SourceLocation.CodeStrict(source, sourceFile2)
       }
 
     // std interfaces with the following import identifiers should get included.
@@ -134,7 +134,7 @@ class WorkspaceSearcherCollectInheritedParentsSpec extends AnyWordSpec with Matc
           case source if expectedImports.contains(source.importIdentifier.value.string.value) =>
             source.parsed.astStrict.statements.collect {
               case tree: Tree.Source =>
-                SourceLocation.Code(
+                SourceLocation.CodeStrict(
                   tree = tree,
                   parsed = source.parsed
                 )
@@ -151,7 +151,7 @@ class WorkspaceSearcherCollectInheritedParentsSpec extends AnyWordSpec with Matc
     // execute the function
     val actual =
       WorkspaceSearcher.collectInheritedParents(
-        sourceCode = SourceLocation.Code(
+        sourceCode = SourceLocation.CodeStrict(
           tree = childTree.tree,
           parsed = sourceFile1
         ),

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcherCollectInheritedParentsSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcherCollectInheritedParentsSpec.scala
@@ -101,7 +101,7 @@ class WorkspaceSearcherCollectInheritedParentsSpec extends AnyWordSpec with Matc
 
     // collect all trees from file1
     val file1Trees =
-      sourceFile1.ast.statements.collect {
+      sourceFile1.astStrict.statements.collect {
         case source: Tree.Source =>
           SourceLocation.Code(source, sourceFile1)
       }
@@ -112,7 +112,7 @@ class WorkspaceSearcherCollectInheritedParentsSpec extends AnyWordSpec with Matc
 
     // collect all trees from file2
     val file2Trees =
-      sourceFile2.ast.statements.collect {
+      sourceFile2.astStrict.statements.collect {
         case source: Tree.Source =>
           SourceLocation.Code(source, sourceFile2)
       }
@@ -132,7 +132,7 @@ class WorkspaceSearcherCollectInheritedParentsSpec extends AnyWordSpec with Matc
         .flatMap(_.sourceCode)
         .collect {
           case source if expectedImports.contains(source.importIdentifier.value.string.value) =>
-            source.parsed.ast.statements.collect {
+            source.parsed.astStrict.statements.collect {
               case tree: Tree.Source =>
                 SourceLocation.Code(
                   tree = tree,


### PR DESCRIPTION
- This PR renames result types. Types related to ralphc's parser are suffixed with `*Strict`, and soft-parser types are suffixed with `*Soft`.
- Towards #104.