### PR TITLE
Boundary checks

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AccessModifierParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AccessModifierParser.scala
@@ -27,6 +27,7 @@ private object AccessModifierParser {
     P {
       Index ~
         TokenParser.parseOrFail(Token.Pub) ~
+        TokenParser.isBoundary() ~
         SpaceParser.parseOrFail.? ~
         Index
     } map {

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ForParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ForParser.scala
@@ -11,6 +11,7 @@ private object ForParser {
     P {
       Index ~
         TokenParser.parseOrFail(Token.For) ~
+        TokenParser.isBoundary(Token.OpenParen) ~
         SpaceParser.parseOrFail.? ~
         TokenParser.parse(Token.OpenParen) ~
         SpaceParser.parseOrFail.? ~

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionParser.scala
@@ -43,12 +43,12 @@ private object FunctionParser {
         BlockParser.parseOrFail.? ~
         Index
     } map {
-      case (from, annotation, postAnnotationSpace, pub, fnDeceleration, headSpace, signature, tailSpace, block, to) =>
+      case (from, annotation, postAnnotationSpace, accessModifier, fnDeceleration, headSpace, signature, tailSpace, block, to) =>
         SoftAST.Function(
           index = range(from, to),
           annotations = annotation,
           postAnnotationSpace = postAnnotationSpace,
-          pub = pub,
+          accessModifier = accessModifier,
           fn = fnDeceleration,
           preSignatureSpace = headSpace,
           signature = signature,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MutableBindingParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MutableBindingParser.scala
@@ -12,8 +12,9 @@ private object MutableBindingParser {
     P {
       Index ~
         TokenParser.parseOrFail(Token.Mut) ~
-        SpaceParser.parseOrFail ~
-        IdentifierParser.parseOrFail ~
+        TokenParser.isBoundary() ~
+        SpaceParser.parseOrFail.? ~
+        IdentifierParser.parse ~
         Index
     } map {
       case (from, mut, space, identifier, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/NumberParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/NumberParser.scala
@@ -80,6 +80,7 @@ private object NumberParser {
       Index ~
         SpaceParser.parseOrFail.? ~
         TokenParser.parseOrFail(Token.AlphLowercase) ~
+        TokenParser.isBoundary() ~
         Index
     } map {
       case (from, space, unit, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/WhileParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/WhileParser.scala
@@ -11,6 +11,7 @@ private object WhileParser {
     P {
       Index ~
         TokenParser.parseOrFail(Token.While) ~
+        TokenParser.isBoundary(Token.OpenParen) ~
         SpaceParser.parseOrFail.? ~
         TokenParser.parse(Token.OpenParen) ~
         SpaceParser.parseOrFail.? ~

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -522,8 +522,8 @@ object SoftAST {
   case class MutableBinding(
       index: SourceIndex,
       mut: TokenDocumented[Token.Mut.type],
-      space: Space,
-      identifier: Identifier)
+      space: Option[Space],
+      identifier: IdentifierAST)
     extends ExpressionAST
 
   case class Annotation(

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -286,7 +286,7 @@ object SoftAST {
       index: SourceIndex,
       annotations: Seq[Annotation],
       postAnnotationSpace: Option[Space],
-      pub: Option[AccessModifier],
+      accessModifier: Option[AccessModifier],
       fn: TokenDocumented[Token.Fn.type],
       preSignatureSpace: Option[Space],
       signature: FunctionSignature,

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AccessModifierParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AccessModifierParserSpec.scala
@@ -1,0 +1,58 @@
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.OptionValues._
+
+class AccessModifierParserSpec extends AnyWordSpec with Matchers {
+
+  "fail" when {
+    "pub is not an independent token" in {
+      val body =
+        parseSoft("pubfn")
+
+      // Code "pubfn" should be recognised as a function. It is an identifier.
+      body.parts should have size 1
+      body.parts.head.part shouldBe
+        Identifier(
+          index = indexOf(">>pubfn<<"),
+          text = "pubfn"
+        )
+    }
+  }
+
+  "succeed" when {
+    "pub an independent token" in {
+      val body =
+        parseSoft("pub fn")
+
+      body.parts should have size 1
+      val function = body.parts.head.part.asInstanceOf[SoftAST.Function]
+
+      function.accessModifier.value shouldBe
+        SoftAST.AccessModifier(
+          index = indexOf(">>pub <<fn"),
+          pub = Pub(indexOf(">>pub<< fn")),
+          postTokenSpace = Some(SpaceOne(indexOf("pub>> <<fn")))
+        )
+    }
+
+    "pub following an end of line" in {
+      val accessModifier =
+        parseAccessModifier("pub")
+
+      accessModifier shouldBe
+        SoftAST.AccessModifier(
+          index = indexOf(">>pub<<"),
+          pub = Pub(indexOf(">>pub<<")),
+          postTokenSpace = None
+        )
+    }
+
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/EventParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/EventParserSpec.scala
@@ -9,6 +9,22 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class EventParserSpec extends AnyWordSpec {
 
+  "fail" when {
+    "event is not followed by a boundary" in {
+      val body =
+        parseSoft("eventMyEvent")
+
+      body.parts should have size 1
+      val identifier = body.parts.head.part
+
+      identifier shouldBe
+        Identifier(
+          index = indexOf(">>eventMyEvent<<"),
+          text = "eventMyEvent"
+        )
+    }
+  }
+
   "successfully parse an event" in {
     val event = parseEvent("event MyEvent(varName: TypeName")
 

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ForParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ForParserSpec.scala
@@ -1,0 +1,82 @@
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ForParserSpec extends AnyWordSpec with Matchers {
+
+  "fail" when {
+    "for is not followed a boundary" in {
+      val body =
+        parseSoft("forloop")
+
+      body.parts should have size 1
+      body.parts.head.part shouldBe
+        Identifier(
+          index = indexOf(">>forloop<<"),
+          text = "forloop"
+        )
+    }
+  }
+
+  "succeed" when {
+    "for is followed by a `space` boundary" in {
+      val forExpression =
+        parseFor("for ")
+
+      forExpression shouldBe
+        SoftAST.For(
+          index = indexOf(">>for <<"),
+          forToken = For(indexOf(">>for<< ")),
+          postForSpace = Some(SpaceOne(indexOf("for>> <<"))),
+          openParen = SoftAST.TokenExpected(indexOf("for >><<"), Token.OpenParen),
+          postOpenParenSpace = None,
+          expression1 = SoftAST.ExpressionExpected(indexOf("for >><<")),
+          postExpression1Space = None,
+          postExpression1Semicolon = SoftAST.TokenExpected(indexOf("for >><<"), Token.Semicolon),
+          postExpression1SemicolonSpace = None,
+          expression2 = SoftAST.ExpressionExpected(indexOf("for >><<")),
+          postExpression2Space = None,
+          postExpression2Semicolon = SoftAST.TokenExpected(indexOf("for >><<"), Token.Semicolon),
+          postExpression2SemicolonSpace = None,
+          expression3 = SoftAST.ExpressionExpected(indexOf("for >><<")),
+          postExpression3Space = None,
+          closeParen = SoftAST.TokenExpected(indexOf("for >><<"), Token.CloseParen),
+          postCloseParenSpace = None,
+          block = None
+        )
+    }
+
+    "for is followed by a `open-paren` boundary" in {
+      val forExpression =
+        parseFor("for(")
+
+      forExpression shouldBe
+        SoftAST.For(
+          index = indexOf(">>for(<<"),
+          forToken = For(indexOf(">>for<<(")),
+          postForSpace = None,
+          openParen = OpenParen(indexOf("for>>(<<")),
+          postOpenParenSpace = None,
+          expression1 = SoftAST.ExpressionExpected(indexOf("for(>><<")),
+          postExpression1Space = None,
+          postExpression1Semicolon = SoftAST.TokenExpected(indexOf("for(>><<"), Token.Semicolon),
+          postExpression1SemicolonSpace = None,
+          expression2 = SoftAST.ExpressionExpected(indexOf("for(>><<")),
+          postExpression2Space = None,
+          postExpression2Semicolon = SoftAST.TokenExpected(indexOf("for(>><<"), Token.Semicolon),
+          postExpression2SemicolonSpace = None,
+          expression3 = SoftAST.ExpressionExpected(indexOf("for(>><<")),
+          postExpression3Space = None,
+          closeParen = SoftAST.TokenExpected(indexOf("for(>><<"), Token.CloseParen),
+          postCloseParenSpace = None,
+          block = None
+        )
+    }
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MutableBindingParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MutableBindingParserSpec.scala
@@ -26,7 +26,35 @@ import org.scalatest.OptionValues._
 
 class MutableBindingParserSpec extends AnyWordSpec with Matchers {
 
+  "fail" when {
+    "mut is not followed by a space boundary" in {
+      val mut =
+        parseSoft("mutvariable")
+
+      // it gets parsed as an identifier and not a mutable-binding
+      mut.parts should have size 1
+      mut.parts.head.part shouldBe
+        Identifier(
+          index = indexOf(">>mutvariable<<"),
+          text = "mutvariable"
+        )
+    }
+  }
+
   "succeed" when {
+    "only mut is defined" in {
+      val annotation =
+        parseMutableBinding("mut")
+
+      annotation shouldBe
+        SoftAST.MutableBinding(
+          index = indexOf(">>mut<<"),
+          mut = Mut(indexOf(">>mut<<")),
+          space = None,
+          identifier = SoftAST.IdentifierExpected(indexOf("mut>><<"))
+        )
+    }
+
     "an identifier is set a mut" in {
       val annotation =
         parseMutableBinding("mut variable")
@@ -35,7 +63,7 @@ class MutableBindingParserSpec extends AnyWordSpec with Matchers {
         SoftAST.MutableBinding(
           index = indexOf(">>mut variable<<"),
           mut = Mut(indexOf(">>mut<< variable")),
-          space = SpaceOne(indexOf("mut>> <<variable")),
+          space = Some(SpaceOne(indexOf("mut>> <<variable"))),
           identifier = Identifier(indexOf("mut >>variable<<"), "variable")
         )
     }
@@ -55,7 +83,7 @@ class MutableBindingParserSpec extends AnyWordSpec with Matchers {
         SoftAST.MutableBinding(
           index = indexOf("(a, b, >>mut variable<<)"),
           mut = Mut(indexOf("(a, b, >>mut<< variable)")),
-          space = SpaceOne(indexOf("(a, b, mut>> <<variable)")),
+          space = Some(SpaceOne(indexOf("(a, b, mut>> <<variable)"))),
           identifier = Identifier(indexOf("(a, b, mut >>variable<<)"), "variable")
         )
     }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MutableBindingParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MutableBindingParserSpec.scala
@@ -43,10 +43,10 @@ class MutableBindingParserSpec extends AnyWordSpec with Matchers {
 
   "succeed" when {
     "only mut is defined" in {
-      val annotation =
+      val mut =
         parseMutableBinding("mut")
 
-      annotation shouldBe
+      mut shouldBe
         SoftAST.MutableBinding(
           index = indexOf(">>mut<<"),
           mut = Mut(indexOf(">>mut<<")),
@@ -56,10 +56,10 @@ class MutableBindingParserSpec extends AnyWordSpec with Matchers {
     }
 
     "an identifier is set a mut" in {
-      val annotation =
+      val mut =
         parseMutableBinding("mut variable")
 
-      annotation shouldBe
+      mut shouldBe
         SoftAST.MutableBinding(
           index = indexOf(">>mut variable<<"),
           mut = Mut(indexOf(">>mut<< variable")),

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/NumberParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/NumberParserSpec.scala
@@ -233,6 +233,35 @@ class NumberParserSpec extends AnyWordSpec with Matchers {
                 text = "alp"
               )
           }
+
+          "invalid unit - 'alphs' is typo" in {
+            val body = parseSoft("1e-18 alphs")
+
+            // since alphs is a typo at the tail end of the "alph" token, it should get recognised as an identifier.
+            // Since both expressions are contains within a single block, the body should have size 1
+            body.parts should have size 1
+            val block = body.parts.head.part.asInstanceOf[SoftAST.ExpressionBlock]
+            block.tailExpressions should have size 1
+            val number = block.headExpression.asInstanceOf[SoftAST.Number]
+            val alphs  = block.tailExpressions.head.expression.asInstanceOf[SoftAST.Identifier]
+
+            number shouldBe
+              SoftAST.Number(
+                index = indexOf(s">>1e-18<< alphs"),
+                documentation = None,
+                number = SoftAST.CodeString(
+                  index = indexOf(s">>1e-18<< alphs"),
+                  text = "1e-18"
+                ),
+                unit = None
+              )
+
+            alphs shouldBe
+              Identifier(
+                index = indexOf(s"1e-18 >>alphs<<"),
+                text = "alphs"
+              )
+          }
         }
       }
     }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StructParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StructParserSpec.scala
@@ -9,30 +9,67 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class StructParserSpec extends AnyWordSpec {
 
-  "closing curly is missing" in {
-    val struct = parseStruct("struct MyStruct{varName: TypeName")
+  "fail" when {
+    "struct is followed by a non-boundary character" in {
+      val struct = parseSoft("structMyStruct")
 
-    struct.structToken shouldBe Struct(indexOf(">>struct<< MyStruct{varName: TypeName"))
-    struct.identifier shouldBe Identifier(indexOf("struct >>MyStruct<<{varName: TypeName"), "MyStruct")
-
-    // Tuples are tested in TupleSpec, test for the index and string code here.
-    struct.params.index shouldBe indexOf("struct MyStruct>>{varName: TypeName<<")
-    struct.params.toCode() shouldBe "{varName: TypeName"
-    struct.params.closeToken shouldBe SoftAST.TokenExpected(indexOf("struct MyStruct{varName: TypeName>><<"), Token.CloseCurly)
+      struct.parts should have size 1
+      struct.parts.head.part shouldBe
+        Identifier(
+          index = indexOf(">>structMyStruct<<"),
+          text = "structMyStruct"
+        )
+    }
   }
 
-  "well defined struct" in {
-    val struct = parseStruct("struct Bar { z: U256, mut foo: Foo }")
+  "pass" when {
+    "struct is defined" in {
+      val struct = parseStruct("struct")
 
-    struct.structToken shouldBe Struct(indexOf(">>struct<< Bar { z: U256, mut foo: Foo }"))
-    struct.identifier shouldBe Identifier(indexOf("struct >>Bar<< { z: U256, mut foo: Foo }"), "Bar")
+      struct shouldBe
+        SoftAST.Struct(
+          index = indexOf(">>struct<<"),
+          structToken = Struct(indexOf(">>struct<<")),
+          preIdentifierSpace = None,
+          identifier = SoftAST.IdentifierExpected(indexOf("struct>><<")),
+          preParamSpace = None,
+          params = SoftAST.Group(
+            index = indexOf("struct>><<"),
+            openToken = SoftAST.TokenExpected(indexOf("struct>><<"), Token.OpenCurly),
+            preHeadExpressionSpace = None,
+            headExpression = None,
+            postHeadExpressionSpace = None,
+            tailExpressions = Seq.empty,
+            closeToken = SoftAST.TokenExpected(indexOf("struct>><<"), Token.CloseCurly)
+          )
+        )
+    }
 
-    // Tuples are tested in TupleSpec, test for the index and string code here.
-    struct.params.index shouldBe indexOf("struct Bar >>{ z: U256, mut foo: Foo }<<")
-    struct.params.toCode() shouldBe "{ z: U256, mut foo: Foo }"
-    struct.params.openToken shouldBe OpenCurly(indexOf("struct Bar >>{<< z: U256, mut foo: Foo }"))
-    struct.params.closeToken shouldBe CloseCurly(indexOf("struct Bar { z: U256, mut foo: Foo >>}<<"))
+    "closing curly is missing" in {
+      val struct = parseStruct("struct MyStruct{varName: TypeName")
 
+      struct.structToken shouldBe Struct(indexOf(">>struct<< MyStruct{varName: TypeName"))
+      struct.identifier shouldBe Identifier(indexOf("struct >>MyStruct<<{varName: TypeName"), "MyStruct")
+
+      // Tuples are tested in TupleSpec, test for the index and string code here.
+      struct.params.index shouldBe indexOf("struct MyStruct>>{varName: TypeName<<")
+      struct.params.toCode() shouldBe "{varName: TypeName"
+      struct.params.closeToken shouldBe SoftAST.TokenExpected(indexOf("struct MyStruct{varName: TypeName>><<"), Token.CloseCurly)
+    }
+
+    "well defined struct" in {
+      val struct = parseStruct("struct Bar { z: U256, mut foo: Foo }")
+
+      struct.structToken shouldBe Struct(indexOf(">>struct<< Bar { z: U256, mut foo: Foo }"))
+      struct.identifier shouldBe Identifier(indexOf("struct >>Bar<< { z: U256, mut foo: Foo }"), "Bar")
+
+      // Tuples are tested in TupleSpec, test for the index and string code here.
+      struct.params.index shouldBe indexOf("struct Bar >>{ z: U256, mut foo: Foo }<<")
+      struct.params.toCode() shouldBe "{ z: U256, mut foo: Foo }"
+      struct.params.openToken shouldBe OpenCurly(indexOf("struct Bar >>{<< z: U256, mut foo: Foo }"))
+      struct.params.closeToken shouldBe CloseCurly(indexOf("struct Bar { z: U256, mut foo: Foo >>}<<"))
+
+    }
   }
 
 }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
@@ -103,6 +103,9 @@ object TestParser {
   def parseAccessModifier(code: String): SoftAST.AccessModifier =
     runSoftParser(AccessModifierParser.parseOrFail(_))(code)
 
+  def parseFor(code: String): SoftAST.For =
+    runSoftParser(ForParser.parseOrFail(_))(code)
+
   def findAnnotation(identifier: String)(code: String): Option[SoftAST.Annotation] =
     findAnnotation(
       identifier = identifier,

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
@@ -106,6 +106,9 @@ object TestParser {
   def parseFor(code: String): SoftAST.For =
     runSoftParser(ForParser.parseOrFail(_))(code)
 
+  def parseWhile(code: String): SoftAST.While =
+    runSoftParser(WhileParser.parseOrFail(_))(code)
+
   def findAnnotation(identifier: String)(code: String): Option[SoftAST.Annotation] =
     findAnnotation(
       identifier = identifier,

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
@@ -100,6 +100,9 @@ object TestParser {
   def parseInheritance(code: String): SoftAST.Inheritance =
     runSoftParser(InheritanceParser.parseOrFail(_))(code)
 
+  def parseAccessModifier(code: String): SoftAST.AccessModifier =
+    runSoftParser(AccessModifierParser.parseOrFail(_))(code)
+
   def findAnnotation(identifier: String)(code: String): Option[SoftAST.Annotation] =
     findAnnotation(
       identifier = identifier,

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/VariableDeclarationParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/VariableDeclarationParserSpec.scala
@@ -40,7 +40,7 @@ class VariableDeclarationParserSpec extends AnyWordSpec with Matchers {
             expressionLeft = SoftAST.MutableBinding(
               index = indexOf("let >>mut variable<< = 1"),
               mut = Mut(indexOf("let >>mut<< variable = 1")),
-              space = SpaceOne(indexOf("let mut>> <<variable = 1")),
+              space = Some(SpaceOne(indexOf("let mut>> <<variable = 1"))),
               identifier = Identifier(indexOf("let mut >>variable<< = 1"), "variable")
             ),
             postIdentifierSpace = Some(SpaceOne(indexOf("let mut variable>> <<= 1"))),
@@ -68,7 +68,7 @@ class VariableDeclarationParserSpec extends AnyWordSpec with Matchers {
               expressionLeft = SoftAST.MutableBinding(
                 index = indexOf("let >>mut variable<< = "),
                 mut = Mut(indexOf("let >>mut<< variable = ")),
-                space = SpaceOne(indexOf("let mut>> <<variable = ")),
+                space = Some(SpaceOne(indexOf("let mut>> <<variable = "))),
                 identifier = Identifier(indexOf("let mut >>variable<< = "), "variable")
               ),
               postIdentifierSpace = Some(SpaceOne(indexOf("let mut variable>> <<= "))),
@@ -94,7 +94,7 @@ class VariableDeclarationParserSpec extends AnyWordSpec with Matchers {
             expressionLeft = SoftAST.MutableBinding(
               index = indexOf("let >>mut variable<<"),
               mut = Mut(indexOf("let >>mut<< variable")),
-              space = SpaceOne(indexOf("let mut>> <<variable")),
+              space = Some(SpaceOne(indexOf("let mut>> <<variable"))),
               identifier = Identifier(indexOf("let mut >>variable<<"), "variable")
             ),
             postIdentifierSpace = None,
@@ -106,36 +106,27 @@ class VariableDeclarationParserSpec extends AnyWordSpec with Matchers {
     }
 
     "variable name is missing" in {
-      val soft =
-        parseSoft("let mut")
+      val varDec =
+        parseVariableDeclaration("let mut")
 
-      soft.parts should have size 2
-
-      val assignment = soft.parts.head.part.asInstanceOf[SoftAST.VariableDeclaration]
-      val unresolved = soft.parts.last.part.asInstanceOf[SoftAST.Unresolved]
-
-      assignment shouldBe
+      varDec shouldBe
         SoftAST.VariableDeclaration(
-          index = indexOf(">>let <<mut"),
+          index = indexOf(">>let mut<<"),
           let = Let(indexOf(">>let<< mut")),
           postLetSpace = Some(SpaceOne(indexOf("let>> <<mut"))),
           assignment = SoftAST.Assignment(
-            index = indexOf("let >><<mut"),
-            expressionLeft = SoftAST.ExpressionExpected(indexOf("let >><<mut")),
+            index = indexOf("let >>mut<<"),
+            expressionLeft = SoftAST.MutableBinding(
+              index = indexOf("let >>mut<<"),
+              mut = Mut(indexOf("let >>mut<<")),
+              space = None,
+              identifier = SoftAST.IdentifierExpected(indexOf("let mut>><<"))
+            ),
             postIdentifierSpace = None,
-            equalToken = SoftAST.TokenExpected(indexOf("let >><<mut"), Token.Equal),
+            equalToken = SoftAST.TokenExpected(indexOf("let mut>><<"), Token.Equal),
             postEqualSpace = None,
-            expressionRight = SoftAST.ExpressionExpected(indexOf("let >><<mut"))
+            expressionRight = SoftAST.ExpressionExpected(indexOf("let mut>><<"))
           )
-        )
-
-      // FIXME: "mut" could still be recognised as part of the `let` variable declaration statement
-      //        instead of reporting it as unresolved.
-      unresolved shouldBe
-        SoftAST.Unresolved(
-          index = indexOf("let >>mut<<"),
-          documentation = None,
-          code = SoftAST.CodeString(indexOf("let >>mut<<"), "mut")
         )
     }
 

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/VariableDeclarationParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/VariableDeclarationParserSpec.scala
@@ -27,10 +27,10 @@ class VariableDeclarationParserSpec extends AnyWordSpec with Matchers {
 
   "succeed" when {
     "full valid variable declaration is defined" in {
-      val assigment =
+      val varDec =
         parseVariableDeclaration("let mut variable = 1")
 
-      assigment shouldBe
+      varDec shouldBe
         SoftAST.VariableDeclaration(
           index = indexOf(">>let mut variable = 1<<"),
           let = Let(indexOf(">>let<< mut variable = 1")),
@@ -55,10 +55,10 @@ class VariableDeclarationParserSpec extends AnyWordSpec with Matchers {
   "let" should {
     "always result in variable-declaration" when {
       "right expression is missing" in {
-        val assigment =
+        val varDec =
           parseVariableDeclaration("let mut variable = ")
 
-        assigment shouldBe
+        varDec shouldBe
           SoftAST.VariableDeclaration(
             index = indexOf(">>let mut variable = <<"),
             let = Let(indexOf(">>let<< mut variable = ")),
@@ -81,10 +81,10 @@ class VariableDeclarationParserSpec extends AnyWordSpec with Matchers {
     }
 
     "equal is missing" in {
-      val assigment =
+      val varDec =
         parseVariableDeclaration("let mut variable")
 
-      assigment shouldBe
+      varDec shouldBe
         SoftAST.VariableDeclaration(
           index = indexOf(">>let mut variable<<"),
           let = Let(indexOf(">>let<< mut variable")),
@@ -131,10 +131,10 @@ class VariableDeclarationParserSpec extends AnyWordSpec with Matchers {
     }
 
     "only let is defined" in {
-      val assignment =
+      val varDec =
         parseVariableDeclaration("let")
 
-      assignment shouldBe
+      varDec shouldBe
         SoftAST.VariableDeclaration(
           index = indexOf(">>let<<"),
           let = Let(indexOf(">>let<<")),
@@ -185,19 +185,19 @@ class VariableDeclarationParserSpec extends AnyWordSpec with Matchers {
 
   "allow expressions as assignment identifiers" when {
     "the identifier is a tuple" in {
-      val tupleDecl =
+      val tupleVarDec =
         parseVariableDeclaration("let (a, b, c) = blah")
 
-      tupleDecl.let shouldBe Let(indexOf(">>let<< (a, b, c) = blah"))
-      tupleDecl.postLetSpace shouldBe Some(SpaceOne(indexOf("let>> <<(a, b, c) = blah")))
+      tupleVarDec.let shouldBe Let(indexOf(">>let<< (a, b, c) = blah"))
+      tupleVarDec.postLetSpace shouldBe Some(SpaceOne(indexOf("let>> <<(a, b, c) = blah")))
 
       // left is a tuple
-      val left = tupleDecl.assignment.expressionLeft.asInstanceOf[SoftAST.Group[Token.OpenParen.type, Token.CloseParen.type]]
+      val left = tupleVarDec.assignment.expressionLeft.asInstanceOf[SoftAST.Group[Token.OpenParen.type, Token.CloseParen.type]]
       left.index shouldBe indexOf("let >>(a, b, c)<< = blah")
       left.toCode() shouldBe "(a, b, c)"
 
       // right is an assignment
-      tupleDecl.assignment.expressionRight shouldBe
+      tupleVarDec.assignment.expressionRight shouldBe
         Identifier(
           index = indexOf("let (a, b, c) = >>blah<<"),
           text = "blah"

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/WhileParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/WhileParserSpec.scala
@@ -1,0 +1,85 @@
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class WhileParserSpec extends AnyWordSpec with Matchers {
+
+  "fail" when {
+    "`while` is not followed by a boundary" in {
+      val body =
+        parseSoft("whilel")
+
+      body.parts should have size 1
+      body.parts.head.part shouldBe
+        Identifier(
+          index = indexOf(">>whilel<<"),
+          text = "whilel"
+        )
+    }
+  }
+
+  "pass" when {
+    "`while` followed by end-of-line boundary" in {
+      val actual =
+        parseWhile("while")
+
+      actual shouldBe
+        SoftAST.While(
+          index = indexOf(">>while<<"),
+          whileToken = While(indexOf(">>while<<")),
+          postWhileSpace = None,
+          openParen = SoftAST.TokenExpected(indexOf("while>><<"), Token.OpenParen),
+          postOpenParenSpace = None,
+          expression = SoftAST.ExpressionExpected(indexOf("while>><<")),
+          postExpressionSpace = None,
+          closeParen = SoftAST.TokenExpected(indexOf("while>><<"), Token.CloseParen),
+          postCloseParenSpace = None,
+          block = None
+        )
+    }
+
+    "`while` followed by space boundary" in {
+      val actual =
+        parseWhile("while ")
+
+      actual shouldBe
+        SoftAST.While(
+          index = indexOf(">>while <<"),
+          whileToken = While(indexOf(">>while<< ")),
+          postWhileSpace = Some(SpaceOne(indexOf("while>> <<"))),
+          openParen = SoftAST.TokenExpected(indexOf("while >><<"), Token.OpenParen),
+          postOpenParenSpace = None,
+          expression = SoftAST.ExpressionExpected(indexOf("while >><<")),
+          postExpressionSpace = None,
+          closeParen = SoftAST.TokenExpected(indexOf("while >><<"), Token.CloseParen),
+          postCloseParenSpace = None,
+          block = None
+        )
+    }
+
+    "`while` followed by open-paren boundary" in {
+      val actual =
+        parseWhile("while(")
+
+      actual shouldBe
+        SoftAST.While(
+          index = indexOf(">>while(<<"),
+          whileToken = While(indexOf(">>while<<")),
+          postWhileSpace = None,
+          openParen = OpenParen(indexOf("while>>(<<")),
+          postOpenParenSpace = None,
+          expression = SoftAST.ExpressionExpected(indexOf("while(>><<")),
+          postExpressionSpace = None,
+          closeParen = SoftAST.TokenExpected(indexOf("while(>><<"), Token.CloseParen),
+          postCloseParenSpace = None,
+          block = None
+        )
+    }
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -186,6 +186,12 @@ object TestSoftAST {
       token = Token.Pub
     )
 
+  def For(index: SourceIndex): SoftAST.TokenDocumented[Token.For.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.For
+    )
+
   def Identifier(
       index: SourceIndex,
       text: String): SoftAST.Identifier =

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -192,6 +192,12 @@ object TestSoftAST {
       token = Token.For
     )
 
+  def While(index: SourceIndex): SoftAST.TokenDocumented[Token.While.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.While
+    )
+
   def Identifier(
       index: SourceIndex,
       text: String): SoftAST.Identifier =

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -180,6 +180,12 @@ object TestSoftAST {
       token = Token.Extends
     )
 
+  def Pub(index: SourceIndex): SoftAST.TokenDocumented[Token.Pub.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Pub
+    )
+
   def Identifier(
       index: SourceIndex,
       text: String): SoftAST.Identifier =

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/soft/gotodef/GoToDefLocalVariableDeclaration.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/soft/gotodef/GoToDefLocalVariableDeclaration.scala
@@ -195,11 +195,18 @@ object GoToDefLocalVariableDeclaration {
 
       case binding: SoftAST.MutableBinding =>
         // Search the identifier
-        expandAndSearchExpression(
-          expression = binding.identifier,
-          identNode = identNode,
-          sourceCode = sourceCode
-        )
+        binding.identifier match {
+          case identifier: SoftAST.Identifier =>
+            expandAndSearchExpression(
+              expression = identifier,
+              identNode = identNode,
+              sourceCode = sourceCode
+            )
+
+          case _: SoftAST.IdentifierExpected =>
+            // identifier not provided
+            Iterator.empty
+        }
 
       case SoftAST.Identifier(_, _, code) if code.text == identNode.data.code.text =>
         // Check if the identifier matches the text in the selected `identNode`.


### PR DESCRIPTION
- Adds missing boundary checks for reserved tokens such as `while`, `for`, `pub` etc. 
  - These boundary checks ensure that tokens such as `pub` immediately followed by another character(s) (`pubfn`) do not get parsed as a `pub` function, but as an identifier. 
- Resolves [FIXME](https://github.com/alephium/ralph-lsp/blob/3a075eaccf563c459d8e159d14128b6233c7f4aa/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/VariableDeclarationParserSpec.scala#L132).
- TODO #373.
- Towards #104.