### PR TITLE
`SoftAST`: Implements go-to-definition for local variables and arguments.

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
@@ -160,7 +160,7 @@ object SourceIndexExtra {
       }
 
     def containsSoft(child: SourceIndex): Boolean =
-      sourceIndex contains child.from
+      sourceIndex.from >= child.from && child.to <= sourceIndex.to
 
     def isBehind(that: SourceIndex): Boolean =
       isBehind(that.from)

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
@@ -94,7 +94,7 @@ object SourceIndexExtra {
       child: Option[SourceIndex]): Boolean =
     (parent, child) match {
       case (Some(parent), Some(child)) =>
-        parent contains child
+        parent containsStrict child
 
       case (_, _) =>
         false
@@ -149,7 +149,8 @@ object SourceIndexExtra {
     def contains(index: Int): Boolean =
       index >= from && index <= to
 
-    def contains(child: SourceIndex): Boolean =
+    /** Strict AST also checks if the fileURIs are matching */
+    def containsStrict(child: SourceIndex): Boolean =
       (sourceIndex.fileURI, child.fileURI) match {
         case (Some(parentURI), Some(childURI)) if parentURI == childURI =>
           sourceIndex contains child.from

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
@@ -159,6 +159,9 @@ object SourceIndexExtra {
           false
       }
 
+    def containsSoft(child: SourceIndex): Boolean =
+      sourceIndex contains child.from
+
     def isBehind(that: SourceIndex): Boolean =
       isBehind(that.from)
 

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
@@ -23,16 +23,16 @@ import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object BlockParser {
 
-  def parse[Unknown: P]: P[SoftAST.BlockClause] =
+  def parse[Unknown: P]: P[SoftAST.Block] =
     parse(required = true)
 
-  def parseOrFail[Unknown: P]: P[SoftAST.BlockClause] =
+  def parseOrFail[Unknown: P]: P[SoftAST.Block] =
     parse(required = false)
 
   def body[Unknown: P]: P[SoftAST.BlockBody] =
     body()
 
-  private def parse[Unknown: P](required: Boolean): P[SoftAST.BlockClause] =
+  private def parse[Unknown: P](required: Boolean): P[SoftAST.Block] =
     P {
       Index ~
         TokenParser.parse(required, Token.OpenCurly) ~
@@ -43,7 +43,7 @@ private object BlockParser {
         Index
     } map {
       case (from, openCurly, preBodySpace, body, postBodySpace, closeCurly, to) =>
-        SoftAST.BlockClause(
+        SoftAST.Block(
           index = range(from, to),
           openCurly = openCurly,
           preBodySpace = preBodySpace,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ExpressionParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ExpressionParser.scala
@@ -43,9 +43,9 @@ private object ExpressionParser {
         InfixCallParser.parseOrFail |
         MethodCallParser.parseOrFail |
         BlockParser.parseOrFail |
-        ReturnStatementParser.parseOrFail |
-        ForLoopParser.parseOrFail |
-        WhileLoopParser.parseOrFail |
+        ReturnParser.parseOrFail |
+        ForParser.parseOrFail |
+        WhileParser.parseOrFail |
         VariableDeclarationParser.parseOrFail |
         MutableBindingParser.parseOrFail |
         ReferenceCallParser.parseOrFail |

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ForParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ForParser.scala
@@ -26,7 +26,7 @@ private object ForParser {
         SpaceParser.parseOrFail.? ~
         TokenParser.parse(Token.CloseParen) ~
         SpaceParser.parseOrFail.? ~
-        BlockParser.parse ~
+        BlockParser.parseOrFail.? ~
         Index
     } map {
       case (from,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ForParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ForParser.scala
@@ -5,9 +5,9 @@ import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
-private object ForLoopParser {
+private object ForParser {
 
-  def parseOrFail[Unknown: P]: P[SoftAST.ForStatement] =
+  def parseOrFail[Unknown: P]: P[SoftAST.For] =
     P {
       Index ~
         TokenParser.parseOrFail(Token.For) ~
@@ -49,7 +49,7 @@ private object ForLoopParser {
             block,
             to
           ) =>
-        SoftAST.ForStatement(
+        SoftAST.For(
           index = range(from, to),
           forToken = forToken,
           postForSpace = postForSpace,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReturnParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReturnParser.scala
@@ -5,9 +5,9 @@ import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
-private object ReturnStatementParser {
+private object ReturnParser {
 
-  def parseOrFail[Unknown: P]: P[SoftAST.ReturnStatement] =
+  def parseOrFail[Unknown: P]: P[SoftAST.Return] =
     P {
       Index ~
         TokenParser.parseOrFail(Token.Return) ~
@@ -17,7 +17,7 @@ private object ReturnStatementParser {
         Index
     } map {
       case (from, returnStatement, space, expression, to) =>
-        SoftAST.ReturnStatement(
+        SoftAST.Return(
           index = range(from, to),
           returnToken = returnStatement,
           preExpressionSpace = space,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/SoftParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/SoftParser.scala
@@ -23,6 +23,6 @@ import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
 object SoftParser {
 
   def parse[Unknown: P]: P[SoftAST.BlockBody] =
-    P(Start ~ BlockParser.body ~ End)
+    P(Start ~ BlockBodyParser.parseOrFail() ~ End)
 
 }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateParser.scala
@@ -18,7 +18,7 @@ private object TemplateParser {
         ParameterParser.parseOrFail.? ~
         SpaceParser.parseOrFail.? ~
         InheritanceParser.parseOrFail.rep ~
-        BlockParser.parse ~
+        BlockParser.parseOrFail.? ~
         Index
     } map {
       case (from, abstractToken, templateType, preIdentifierSpace, identifier, preParamSpace, params, postParamSpace, inheritance, block, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeAssignmentParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeAssignmentParser.scala
@@ -20,11 +20,11 @@ private object TypeAssignmentParser {
       case (from, left, postIdentifierSpace, equalToken, postEqualSpace, right, to) =>
         SoftAST.TypeAssignment(
           index = range(from, to),
-          name = left,
+          expressionLeft = left,
           preColonSpace = postIdentifierSpace,
           colon = equalToken,
           postColonSpace = postEqualSpace,
-          tpe = right
+          expressionRight = right
         )
     }
 

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/WhileParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/WhileParser.scala
@@ -18,7 +18,7 @@ private object WhileParser {
         SpaceParser.parseOrFail.? ~
         TokenParser.parse(Token.CloseParen) ~
         SpaceParser.parseOrFail.? ~
-        BlockParser.parse ~
+        BlockParser.parseOrFail.? ~
         Index
     } map {
       case (from, whileToken, postWhileSpace, openParen, postOpenParenSpace, expression, postExpressionSpace, closeParen, postCloseParenSpace, block, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/WhileParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/WhileParser.scala
@@ -5,9 +5,9 @@ import fastparse.NoWhitespace.noWhitespaceImplicit
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
-private object WhileLoopParser {
+private object WhileParser {
 
-  def parseOrFail[Unknown: P]: P[SoftAST.WhileStatement] =
+  def parseOrFail[Unknown: P]: P[SoftAST.While] =
     P {
       Index ~
         TokenParser.parseOrFail(Token.While) ~
@@ -22,7 +22,7 @@ private object WhileLoopParser {
         Index
     } map {
       case (from, whileToken, postWhileSpace, openParen, postOpenParenSpace, expression, postExpressionSpace, closeParen, postCloseParenSpace, block, to) =>
-        SoftAST.WhileStatement(
+        SoftAST.While(
           index = range(from, to),
           whileToken = whileToken,
           postWhileSpace = postWhileSpace,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -334,6 +334,7 @@ object SoftAST {
       documentation: Option[Comments],
       code: CodeString)
     extends IdentifierAST
+       with ExpressionAST
        with CodeDocumentedAST
 
   case class IdentifierExpected(
@@ -364,7 +365,7 @@ object SoftAST {
        with CodeDocumentedAST
        with BodyPartAST
 
-  sealed trait ReferenceCallOrIdentifier extends ExpressionAST {
+  sealed trait ReferenceCallOrIdentifier extends BodyPartAST {
 
     def identifier: IdentifierAST =
       this match {
@@ -383,6 +384,7 @@ object SoftAST {
       preArgumentsSpace: Option[Space],
       arguments: Group[Token.OpenParen.type, Token.CloseParen.type])
     extends ReferenceCallOrIdentifier
+       with ExpressionAST
 
   case class InfixExpression(
       index: SourceIndex,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -407,14 +407,14 @@ object SoftAST {
       rightExpression: ReferenceCallOrIdentifier)
     extends SoftAST
 
-  case class ReturnStatement(
+  case class Return(
       index: SourceIndex,
       returnToken: TokenDocumented[Token.Return.type],
       preExpressionSpace: Option[Space],
       rightExpression: ExpressionAST)
     extends ExpressionAST
 
-  case class ForStatement(
+  case class For(
       index: SourceIndex,
       forToken: TokenDocumented[Token.For.type],
       postForSpace: Option[Space],
@@ -435,7 +435,7 @@ object SoftAST {
       block: SoftAST.Block)
     extends ExpressionAST
 
-  case class WhileStatement(
+  case class While(
       index: SourceIndex,
       whileToken: TokenDocumented[Token.While.type],
       postWhileSpace: Option[Space],

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -168,7 +168,7 @@ object SoftAST {
       params: Option[Group[Token.OpenParen.type, Token.CloseParen.type]],
       postParamSpace: Option[Space],
       inheritance: Seq[Inheritance],
-      block: Block)
+      block: Option[Block])
     extends BodyPartAST
 
   case class Abstract(
@@ -432,7 +432,7 @@ object SoftAST {
       postExpression3Space: Option[Space],
       closeParen: TokenDocExpectedAST[Token.CloseParen.type],
       postCloseParenSpace: Option[Space],
-      block: Block)
+      block: Option[Block])
     extends ExpressionAST
 
   case class While(
@@ -445,7 +445,7 @@ object SoftAST {
       postExpressionSpace: Option[Space],
       closeParen: TokenDocExpectedAST[Token.CloseParen.type],
       postCloseParenSpace: Option[Space],
-      block: Block)
+      block: Option[Block])
     extends ExpressionAST
 
   case class Assignment(

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -309,7 +309,13 @@ object SoftAST {
       postHeadExpressionSpace: Option[Space],
       tailExpressions: Seq[GroupTail],
       closeToken: TokenDocExpectedAST[C])
-    extends ExpressionAST
+    extends ExpressionAST {
+
+    /** Collects all expressions defined in this group */
+    def expressions: Iterable[ExpressionAST] =
+      headExpression ++ tailExpressions.map(_.expression)
+
+  }
 
   /** Comma separated tail expressions of a [[Group]] */
   case class GroupTail(

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -168,7 +168,7 @@ object SoftAST {
       params: Option[Group[Token.OpenParen.type, Token.CloseParen.type]],
       postParamSpace: Option[Space],
       inheritance: Seq[Inheritance],
-      block: BlockClause)
+      block: Block)
     extends BodyPartAST
 
   case class Abstract(
@@ -230,7 +230,7 @@ object SoftAST {
       postReferenceSpace: Option[Space])
     extends SoftAST
 
-  case class BlockClause(
+  case class Block(
       index: SourceIndex,
       openCurly: TokenDocExpectedAST[Token.OpenCurly.type],
       preBodySpace: Option[Space],
@@ -260,7 +260,7 @@ object SoftAST {
       preSignatureSpace: Option[Space],
       signature: FunctionSignature,
       postSignatureSpace: Option[Space],
-      block: Option[BlockClause])
+      block: Option[Block])
     extends BodyPartAST
 
   case class FunctionSignature(
@@ -432,7 +432,7 @@ object SoftAST {
       postExpression3Space: Option[Space],
       closeParen: TokenDocExpectedAST[Token.CloseParen.type],
       postCloseParenSpace: Option[SoftAST.Space],
-      block: SoftAST.BlockClause)
+      block: SoftAST.Block)
     extends ExpressionAST
 
   case class WhileStatement(
@@ -445,7 +445,7 @@ object SoftAST {
       postExpressionSpace: Option[Space],
       closeParen: TokenDocExpectedAST[Token.CloseParen.type],
       postCloseParenSpace: Option[SoftAST.Space],
-      block: SoftAST.BlockClause)
+      block: SoftAST.Block)
     extends ExpressionAST
 
   case class Assignment(

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -17,6 +17,7 @@
 package org.alephium.ralph.lsp.access.compiler.parser.soft.ast
 
 import org.alephium.ralph.SourceIndex
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.SourceIndexExtension
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST.collectASTs
 import org.alephium.ralph.lsp.utils.Node
 
@@ -48,6 +49,21 @@ sealed trait SoftAST extends Product { self =>
   def toStringPretty(): String =
     s"${self.getClass.getSimpleName}: ${self.index}"
 
+  /**
+   * Checks if `this` AST's position is before the `anchor` AST's position.
+   *
+   * @param anchor The AST with which the position of `current` is compared.
+   * @return `true` if `current`'s position is before `anchor`'s position, `false` otherwise.
+   */
+  def isBehind(anchor: SoftAST): Boolean =
+    this.index isBehind anchor.index
+
+  def contains(anchor: SoftAST): Boolean =
+    contains(anchor.index)
+
+  def contains(anchor: SourceIndex): Boolean =
+    this.index containsSoft anchor
+
 }
 
 object SoftAST {
@@ -65,6 +81,9 @@ object SoftAST {
 
     def toStringTree(): String =
       node.toStringTree(_.toStringPretty())
+
+    def contains(anchor: Node[SoftAST, SoftAST]): Boolean =
+      node.data contains anchor.data
 
   }
 

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -431,8 +431,8 @@ object SoftAST {
       expression3: ExpressionAST,
       postExpression3Space: Option[Space],
       closeParen: TokenDocExpectedAST[Token.CloseParen.type],
-      postCloseParenSpace: Option[SoftAST.Space],
-      block: SoftAST.Block)
+      postCloseParenSpace: Option[Space],
+      block: Block)
     extends ExpressionAST
 
   case class While(
@@ -444,8 +444,8 @@ object SoftAST {
       expression: ExpressionAST,
       postExpressionSpace: Option[Space],
       closeParen: TokenDocExpectedAST[Token.CloseParen.type],
-      postCloseParenSpace: Option[SoftAST.Space],
-      block: SoftAST.Block)
+      postCloseParenSpace: Option[Space],
+      block: Block)
     extends ExpressionAST
 
   case class Assignment(

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -461,11 +461,11 @@ object SoftAST {
 
   case class TypeAssignment(
       index: SourceIndex,
-      name: ExpressionAST,
+      expressionLeft: ExpressionAST,
       preColonSpace: Option[Space],
       colon: TokenDocumented[Token.Colon.type],
       postColonSpace: Option[Space],
-      tpe: ExpressionAST)
+      expressionRight: ExpressionAST)
     extends ExpressionAST
 
   case class AssignmentAccessModifier(

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/GroupParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/GroupParserSpec.scala
@@ -121,7 +121,7 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
     val headExpression =
       tuple.headExpression.value.asInstanceOf[SoftAST.TypeAssignment]
 
-    headExpression.name shouldBe
+    headExpression.expressionLeft shouldBe
       Identifier(
         index = indexOf("(>>aaa<<: typename"),
         text = "aaa"
@@ -131,7 +131,7 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
 
     headExpression.postColonSpace.value shouldBe SpaceOne(indexOf("(aaa:>> <<typename"))
 
-    headExpression.tpe shouldBe
+    headExpression.expressionRight shouldBe
       Identifier(
         index = indexOf("(aaa: >>typename<<"),
         text = "typename"
@@ -153,13 +153,13 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
     val bbbTypeAssignment =
       bbb.expression.asInstanceOf[SoftAST.TypeAssignment]
 
-    bbbTypeAssignment.name shouldBe
+    bbbTypeAssignment.expressionLeft shouldBe
       Identifier(
         index = indexOf("(aaa: typename, >>bbb<<: type2)"),
         text = "bbb"
       )
 
-    bbbTypeAssignment.tpe shouldBe
+    bbbTypeAssignment.expressionRight shouldBe
       Identifier(
         index = indexOf("(aaa: typename, bbb: >>type2<<)"),
         text = "type2"
@@ -180,16 +180,16 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
 
     val bbb = tupleTail.expression.asInstanceOf[SoftAST.TypeAssignment]
 
-    bbb.name shouldBe
+    bbb.expressionLeft shouldBe
       Identifier(
         index = indexOf("(aaa: typename, >>bbb<<: (tuple1, tuple2))"),
         text = "bbb"
       )
 
     // A quick text to check that the tuple is actually a tuple
-    bbb.tpe shouldBe a[SoftAST.Group[_, _]]
+    bbb.expressionRight shouldBe a[SoftAST.Group[_, _]]
     // Convert the tpe to code and it should be the tuple
-    bbb.tpe.toCode() shouldBe "(tuple1, tuple2)"
+    bbb.expressionRight.toCode() shouldBe "(tuple1, tuple2)"
   }
 
   "nested tuples" in {

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
@@ -49,7 +49,7 @@ object TestParser {
     runSoftParser(ParameterParser.parse(_))(code)
 
   def parseBlockBody(code: String): SoftAST.BlockBody =
-    runSoftParser(BlockParser.body(_))(code)
+    runSoftParser(BlockBodyParser.parseOrFail()(_))(code)
 
   def parseComment(code: String): SoftAST.Comments =
     runSoftParser(CommentParser.parseOrFail(_))(code)

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeAssignmentParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeAssignmentParserSpec.scala
@@ -17,11 +17,11 @@ class TypeAssignmentParserSpec extends AnyWordSpec {
       assignment shouldBe
         SoftAST.TypeAssignment(
           index = indexOf(">>: Type<<"),
-          name = SoftAST.ExpressionExpected(indexOf(">><<: Type")),
+          expressionLeft = SoftAST.ExpressionExpected(indexOf(">><<: Type")),
           preColonSpace = None,
           colon = Colon(indexOf(">>:<< Type")),
           postColonSpace = Some(SpaceOne(indexOf(":>> <<Type"))),
-          tpe = Identifier(indexOf(": >>Type<<"), "Type")
+          expressionRight = Identifier(indexOf(": >>Type<<"), "Type")
         )
     }
   }
@@ -35,11 +35,11 @@ class TypeAssignmentParserSpec extends AnyWordSpec {
         assignment shouldBe
           SoftAST.TypeAssignment(
             index = indexOf(">>name : Type<<"),
-            name = Identifier(indexOf(">>name<< : Type"), "name"),
+            expressionLeft = Identifier(indexOf(">>name<< : Type"), "name"),
             preColonSpace = Some(SpaceOne(indexOf("name>> <<: Type"))),
             colon = Colon(indexOf("name >>:<< Type")),
             postColonSpace = Some(SpaceOne(indexOf("name :>> <<Type"))),
-            tpe = Identifier(indexOf("name : >>Type<<"), "Type")
+            expressionRight = Identifier(indexOf("name : >>Type<<"), "Type")
           )
       }
     }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/ScopeWalker.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/ScopeWalker.scala
@@ -19,11 +19,12 @@ package org.alephium.ralph.lsp.pc.search.gotodef
 import org.alephium.ralph.Ast
 import org.alephium.ralph.lsp.access.compiler.ast.AstExtra
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
 import org.alephium.ralph.lsp.utils.Node
 
 import scala.collection.mutable.ListBuffer
 
-private object ScopeWalker {
+private[search] object ScopeWalker {
 
   /**
    * Navigates the nodes within the scope of the `anchor` node, starting from the `from` node.
@@ -61,6 +62,47 @@ private object ScopeWalker {
         // - And is it before the anchor node?
         // - If it's defined after the anchor node (node in scope), then only add it if currently collected items are empty.
         case node @ Node(ast, _) if pf.isDefinedAt(node) && (AstExtra.isBehind(ast, anchor) || found.isEmpty) =>
+          found addOne pf(node)
+
+        case _ =>
+        // ignore the rest
+      }
+
+    found
+
+  }
+
+  /**
+   * Note: This is a direct clone of the above `walk` function for strict-ast.
+   *
+   * Navigates the nodes within the scope of the `anchor` node, starting from the `from` node.
+   *
+   * @param from   The node where the search starts.
+   * @param anchor The node which is being scoped and where the search ends.
+   *               If the collected result is empty, nodes after the `anchor`'s position
+   *               are processed until at least one item is collected.
+   * @param pf     Only the Nodes defined by this partial function are collected.
+   * @return Nodes within the scope of the anchor AST.
+   */
+  def walk[T](
+      from: Node[SoftAST, SoftAST],
+      anchor: SoftAST
+    )(pf: PartialFunction[Node[SoftAST, SoftAST], T]): Iterable[T] = {
+    val found  = ListBuffer.empty[T]
+    var walker = from.walkDown
+
+    while (walker.hasNext)
+      walker.next() match {
+        // Check: Is this a scoped node that does not contain the anchor node within its scope? If yes, drop all its child nodes.
+        case block @ Node(_: SoftAST.While | _: SoftAST.For | _: SoftAST.Template | _: SoftAST.Function | _: SoftAST.Block, _) if !block.data.contains(anchor) =>
+          // drop all child nodes
+          walker = walker dropWhile block.contains
+
+        // Check:
+        // - Is this node (i.e. within the scope) defined by the partial-function?
+        // - And is it before the anchor node?
+        // - If it's defined after the anchor node (node in scope), then only add it if currently collected items are empty.
+        case node @ Node(ast, _) if pf.isDefinedAt(node) && (ast.isBehind(anchor) || found.isEmpty) =>
           found addOne pf(node)
 
         case _ =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/ScopeWalker.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/ScopeWalker.scala
@@ -77,6 +77,9 @@ private[search] object ScopeWalker {
    *
    * Navigates the nodes within the scope of the `anchor` node, starting from the `from` node.
    *
+   * TODO: Improve performance: `dropWhile` drops elements linearly which can be slow.
+   *       Removing child nodes directly from the Node’s `children` field will be faster.
+   *
    * @param from   The node where the search starts.
    * @param anchor The node which is being scoped and where the search ends.
    *               If the collected result is empty, nodes after the `anchor`'s position
@@ -104,6 +107,8 @@ private[search] object ScopeWalker {
         // - If it's defined after the anchor node (node in scope), then only add it if currently collected items are empty.
         case node @ Node(ast, _) if pf.isDefinedAt(node) && (ast.isBehind(anchor) || found.isEmpty) =>
           found addOne pf(node)
+          // This node is processed, drop all its children.
+          walker = walker dropWhile node.contains
 
         case _ =>
         // ignore the rest

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/soft/gotodef/GoToDefCodeString.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/soft/gotodef/GoToDefCodeString.scala
@@ -18,7 +18,11 @@ private object GoToDefCodeString {
       node: Node[SoftAST.CodeString, SoftAST],
       sourceCode: SourceLocation.CodeSoft): Iterator[SourceLocation.GoToDefSoft] =
     node.parent match {
-      case Some(node @ Node(id @ SoftAST.Identifier(_, _, _), _)) =>
+      case Some(Node(_: SoftAST.Space, _)) =>
+        // Spaces do not require go-to-definition
+        Iterator.empty
+
+      case Some(node @ Node(id: SoftAST.Identifier, _)) =>
         GoToDefIdentifier(
           identNode = node.upcast(id),
           sourceCode = sourceCode

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/soft/gotodef/GoToDefIdentifier.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/soft/gotodef/GoToDefIdentifier.scala
@@ -22,79 +22,17 @@ private object GoToDefIdentifier {
       identNode: Node[SoftAST.Identifier, SoftAST],
       sourceCode: SourceLocation.CodeSoft): Iterator[SourceLocation.GoToDefSoft] =
     identNode.parent match {
-      case Some(Node(assignment: SoftAST.Assignment, _)) if assignment.expressionLeft == identNode.data =>
-        Iterator.single(
-          SourceLocation.NodeSoft(
-            ast = identNode.data.code,
-            source = sourceCode
-          )
-        )
-
-      case Some(Node(assignment: SoftAST.MutableBinding, _)) if assignment.identifier == identNode.data =>
-        Iterator.single(
-          SourceLocation.NodeSoft(
-            ast = identNode.data.code,
-            source = sourceCode
-          )
-        )
+      case Some(Node(_: SoftAST.ReferenceCall | _: SoftAST.DotCall, _)) =>
+        // TODO: Handle function and dot calls
+        Iterator.empty
 
       case _ =>
-        searchScope(
+        // Everything else
+        // TODO: Also execute inherited variables and arguments here, possibly in parallel.
+        GoToDefLocalVariableDeclaration(
           identNode = identNode,
           sourceCode = sourceCode
         )
-    }
-
-  /**
-   * Searches for definitions given the location of the identifier node [[SoftAST.Identifier]]
-   * and the [[SourceLocation]] of the identifier.
-   *
-   * @param identNode  The node representing the identifier being searched.
-   * @param sourceCode The body-part and its source code state where this search is executed.
-   * @return An iterator over definition search results.
-   */
-  private def searchScope(
-      identNode: Node[SoftAST.Identifier, SoftAST],
-      sourceCode: SourceLocation.CodeSoft): Iterator[SourceLocation.NodeSoft[SoftAST.CodeString]] =
-    sourceCode // search within scope
-      .body
-      .toNode
-      .walkDown
-      .flatMap {
-        case Node(variable: SoftAST.VariableDeclaration, _) =>
-          checkVariableDeclaration(
-            variableDec = variable,
-            identNode = identNode,
-            sourceCode = sourceCode
-          )
-
-        case _ =>
-          Iterator.empty
-      }
-
-  /**
-   * Checks if the given identifier is defined by the specified variable declaration.
-   *
-   * @param variableDec The variable declaration to check.
-   * @param identNode   The node representing the identifier being searched for.
-   * @param sourceCode  The body part containing the variable declaration.
-   * @return The [[SourceLocation]] of the [[SoftAST.CodeString]] where the identifier is defined, if found, else [[None]].
-   */
-  private def checkVariableDeclaration(
-      variableDec: SoftAST.VariableDeclaration,
-      identNode: Node[SoftAST.Identifier, SoftAST],
-      sourceCode: SourceLocation.CodeSoft): Option[SourceLocation.NodeSoft[SoftAST.CodeString]] =
-    variableDec.assignment.expressionLeft match {
-      case id: SoftAST.Identifier if id.code.text == identNode.data.code.text =>
-        Some(
-          SourceLocation.NodeSoft(
-            ast = id.code,
-            source = sourceCode
-          )
-        )
-
-      case _ =>
-        None
     }
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/soft/gotodef/GoToDefLocalVariableDeclaration.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/soft/gotodef/GoToDefLocalVariableDeclaration.scala
@@ -1,6 +1,7 @@
 package org.alephium.ralph.lsp.pc.search.soft.gotodef
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.pc.search.gotodef.ScopeWalker
 import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
 import org.alephium.ralph.lsp.utils.Node
 
@@ -56,21 +57,20 @@ object GoToDefLocalVariableDeclaration {
   private def searchScope(
       identNode: Node[SoftAST.Identifier, SoftAST],
       sourceCode: SourceLocation.CodeSoft): Iterator[SourceLocation.NodeSoft[SoftAST.CodeString]] =
-    sourceCode // search within scope
-      .body
-      .toNode
-      .walkDown
-      .flatMap {
+    ScopeWalker
+      .walk(
+        from = sourceCode.body.toNode,
+        anchor = identNode.data
+      ) {
         case Node(variable: SoftAST.VariableDeclaration, _) =>
           checkVariableDeclaration(
             variableDec = variable,
             identNode = identNode,
             sourceCode = sourceCode
           )
-
-        case _ =>
-          Iterator.empty
       }
+      .iterator
+      .flatten
 
   /**
    * Checks if the given identifier is defined by the specified variable declaration.

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/soft/gotodef/GoToDefLocalVariableDeclaration.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/soft/gotodef/GoToDefLocalVariableDeclaration.scala
@@ -1,0 +1,100 @@
+package org.alephium.ralph.lsp.pc.search.soft.gotodef
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
+import org.alephium.ralph.lsp.utils.Node
+
+object GoToDefLocalVariableDeclaration {
+
+  /**
+   * Searches for definitions given the location of the identifier node [[SoftAST.Identifier]]
+   * and the [[SourceLocation]] of the identifier.
+   *
+   * Steps:
+   *  - First, checks if the current [[SoftAST.Identifier]] itself belongs to a definition.
+   *  - Second, executes search for all nodes within the scope of the current block of code.
+   *
+   * @param identNode  The node representing the identifier being searched.
+   * @param sourceCode The body-part and its source code state where this search is executed.
+   * @return An iterator over definition search results.
+   */
+  def apply(
+      identNode: Node[SoftAST.Identifier, SoftAST],
+      sourceCode: SourceLocation.CodeSoft): Iterator[SourceLocation.GoToDefSoft] =
+    identNode.parent match {
+      case Some(Node(assignment: SoftAST.Assignment, _)) if assignment.expressionLeft == identNode.data =>
+        Iterator.single(
+          SourceLocation.NodeSoft(
+            ast = identNode.data.code,
+            source = sourceCode
+          )
+        )
+
+      case Some(Node(assignment: SoftAST.MutableBinding, _)) if assignment.identifier == identNode.data =>
+        Iterator.single(
+          SourceLocation.NodeSoft(
+            ast = identNode.data.code,
+            source = sourceCode
+          )
+        )
+
+      case _ =>
+        searchScope(
+          identNode = identNode,
+          sourceCode = sourceCode
+        )
+    }
+
+  /**
+   * Searches for definitions given the location of the identifier node [[SoftAST.Identifier]]
+   * and the [[SourceLocation]] of the identifier.
+   *
+   * @param identNode  The node representing the identifier being searched.
+   * @param sourceCode The body-part and its source code state where this search is executed.
+   * @return An iterator over definition search results.
+   */
+  private def searchScope(
+      identNode: Node[SoftAST.Identifier, SoftAST],
+      sourceCode: SourceLocation.CodeSoft): Iterator[SourceLocation.NodeSoft[SoftAST.CodeString]] =
+    sourceCode // search within scope
+      .body
+      .toNode
+      .walkDown
+      .flatMap {
+        case Node(variable: SoftAST.VariableDeclaration, _) =>
+          checkVariableDeclaration(
+            variableDec = variable,
+            identNode = identNode,
+            sourceCode = sourceCode
+          )
+
+        case _ =>
+          Iterator.empty
+      }
+
+  /**
+   * Checks if the given identifier is defined by the specified variable declaration.
+   *
+   * @param variableDec The variable declaration to check.
+   * @param identNode   The node representing the identifier being searched for.
+   * @param sourceCode  The body part containing the variable declaration.
+   * @return The [[SourceLocation]] of the [[SoftAST.CodeString]] where the identifier is defined, if found, else [[None]].
+   */
+  private def checkVariableDeclaration(
+      variableDec: SoftAST.VariableDeclaration,
+      identNode: Node[SoftAST.Identifier, SoftAST],
+      sourceCode: SourceLocation.CodeSoft): Option[SourceLocation.NodeSoft[SoftAST.CodeString]] =
+    variableDec.assignment.expressionLeft match {
+      case id: SoftAST.Identifier if id.code.text == identNode.data.code.text =>
+        Some(
+          SourceLocation.NodeSoft(
+            ast = id.code,
+            source = sourceCode
+          )
+        )
+
+      case _ =>
+        None
+    }
+
+}

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToAssignmentsInContractSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToAssignmentsInContractSpec.scala
@@ -24,7 +24,7 @@ class GoToAssignmentsInContractSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "assigned variable does not exist" in {
-      goToDefinitionStrict()(
+      goToDefinition()(
         """
           |Contract GoToAssignment() {
           |
@@ -40,7 +40,7 @@ class GoToAssignmentsInContractSpec extends AnyWordSpec with Matchers {
   "return non-empty" when {
     "assigned variables exist" when {
       "locally in the function" in {
-        goToDefinitionStrict()(
+        goToDefinition()(
           """
             |Contract GoToAssignment() {
             |
@@ -54,7 +54,7 @@ class GoToAssignmentsInContractSpec extends AnyWordSpec with Matchers {
       }
 
       "as function argument" in {
-        goToDefinitionStrict()(
+        goToDefinition()(
           """
             |Contract GoToAssignment() {
             |
@@ -67,7 +67,7 @@ class GoToAssignmentsInContractSpec extends AnyWordSpec with Matchers {
       }
 
       "as template argument" in {
-        goToDefinitionStrict()(
+        goToDefinition()(
           """
             |Contract GoToAssignment(mut >>counter<<: U256) {
             |

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToNamedVarSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToNamedVarSpec.scala
@@ -24,7 +24,7 @@ class GoToNamedVarSpec extends AnyWordSpec with Matchers {
 
   "return self" when {
     "variable definition is selected" in {
-      goToDefinitionStrict()(
+      goToDefinition()(
         """
           |Contract Test() {
           |
@@ -38,7 +38,7 @@ class GoToNamedVarSpec extends AnyWordSpec with Matchers {
 
     "duplicates exist" when {
       "first duplicate is selected" in {
-        goToDefinitionStrict()(
+        goToDefinition()(
           """
             |Contract Test() {
             |
@@ -52,7 +52,7 @@ class GoToNamedVarSpec extends AnyWordSpec with Matchers {
       }
 
       "second duplicate is selected" in {
-        goToDefinitionStrict()(
+        goToDefinition()(
           """
             |Contract Test() {
             |


### PR DESCRIPTION
- Handles go-to-definition cases for local variables, mutable bindings and type assignments. Next PR will handle inheritance.
  - Test-cases executing `goToDefinitionSoft` work only on `SoftAST` because strict-ast results in parser errors.
  - Test-cases executing `goToDefinitionStrict` work only on strict-ast because they're missing implementation for SoftAST. 
  - Test-cases executing `goToDefinition` work on both.
- The commits messages are descriptive and can be reviewed independently.
- Towards #104.
