### PR TITLE
Number: Defer parsing space when unit is invalid

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/NumberParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/NumberParser.scala
@@ -12,16 +12,14 @@ private object NumberParser {
       Index ~
         CommentParser.parseOrFail.? ~
         number ~
-        SpaceParser.parseOrFail.? ~
-        TokenParser.parseOrFail(Token.AlphLowercase).? ~
+        unitAlph.? ~
         Index
     } map {
-      case (from, documentation, digits, postDigitSpace, unit, to) =>
+      case (from, documentation, digits, unit, to) =>
         SoftAST.Number(
           index = range(from, to),
           documentation = documentation,
           number = digits,
-          space = postDigitSpace,
           unit = unit
         )
     }
@@ -67,6 +65,29 @@ private object NumberParser {
         CharsWhileIn("0-9_") ~
         ("." ~ CharsWhileIn("0-9_")).? ~
         (!Token.AlphLowercase.lexeme ~ (StringIn("e-", "E-") | CharIn("0-9a-zA-Z_"))).rep
+    }
+
+  /**
+   * Parses the space and the unit `alph`.
+   *
+   * {{{
+   *   1234.0 alph
+   *         ↑___↑
+   * }}}
+   */
+  private def unitAlph[Unknown: P]: P[SoftAST.UnitAlph] =
+    P {
+      Index ~
+        SpaceParser.parseOrFail.? ~
+        TokenParser.parseOrFail(Token.AlphLowercase) ~
+        Index
+    } map {
+      case (from, space, unit, to) =>
+        SoftAST.UnitAlph(
+          index = range(from, to),
+          space = space,
+          unit = unit
+        )
     }
 
 }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -533,9 +533,14 @@ object SoftAST {
       index: SourceIndex,
       documentation: Option[Comments],
       number: CodeString,
-      space: Option[Space],
-      unit: Option[TokenDocumented[Token.AlphLowercase.type]])
+      unit: Option[UnitAlph])
     extends ExpressionAST
+
+  case class UnitAlph(
+      index: SourceIndex,
+      space: Option[Space],
+      unit: TokenDocumented[Token.AlphLowercase.type])
+    extends SoftAST
 
   case class BString(
       index: SourceIndex,

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/NumberParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/NumberParserSpec.scala
@@ -78,8 +78,13 @@ class NumberParserSpec extends AnyWordSpec with Matchers {
                 index = indexOf(s">>$numberOnly<<alph"),
                 text = numberOnly
               ),
-              space = None,
-              unit = Some(AlphLowercase(indexOf(s"$numberOnly>>alph<<")))
+              unit = Some(
+                SoftAST.UnitAlph(
+                  index = indexOf(s"$numberOnly>>alph<<"),
+                  space = None,
+                  unit = AlphLowercase(indexOf(s"$numberOnly>>alph<<"))
+                )
+              )
             )
 
         "no sign" in {
@@ -111,8 +116,13 @@ class NumberParserSpec extends AnyWordSpec with Matchers {
                 index = indexOf(s">>$numberOnly<< alph"),
                 text = numberOnly
               ),
-              space = Some(SpaceOne(indexOf(s"$numberOnly>> <<alph"))),
-              unit = Some(AlphLowercase(indexOf(s"$numberOnly >>alph<<")))
+              unit = Some(
+                SoftAST.UnitAlph(
+                  index = indexOf(s"$numberOnly>> alph<<"),
+                  space = Some(SpaceOne(indexOf(s"$numberOnly>> <<alph"))),
+                  unit = AlphLowercase(indexOf(s"$numberOnly >>alph<<"))
+                )
+              )
             )
 
         "no sign" in {
@@ -145,8 +155,13 @@ class NumberParserSpec extends AnyWordSpec with Matchers {
                   index = indexOf(s">>1e-18<<alph"),
                   text = "1e-18"
                 ),
-                space = None,
-                unit = Some(AlphLowercase(indexOf("1e-18>>alph<<")))
+                unit = Some(
+                  SoftAST.UnitAlph(
+                    index = indexOf("1e-18>>alph<<"),
+                    space = None,
+                    unit = AlphLowercase(indexOf("1e-18>>alph<<"))
+                  )
+                )
               )
           }
 
@@ -159,7 +174,6 @@ class NumberParserSpec extends AnyWordSpec with Matchers {
                   index = indexOf(s">>1e-18alp<<"),
                   text = "1e-18alp"
                 ),
-                space = None,
                 unit = None
               )
           }
@@ -175,28 +189,33 @@ class NumberParserSpec extends AnyWordSpec with Matchers {
                   index = indexOf(s">>1e-18<< alph"),
                   text = "1e-18"
                 ),
-                space = Some(SpaceOne(indexOf("1e-18>> <<alph"))),
-                unit = Some(AlphLowercase(indexOf("1e-18 >>alph<<")))
+                unit = Some(
+                  SoftAST.UnitAlph(
+                    index = indexOf("1e-18>> alph<<"),
+                    space = Some(SpaceOne(indexOf("1e-18>> <<alph"))),
+                    unit = AlphLowercase(indexOf("1e-18 >>alph<<"))
+                  )
+                )
               )
           }
 
           "invalid unit - 'alp' is typo" in {
             val body = parseSoft("1e-18 alp")
-            body.parts should have size 2
 
             val number = body.parts.head.part
             val alp    = body.parts.last.part
 
             // Note: alp is not a unit. So it's not parsed as part of the number.
+            //       Since alp is not part of the number, the number should
+            //       not parse the space after 1e-18.
             number shouldBe
               SoftAST.Number(
-                index = indexOf(s">>1e-18 << alp"),
+                index = indexOf(s">>1e-18<< alp"),
                 documentation = None,
                 number = SoftAST.CodeString(
                   index = indexOf(s">>1e-18<< alp"),
                   text = "1e-18"
                 ),
-                space = Some(SpaceOne(indexOf("1e-18>> <<alp"))),
                 unit = None
               )
 

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -202,7 +202,6 @@ object TestSoftAST {
         index = index,
         text = text
       ),
-      space = None,
       unit = None
     )
 


### PR DESCRIPTION
- For example, in `1e-18 alp` the spaces get parsed with the number/digits `>>1e-18 <<alp`.
   It should not parse the space when the unit is invalid `>>1e-18<< alp`.
- Towards #104