### PR TITLE
Repeated token check

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentParser.scala
@@ -66,8 +66,7 @@ private case object AssignmentParser {
 
   private def leftExpression[Unknown: P]: P[SoftAST.ExpressionAST] =
     P {
-      InfixCallParser.parseOrFail |
-        MethodCallParser.parseOrFail |
+      MethodCallParser.parseOrFail |
         BlockParser.parseOrFail |
         VariableDeclarationParser.parseOrFail |
         MutableBindingParser.parseOrFail |

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
@@ -51,7 +51,7 @@ object Token {
   sealed trait Expression    extends Token // A token that is also an expression.
 
   sealed abstract class Operator(override val lexeme: String) extends Token
-  case object Equality                                        extends Operator("==") with Reserved with InfixOperator
+  case object EqualEqual                                      extends Operator("==") with Reserved with InfixOperator
   case object GreaterThanOrEqual                              extends Operator(">=") with Reserved with InfixOperator
   case object PlusPlus                                        extends Operator("++") with Reserved with InfixOperator
   case object PlusEquals                                      extends Operator("+=") with Reserved with InfixOperator

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
@@ -23,6 +23,23 @@ sealed trait Token extends Ordered[Token] { self =>
   def lexeme: String
 
   /**
+   * Fetches all other reserved token that may have this token's lexeme its prefix.
+   *
+   * For example, if this token is `-`, fetch `->` and `-=`.
+   */
+  lazy val otherReservedTokensWithThisPrefix: List[Token.Reserved] =
+    // FIXME: All tokens should be searched instead of reserved.
+    //        `sealedInstancesOf` does not work on `Token` yet.
+    Token
+      .reserved
+      .filter {
+        token =>
+          token != self &&
+          token.lexeme.startsWith(lexeme)
+      }
+      .toList
+
+  /**
    * Order such that tokens such as:
    *  - `||` comes before `|`
    *  - `+=` comes before `+` and `=`

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParserSpec.scala
@@ -35,4 +35,20 @@ class TokenParserSpec extends AnyWordSpec {
     }
   }
 
+  "otherReservedTokenWithThisPrefix" should {
+    "fetch other reserved tokens with same prefixes" when {
+      "-" in {
+        Token.Minus.otherReservedTokensWithThisPrefix should contain only (Token.MinusEquals, Token.ForwardArrow)
+      }
+
+      "+" in {
+        Token.Plus.otherReservedTokensWithThisPrefix should contain only (Token.PlusPlus, Token.PlusEquals)
+      }
+
+      "++" in {
+        Token.PlusEquals.otherReservedTokensWithThisPrefix shouldBe empty
+      }
+    }
+  }
+
 }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -120,6 +120,12 @@ object TestSoftAST {
       token = Token.Equal
     )
 
+  def EqualEqual(index: SourceIndex): SoftAST.TokenDocumented[Token.EqualEqual.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.EqualEqual
+    )
+
   def Plus(index: SourceIndex): SoftAST.TokenDocumented[Token.Plus.type] =
     TokenDocumented(
       index = index,


### PR DESCRIPTION
- Ensure that the input token is not a prefix of another token. For example, if the input token is `+`, ensure that the token being parsed is neither `+=` nor `++`.
- Removed `InfixCallParser.parseOrFail` from `AssignmentParser` (addresses point two in #358).

## Update: Pending tasks before release
- Following up on point two in #358: The expression parsers executed wherever `ExpressionAST` is required should be narrowed. I'm working on this now. Important. 
- Improve test coverage.

Towards #104.