### PR TITLE
Expression block

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
@@ -28,7 +28,7 @@ private object BlockParser {
       Index ~
         TokenParser.parseOrFail(Token.OpenCurly) ~
         SpaceParser.parseOrFail.? ~
-        BlockBodyParser.parseOrFail(Token.CloseCurly) ~
+        BlockBodyParser.parseOrFailChild(Token.CloseCurly) ~
         SpaceParser.parseOrFail.? ~
         TokenParser.parse(Token.CloseCurly) ~
         Index

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ExpressionBlockParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ExpressionBlockParser.scala
@@ -1,0 +1,59 @@
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse._
+import fastparse.NoWhitespace.noWhitespaceImplicit
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+
+object ExpressionBlockParser {
+
+  /**
+   * Parses two or more expressions as a block.
+   *
+   * For example, when two or more expressions are defined within a root call:
+   * {{{
+   *   let one = 1
+   *   let two = 2
+   * }}}
+   *
+   * These expressions should be parsed such that they are available within a single tree.
+   * The AST [[SoftAST.ExpressionBlock]] provides this tree. But if these expressions
+   * are already defined within a parent block, for example, within a contract or a function,
+   * then the expression-block is not required.
+   *
+   * @return An expression-block when multiple expressions are defined, otherwise a single expression-ast.
+   */
+  def parseOrFail[Unknown: P]: P[SoftAST.BodyPartAST] =
+    P {
+      Index ~
+        ExpressionParser.parseOrFail ~
+        tail.rep(1).? ~
+        Index
+    } map {
+      case (from, headExpression, Some(tailExpressions), to) =>
+        SoftAST.ExpressionBlock(
+          index = range(from, to),
+          headExpression = headExpression,
+          tailExpressions = tailExpressions
+        )
+
+      case (_, headExpression, None, _) =>
+        headExpression
+    }
+
+  private def tail[Unknown: P]: P[SoftAST.TailExpressionBlock] =
+    P {
+      Index ~
+        SpaceParser.parseOrFail ~
+        ExpressionParser.parseOrFail ~
+        Index
+    } map {
+      case (from, space, ast, to) =>
+        SoftAST.TailExpressionBlock(
+          index = range(from, to),
+          preExpressionSpace = space,
+          expression = ast
+        )
+    }
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/SoftParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/SoftParser.scala
@@ -23,6 +23,6 @@ import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
 object SoftParser {
 
   def parse[Unknown: P]: P[SoftAST.BlockBody] =
-    P(Start ~ BlockBodyParser.parseOrFail() ~ End)
+    P(Start ~ BlockBodyParser.parseOrFailRoot ~ End)
 
 }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -264,6 +264,18 @@ object SoftAST {
       parts: Seq[BlockBodyPart])
     extends SoftAST
 
+  case class ExpressionBlock(
+      index: SourceIndex,
+      headExpression: ExpressionAST,
+      tailExpressions: Seq[TailExpressionBlock])
+    extends BodyPartAST
+
+  case class TailExpressionBlock(
+      index: SourceIndex,
+      preExpressionSpace: Space,
+      expression: ExpressionAST)
+    extends SoftAST
+
   case class BlockBodyPart(
       index: SourceIndex,
       part: BodyPartAST,

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockBodyParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockBodyParserSpec.scala
@@ -1,0 +1,93 @@
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class BlockBodyParserSpec extends AnyWordSpec with Matchers {
+
+  "not wrap a single expression within an ExpressionBlock" when {
+    "only one expression exists" when {
+      def doTest(body: SoftAST.BlockBody) = {
+        // the body contains only a single element
+        body.parts should have size 1
+        // that element is a `VariableDeclaration` and not an `ExpressionBlock`.
+        val variableDeclaration = body.parts.head.part.asInstanceOf[SoftAST.VariableDeclaration]
+        variableDeclaration.toCode() shouldBe "let one = 1"
+      }
+
+      "block is parsed as root" in {
+        doTest {
+          parseBlockBodyRoot {
+            """
+              |let one = 1
+              |""".stripMargin
+          }
+        }
+      }
+
+      "block is parsed as child" in {
+        doTest {
+          parseBlockBodyChild {
+            """
+              |let one = 1
+              |""".stripMargin
+          }
+        }
+      }
+    }
+  }
+
+  "two expressions" should {
+    "wrap multiple expression within ExpressionBlock" when {
+      "block is parsed as root" in {
+        val body =
+          parseBlockBodyRoot {
+            """
+              |let one = 1
+              |true == true
+              |""".stripMargin
+          }
+
+        // now that the body contains two expressions, it should wrap it in an ExpressionBlock
+        // so it still contains only one element
+        body.parts should have size 1
+        val expressionBlock = body.parts.head.part.asInstanceOf[SoftAST.ExpressionBlock]
+
+        // head expression contains the variable declaration
+        expressionBlock.headExpression shouldBe a[SoftAST.VariableDeclaration]
+        expressionBlock.headExpression.toCode() shouldBe "let one = 1"
+
+        // tail expression also has size one as it contains only the infix equal check
+        expressionBlock.tailExpressions should have size 1
+        expressionBlock.tailExpressions.head.expression shouldBe a[SoftAST.InfixExpression]
+        expressionBlock.tailExpressions.head.expression.toCode() shouldBe "true == true"
+      }
+    }
+
+    "not wrap multiple expression within ExpressionBlock" when {
+      "block is parsed as a child" in {
+        val body =
+          parseBlockBodyChild {
+            """
+              |let one = 1
+              |true == true
+              |""".stripMargin
+          }
+
+        // each expression is parsed as an individual expression/body-part i.e. it does not get wrapped into a block
+        body.parts should have size 2
+
+        // head expression contains the variable declaration
+        body.parts.head.part shouldBe a[SoftAST.VariableDeclaration]
+        body.parts.head.part.toCode() shouldBe "let one = 1"
+
+        // last expression contains the infix operation
+        body.parts.last.part shouldBe a[SoftAST.InfixExpression]
+        body.parts.last.part.toCode() shouldBe "true == true"
+      }
+    }
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/NumberParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/NumberParserSpec.scala
@@ -202,8 +202,15 @@ class NumberParserSpec extends AnyWordSpec with Matchers {
           "invalid unit - 'alp' is typo" in {
             val body = parseSoft("1e-18 alp")
 
-            val number = body.parts.head.part
-            val alp    = body.parts.last.part
+            // since "1e-18" and "alp" individual expressions, they are parsed as an expression-block
+            // Since both expressions are contains within a single block, the body should have size 1
+            body.parts should have size 1
+
+            val expressionBlock = body.parts.head.part.asInstanceOf[SoftAST.ExpressionBlock]
+            val number          = expressionBlock.headExpression
+            val alp             = expressionBlock.tailExpressions.head.expression
+            // tail expression contains only the `alph` identifier
+            expressionBlock.tailExpressions should have size 1
 
             // Note: alp is not a unit. So it's not parsed as part of the number.
             //       Since alp is not part of the number, the number should

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
@@ -48,8 +48,11 @@ object TestParser {
   def parseTuple(code: String): SoftAST.Group[Token.OpenParen.type, Token.CloseParen.type] =
     runSoftParser(ParameterParser.parse(_))(code)
 
-  def parseBlockBody(code: String): SoftAST.BlockBody =
-    runSoftParser(BlockBodyParser.parseOrFail()(_))(code)
+  def parseBlockBodyChild(code: String): SoftAST.BlockBody =
+    runSoftParser(BlockBodyParser.parseOrFailChild()(_))(code)
+
+  def parseBlockBodyRoot(code: String): SoftAST.BlockBody =
+    runSoftParser(BlockBodyParser.parseOrFailRoot(_))(code)
 
   def parseComment(code: String): SoftAST.Comments =
     runSoftParser(CommentParser.parseOrFail(_))(code)

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToLocalVariableSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToLocalVariableSpec.scala
@@ -312,6 +312,41 @@ class GoToLocalVariableSpec extends AnyWordSpec with Matchers {
                 |""".stripMargin
             }
           }
+
+          "accessed after other body-parts" when {
+            "physical block is not defined" ignore {
+              // FIXME: Because `Contract Test` sits between two groups of expressions,
+              //        both groups of expressions do not recognise each other.
+              //        This is fixed if a physical block `{}` is provided, for example in the test below.
+              goToDefinitionSoft() {
+                """
+                  |let >>varA<< = 123
+                  |let varB = varA
+                  |
+                  |Contract Test() { }
+                  |
+                  |let >>varA<< = 123
+                  |let varB = va@@rA
+                  |""".stripMargin
+              }
+            }
+
+            "physical block is defined" in {
+              goToDefinitionSoft() {
+                """
+                  |{
+                  |  let >>varA<< = 123
+                  |  let varB = varA
+                  |
+                  |  Contract Test() { }
+                  |
+                  |  let >>varA<< = 123
+                  |  let varB = va@@rA
+                  |}
+                  |""".stripMargin
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
- `ExpressionBlock` ensures that when two or more expressions are defined outside of a physical block `{ ... expressions ... }`, they are always parsed as a single block instead of individual trees. This ensures that these expressions always available as a set to the `CodeProvider`s .
  - One case is not handled yet, see the `ignore`d test-case (less important).
- Towards #104.