### PR TITLE
Added missing operators

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
@@ -78,6 +78,13 @@ object Token {
   case object ForwardArrow                                    extends Operator("->") with Reserved
   case object Or                                              extends Operator("||") with Reserved with InfixOperator
   case object And                                             extends Operator("&&") with Reserved with InfixOperator
+  case object ShiftLeft                                       extends Operator("<<") with Reserved with InfixOperator
+  case object ShiftRight                                      extends Operator(">>") with Reserved with InfixOperator
+  case object ModuloAddition                                  extends Operator("|+|") with Reserved with InfixOperator
+  case object ModuloSubtraction                               extends Operator("|-|") with Reserved with InfixOperator
+  case object ModuloExponentiation                            extends Operator("|**|") with Reserved with InfixOperator
+  case object ModuloMultiplication                            extends Operator("|*|") with Reserved with InfixOperator
+  case object Exponentiation                                  extends Operator("**") with Reserved with InfixOperator
   case object Minus                                           extends Operator("-") with Reserved with InfixOperator
   case object Plus                                            extends Operator("+") with Reserved with InfixOperator
   case object Asterisk                                        extends Operator("*") with Reserved with InfixOperator


### PR DESCRIPTION
- Follows [arithmetic-operators](https://docs.alephium.org/ralph/operators/#arithmetic-operators) documentation.
- Towards #104.