### PR TITLE
`Import` statement parser

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
@@ -89,6 +89,7 @@ private object BlockParser {
         EventParser.parseOrFail |
         StructParser.parseOrFail |
         FunctionParser.parseOrFail |
+        ImportParser.parseOrFail |
         ExpressionParser.parseOrFail |
         CommentParser.parseOrFail |
         UnresolvedParser.parseOrFail(stop: _*)

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala
@@ -10,6 +10,8 @@ object Demo extends App {
   val ast =
     compiler.parseSoft {
       """
+        |import "a/b"
+        |
         |event Event(a: Type)
         |struct Struct { a: Type }
         |

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ExpressionParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ExpressionParser.scala
@@ -38,8 +38,7 @@ private object ExpressionParser {
 
   def parseOrFail[Unknown: P]: P[SoftAST.ExpressionAST] =
     P {
-      ImportParser.parseOrFail |
-        TypeAssignmentParser.parseOrFail |
+      TypeAssignmentParser.parseOrFail |
         AssignmentParser.parseOrFail |
         InfixCallParser.parseOrFail |
         MethodCallParser.parseOrFail |

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ExpressionParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ExpressionParser.scala
@@ -38,7 +38,8 @@ private object ExpressionParser {
 
   def parseOrFail[Unknown: P]: P[SoftAST.ExpressionAST] =
     P {
-      TypeAssignmentParser.parseOrFail |
+      ImportParser.parseOrFail |
+        TypeAssignmentParser.parseOrFail |
         AssignmentParser.parseOrFail |
         InfixCallParser.parseOrFail |
         MethodCallParser.parseOrFail |

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ExpressionParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ExpressionParser.scala
@@ -54,6 +54,7 @@ private object ExpressionParser {
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |
         BStringParser.parseOrFail |
+        StringLiteralParser.parseOrFail |
         IdentifierParser.parseOrFail
     }
 

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ImportParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ImportParser.scala
@@ -1,0 +1,38 @@
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse._
+import fastparse.NoWhitespace.noWhitespaceImplicit
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
+
+private object ImportParser {
+
+  /**
+   * Parses an import statement.
+   *
+   * Example syntax:
+   *
+   * {{{
+   *   import "some text"
+   *   import "a/b/c/d"
+   * }}}
+   */
+  def parseOrFail[Unknown: P]: P[SoftAST.Import] =
+    P {
+      Index ~
+        TokenParser.parseOrFail(Token.Import) ~
+        &(TokenParser.WhileInOrFail(Token.Space, Token.Newline, Token.Quote) | End) ~
+        SpaceParser.parseOrFail.? ~
+        StringLiteralParser.parseOrFail.? ~
+        Index
+    } map {
+      case (from, importToken, space, endQuote, to) =>
+        SoftAST.Import(
+          index = range(from, to),
+          importToken = importToken,
+          postImportSpace = space,
+          string = endQuote
+        )
+    }
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TextParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TextParser.scala
@@ -2,11 +2,34 @@ package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
-import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.{point, range}
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object TextParser {
 
+  /**
+   * Parses a text string, stopping at the specified tokens.
+   *
+   * @param stop The tokens at which parsing should stop.
+   * @return One of the following:
+   *         - [[SoftAST.CodeStringExpected]] if the text is empty.
+   *         - [[SoftAST.CodeString]] for non-empty text.
+   */
+  def parse[Unknown: P](stop: Token*): P[SoftAST.CodeStringAST] =
+    P(Index ~ parseOrFail(stop: _*).?) map {
+      case (from, None) =>
+        SoftAST.CodeStringExpected(point(from))
+
+      case (_, Some(code)) =>
+        code
+    }
+
+  /**
+   * Parses a text string, stopping at the specified tokens.
+   *
+   * @param stop The tokens at which parsing should stop.
+   * @return Non-empty text string.
+   */
   def parseOrFail[Unknown: P](stop: Token*): P[SoftAST.CodeString] =
     P(Index ~ TokenParser.WhileNotOrFail(stop: _*).! ~ Index) map {
       case (from, text, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -463,6 +463,13 @@ object SoftAST {
       endTick: TokenDocExpectedAST[Token.Tick.type])
     extends ExpressionAST
 
+  case class Import(
+      index: SourceIndex,
+      importToken: TokenDocumented[Token.Import.type],
+      postImportSpace: Option[Space],
+      string: Option[StringLiteral])
+    extends ExpressionAST
+
   case class StringLiteral(
       index: SourceIndex,
       startQuote: TokenDocumented[Token.Quote.type],

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -463,6 +463,20 @@ object SoftAST {
       endTick: TokenDocExpectedAST[Token.Tick.type])
     extends ExpressionAST
 
+  case class StringLiteral(
+      index: SourceIndex,
+      startQuote: TokenDocumented[Token.Quote.type],
+      head: Option[CodeStringAST],
+      tail: Seq[Path],
+      endQuote: TokenDocExpectedAST[Token.Quote.type])
+    extends ExpressionAST
+
+  case class Path(
+      index: SourceIndex,
+      slash: TokenDocumented[Token.ForwardSlash.type],
+      text: CodeStringAST)
+    extends SoftAST
+
   sealed trait SpaceAST extends SoftAST
 
   case class Space(

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -495,6 +495,8 @@ object SoftAST {
 
   }
 
+  sealed trait CodeStringAST extends SoftAST
+
   /**
    * Represents a string within a segment of code.
    *
@@ -504,7 +506,14 @@ object SoftAST {
   case class CodeString(
       index: SourceIndex,
       text: String)
-    extends Code
+    extends CodeStringAST
+       with Code
+
+  /** Represents a location where a code symbol is expected, but an empty value was provided. */
+  case class CodeStringExpected(
+      index: SourceIndex)
+    extends ExpectedErrorAST("Symbol")
+       with CodeStringAST
 
   /**
    * Represents a token within a segment of code.

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -188,6 +188,13 @@ object SoftAST {
       params: Group[Token.OpenCurly.type, Token.CloseCurly.type])
     extends BodyPartAST
 
+  case class Import(
+      index: SourceIndex,
+      importToken: TokenDocumented[Token.Import.type],
+      postImportSpace: Option[Space],
+      string: Option[StringLiteral])
+    extends BodyPartAST
+
   /** Syntax: `implements or extends contract(arg1, arg2 ...)` */
   case class Inheritance(
       index: SourceIndex,
@@ -461,13 +468,6 @@ object SoftAST {
       startTick: TokenDocumented[Token.Tick.type],
       text: Option[CodeString],
       endTick: TokenDocExpectedAST[Token.Tick.type])
-    extends ExpressionAST
-
-  case class Import(
-      index: SourceIndex,
-      importToken: TokenDocumented[Token.Import.type],
-      postImportSpace: Option[Space],
-      string: Option[StringLiteral])
     extends ExpressionAST
 
   case class StringLiteral(

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ImportParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ImportParserSpec.scala
@@ -1,0 +1,97 @@
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.alephium.ralph.lsp.access.util.TestFastParse.assertIsFastParseError
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ImportParserSpec extends AnyWordSpec with Matchers {
+
+  "fail" when {
+    "import is a prefix of an identifier" in {
+      assertIsFastParseError {
+        parseImport("important")
+      }
+    }
+  }
+
+  "succeed" when {
+    "only the import token is defined" in {
+      val importAST =
+        parseImport("import")
+
+      importAST shouldBe
+        SoftAST.Import(
+          index = indexOf(">>import<<"),
+          importToken = Import(indexOf(">>import<<")),
+          postImportSpace = None,
+          string = None
+        )
+    }
+
+    "tail space is defined" in {
+      val importAST =
+        parseImport("import ")
+
+      importAST shouldBe
+        SoftAST.Import(
+          index = indexOf(">>import <<"),
+          importToken = Import(indexOf(">>import<< ")),
+          postImportSpace = Some(SpaceOne(indexOf("import>> <<"))),
+          string = None
+        )
+    }
+
+    "starting quote is defined without space" in {
+      val importAST =
+        parseImport("import\"")
+
+      importAST shouldBe
+        SoftAST.Import(
+          index = indexOf(">>import\"<<"),
+          importToken = Import(indexOf(">>import<<")),
+          postImportSpace = None,
+          string = Some(
+            SoftAST.StringLiteral(
+              index = indexOf("import>>\"<<"),
+              startQuote = Quote(indexOf("import>>\"<<")),
+              head = None,
+              tail = Seq.empty,
+              endQuote = SoftAST.TokenExpected(indexOf("import\">><<"), Token.Quote)
+            )
+          )
+        )
+    }
+
+    "import is fully defined" in {
+      val importAST =
+        parseImport("""import "folder/file.ral"""")
+
+      importAST shouldBe
+        SoftAST.Import(
+          index = indexOf(""">>import "folder/file.ral"<<"""),
+          importToken = Import(indexOf(""">>import<< "folder/file.ral"""")),
+          postImportSpace = Some(SpaceOne(indexOf("""import>> <<"folder/file.ral""""))),
+          string = Some(
+            SoftAST.StringLiteral(
+              index = indexOf("""import >>"folder/file.ral"<<"""),
+              startQuote = Quote(indexOf("""import >>"<<folder/file.ral"""")),
+              head = Some(SoftAST.CodeString(indexOf("""import ">>folder<</file.ral""""), "folder")),
+              tail = Seq(
+                SoftAST.Path(
+                  index = indexOf("""import "folder>>/file.ral<<""""),
+                  slash = ForwardSlash(indexOf("""import "folder>>/<<file.ral"""")),
+                  text = SoftAST.CodeString(indexOf("""import "folder/>>file.ral<<""""), "file.ral")
+                )
+              ),
+              endQuote = Quote(indexOf("""import "folder/file.ral>>"<<"""))
+            )
+          )
+        )
+    }
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringLiteralParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringLiteralParserSpec.scala
@@ -11,6 +11,9 @@ import org.scalatest.OptionValues._
 
 class StringLiteralParserSpec extends AnyWordSpec with Matchers {
 
+  private val newline =
+    Token.Newline.lexeme
+
   "fail" when {
     "empty" in {
       assertIsFastParseError {
@@ -63,15 +66,15 @@ class StringLiteralParserSpec extends AnyWordSpec with Matchers {
 
       "text is non-empty with newline" in {
         val string =
-          parseStringLiteral("\" \n a b c \n ")
+          parseStringLiteral(s"\" $newline a b c $newline ")
 
         string shouldBe
           SoftAST.StringLiteral(
-            index = indexOf(">>\" \n a b c \n <<"),
-            startQuote = Quote(indexOf(">>\"<< \n a b c \n ")),
-            head = Some(SoftAST.CodeString(indexOf("\">> \n a b c \n <<"), " \n a b c \n ")),
+            index = indexOf(s">>\" $newline a b c $newline <<"),
+            startQuote = Quote(indexOf(s">>\"<< $newline a b c $newline ")),
+            head = Some(SoftAST.CodeString(indexOf(s"\">> $newline a b c $newline <<"), s" $newline a b c $newline ")),
             tail = Seq.empty,
-            endQuote = SoftAST.TokenExpected(indexOf("\" \n a b c \n >><<"), Token.Quote)
+            endQuote = SoftAST.TokenExpected(indexOf(s"\" $newline a b c $newline >><<"), Token.Quote)
           )
       }
     }
@@ -79,15 +82,20 @@ class StringLiteralParserSpec extends AnyWordSpec with Matchers {
     "closing quote is provided" when {
       "text is non-empty with newlines" in {
         val string =
-          parseStringLiteral("\" \n a b c \n \"")
+          parseStringLiteral(s"\" $newline a b c $newline \"")
 
         string shouldBe
           SoftAST.StringLiteral(
-            index = indexOf(">>\" \n a b c \n \"<<"),
-            startQuote = Quote(indexOf(">>\"<< \n a b c \n \"")),
-            head = Some(SoftAST.CodeString(indexOf("\">> \n a b c \n <<\""), " \n a b c \n ")),
+            index = indexOf(s">>\" $newline a b c $newline \"<<"),
+            startQuote = Quote(indexOf(s">>\"<< $newline a b c $newline \"")),
+            head = Some(
+              SoftAST.CodeString(
+                index = indexOf(s"\">> $newline a b c $newline <<\""),
+                text = s" $newline a b c $newline "
+              )
+            ),
             tail = Seq.empty,
-            endQuote = Quote(indexOf("\" \n a b c \n >>\"<<"))
+            endQuote = Quote(indexOf(s"\" $newline a b c $newline >>\"<<"))
           )
       }
     }
@@ -165,15 +173,20 @@ class StringLiteralParserSpec extends AnyWordSpec with Matchers {
       "text is non-empty with newlines" when {
         "it is not a path but a regular String literal" in {
           val string =
-            parseStringLiteral("\" \n a b c \n \"")
+            parseStringLiteral(s"\" $newline a b c $newline \"")
 
           string shouldBe
             SoftAST.StringLiteral(
-              index = indexOf(">>\" \n a b c \n \"<<"),
-              startQuote = Quote(indexOf(">>\"<< \n a b c \n \"")),
-              head = Some(SoftAST.CodeString(indexOf("\">> \n a b c \n <<\""), " \n a b c \n ")),
+              index = indexOf(s">>\" $newline a b c $newline \"<<"),
+              startQuote = Quote(indexOf(s">>\"<< $newline a b c $newline \"")),
+              head = Some(
+                SoftAST.CodeString(
+                  index = indexOf(s"\">> $newline a b c $newline <<\""),
+                  text = s" $newline a b c $newline "
+                )
+              ),
               tail = Seq.empty,
-              endQuote = Quote(indexOf("\" \n a b c \n >>\"<<"))
+              endQuote = Quote(indexOf(s"\" $newline a b c $newline >>\"<<"))
             )
         }
 
@@ -223,7 +236,7 @@ class StringLiteralParserSpec extends AnyWordSpec with Matchers {
       string.parts.head.part shouldBe a[SoftAST.Function]
       // second one is a string-literal
       val stringLit = string.parts.last.part.asInstanceOf[SoftAST.StringLiteral]
-      stringLit.startQuote.documentation.value.toCode() shouldBe "// Some comment\n"
+      stringLit.startQuote.documentation.value.toCode() shouldBe s"// Some comment$newline"
       stringLit.head.value.asInstanceOf[SoftAST.CodeString].text shouldBe "some string"
     }
   }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringLiteralParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringLiteralParserSpec.scala
@@ -1,0 +1,231 @@
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.alephium.ralph.lsp.access.util.TestFastParse.assertIsFastParseError
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.OptionValues._
+
+class StringLiteralParserSpec extends AnyWordSpec with Matchers {
+
+  "fail" when {
+    "empty" in {
+      assertIsFastParseError {
+        parseStringLiteral("")
+      }
+    }
+
+    "blank" in {
+      assertIsFastParseError {
+        parseStringLiteral("  ")
+      }
+    }
+
+    "not a quote" in {
+      assertIsFastParseError {
+        parseStringLiteral("b")
+      }
+    }
+  }
+
+  "succeed as a regular String (not a path)" when {
+    "closing quote is missing" when {
+      "text is empty" in {
+        val string =
+          parseStringLiteral("\"")
+
+        string shouldBe
+          SoftAST.StringLiteral(
+            index = indexOf(">>\"<<"),
+            startQuote = Quote(indexOf(">>\"<<")),
+            head = None,
+            tail = Seq.empty,
+            endQuote = SoftAST.TokenExpected(indexOf("\">><<"), Token.Quote)
+          )
+      }
+
+      "text is non-empty" in {
+        val string =
+          parseStringLiteral("\" a b c ")
+
+        string shouldBe
+          SoftAST.StringLiteral(
+            index = indexOf(">>\" a b c <<"),
+            startQuote = Quote(indexOf(">>\"<< a b c ")),
+            head = Some(SoftAST.CodeString(indexOf("\">> a b c <<"), " a b c ")),
+            tail = Seq.empty,
+            endQuote = SoftAST.TokenExpected(indexOf("\" a b c >><<"), Token.Quote)
+          )
+      }
+
+      "text is non-empty with newline" in {
+        val string =
+          parseStringLiteral("\" \n a b c \n ")
+
+        string shouldBe
+          SoftAST.StringLiteral(
+            index = indexOf(">>\" \n a b c \n <<"),
+            startQuote = Quote(indexOf(">>\"<< \n a b c \n ")),
+            head = Some(SoftAST.CodeString(indexOf("\">> \n a b c \n <<"), " \n a b c \n ")),
+            tail = Seq.empty,
+            endQuote = SoftAST.TokenExpected(indexOf("\" \n a b c \n >><<"), Token.Quote)
+          )
+      }
+    }
+
+    "closing quote is provided" when {
+      "text is non-empty with newlines" in {
+        val string =
+          parseStringLiteral("\" \n a b c \n \"")
+
+        string shouldBe
+          SoftAST.StringLiteral(
+            index = indexOf(">>\" \n a b c \n \"<<"),
+            startQuote = Quote(indexOf(">>\"<< \n a b c \n \"")),
+            head = Some(SoftAST.CodeString(indexOf("\">> \n a b c \n <<\""), " \n a b c \n ")),
+            tail = Seq.empty,
+            endQuote = Quote(indexOf("\" \n a b c \n >>\"<<"))
+          )
+      }
+    }
+  }
+
+  "succeed as a path String (contains forward slashes defining a path)" when {
+    "closing quote is missing" when {
+      "head path is empty" in {
+        val string =
+          parseStringLiteral("\"/b")
+
+        string shouldBe
+          SoftAST.StringLiteral(
+            index = indexOf(">>\"/b<<"),
+            startQuote = Quote(indexOf(">>\"<</b")),
+            head = Some(SoftAST.CodeStringExpected(indexOf("\">><</b"))),
+            tail = Seq(
+              SoftAST.Path(
+                index = indexOf("\">>/b<<"),
+                slash = ForwardSlash(indexOf("\">>/<<b")),
+                text = SoftAST.CodeString(indexOf("\"/>>b<<"), "b")
+              )
+            ),
+            endQuote = SoftAST.TokenExpected(indexOf("\"/b>><<"), Token.Quote)
+          )
+      }
+
+      "tail path is empty" in {
+        val string =
+          parseStringLiteral("\"a/")
+
+        string shouldBe
+          SoftAST.StringLiteral(
+            index = indexOf(">>\"a/<<"),
+            startQuote = Quote(indexOf(">>\"<<a/")),
+            head = Some(SoftAST.CodeString(indexOf("\">>a<</"), "a")),
+            tail = Seq(
+              SoftAST.Path(
+                index = indexOf("\"a>>/<<"),
+                slash = ForwardSlash(indexOf("\"a>>/<<")),
+                text = SoftAST.CodeStringExpected(indexOf("\"a/>><<"))
+              )
+            ),
+            endQuote = SoftAST.TokenExpected(indexOf("\"a/>><<"), Token.Quote)
+          )
+      }
+
+      "tail path non-empty" in {
+        val string =
+          parseStringLiteral("\" a / b / c ")
+
+        string shouldBe
+          SoftAST.StringLiteral(
+            index = indexOf(">>\" a / b / c <<"),
+            startQuote = Quote(indexOf(">>\"<< a / b / c ")),
+            head = Some(SoftAST.CodeString(indexOf("\">> a <</ b / c "), " a ")),
+            tail = Seq(
+              SoftAST.Path(
+                index = indexOf("\" a >>/ b <</ c "),
+                slash = ForwardSlash(indexOf("\" a >>/<< b / c ")),
+                text = SoftAST.CodeString(indexOf("\" a />> b <</ c "), " b ")
+              ),
+              SoftAST.Path(
+                index = indexOf("\" a / b >>/ c <<"),
+                slash = ForwardSlash(indexOf("\" a / b >>/<< c ")),
+                text = SoftAST.CodeString(indexOf("\" a / b />> c <<"), " c ")
+              )
+            ),
+            endQuote = SoftAST.TokenExpected(indexOf("\" a / b / c >><<"), Token.Quote)
+          )
+      }
+    }
+
+    "closing quote is provided" when {
+      "text is non-empty with newlines" when {
+        "it is not a path but a regular String literal" in {
+          val string =
+            parseStringLiteral("\" \n a b c \n \"")
+
+          string shouldBe
+            SoftAST.StringLiteral(
+              index = indexOf(">>\" \n a b c \n \"<<"),
+              startQuote = Quote(indexOf(">>\"<< \n a b c \n \"")),
+              head = Some(SoftAST.CodeString(indexOf("\">> \n a b c \n <<\""), " \n a b c \n ")),
+              tail = Seq.empty,
+              endQuote = Quote(indexOf("\" \n a b c \n >>\"<<"))
+            )
+        }
+
+        "it is a path" in {
+          val string =
+            parseStringLiteral("\" a / b / c \"")
+
+          string shouldBe
+            SoftAST.StringLiteral(
+              index = indexOf(">>\" a / b / c \"<<"),
+              startQuote = Quote(indexOf(">>\"<< a / b / c \"")),
+              head = Some(SoftAST.CodeString(indexOf("\">> a <</ b / c \""), " a ")),
+              tail = Seq(
+                SoftAST.Path(
+                  index = indexOf("\" a >>/ b <</ c \""),
+                  slash = ForwardSlash(indexOf("\" a >>/<< b / c \"")),
+                  text = SoftAST.CodeString(indexOf("\" a />> b <</ c \""), " b ")
+                ),
+                SoftAST.Path(
+                  index = indexOf("\" a / b >>/ c <<\""),
+                  slash = ForwardSlash(indexOf("\" a / b >>/<< c \"")),
+                  text = SoftAST.CodeString(indexOf("\" a / b />> c <<\""), " c ")
+                )
+              ),
+              endQuote = Quote(indexOf("\" a / b / c >>\"<<"))
+            )
+        }
+      }
+    }
+  }
+
+  "SoftParser" should {
+    "parse StringLiteral" in {
+      val string =
+        parseSoft {
+          """
+            |fn function() -> {}
+            |
+            |// Some comment
+            |"some string"
+            |
+            |""".stripMargin
+        }
+
+      string.parts should have size 2
+      // first one is a function
+      string.parts.head.part shouldBe a[SoftAST.Function]
+      // second one is a string-literal
+      val stringLit = string.parts.last.part.asInstanceOf[SoftAST.StringLiteral]
+      stringLit.startQuote.documentation.value.toCode() shouldBe "// Some comment\n"
+      stringLit.head.value.asInstanceOf[SoftAST.CodeString].text shouldBe "some string"
+    }
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
@@ -82,6 +82,9 @@ object TestParser {
   def parseStringLiteral(code: String): SoftAST.StringLiteral =
     runSoftParser(StringLiteralParser.parseOrFail(_))(code)
 
+  def parseImport(code: String): SoftAST.Import =
+    runSoftParser(ImportParser.parseOrFail(_))(code)
+
   def parseEvent(code: String): SoftAST.Event =
     runSoftParser(EventParser.parseOrFail(_))(code)
 

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
@@ -79,6 +79,9 @@ object TestParser {
   def parseBString(code: String): SoftAST.BString =
     runSoftParser(BStringParser.parseOrFail(_))(code)
 
+  def parseStringLiteral(code: String): SoftAST.StringLiteral =
+    runSoftParser(StringLiteralParser.parseOrFail(_))(code)
+
   def parseEvent(code: String): SoftAST.Event =
     runSoftParser(EventParser.parseOrFail(_))(code)
 

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -150,6 +150,12 @@ object TestSoftAST {
       token = Token.Quote
     )
 
+  def Import(index: SourceIndex): SoftAST.TokenDocumented[Token.Import.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Import
+    )
+
   def Event(index: SourceIndex): SoftAST.TokenDocumented[Token.Event.type] =
     TokenDocumented(
       index = index,

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -138,6 +138,18 @@ object TestSoftAST {
       token = Token.Tick
     )
 
+  def ForwardSlash(index: SourceIndex): SoftAST.TokenDocumented[Token.ForwardSlash.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.ForwardSlash
+    )
+
+  def Quote(index: SourceIndex): SoftAST.TokenDocumented[Token.Quote.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Quote
+    )
+
   def Event(index: SourceIndex): SoftAST.TokenDocumented[Token.Event.type] =
     TokenDocumented(
       index = index,


### PR DESCRIPTION
- Implementing new parsers is still on hold, but parsing `import` statements is required to complete scoping rules for integration.
- Towards #104.