### PR TITLE
Remove manual repeated token check for `/`

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -63,20 +63,11 @@ private object TokenParser {
   /**
    * Parses all tokens of type [[Token.InfixOperator]] and also their comments.
    */
-  def InfixOperatorOrFail[Unknown: P]: P[SoftAST.TokenDocumented[Token.InfixOperator]] = {
-    val infixOps =
-      ParserUtil.orCombinator(
-        items = Token.infix.diff(Seq(Token.ForwardSlash)).iterator, // remove forward-slash
-        parser = TokenParser.parseOrFail(_: Token.InfixOperator)
-      )
-
-    // Forward-slash followed by another forward-slash is not an Operator.
-    // `//` is reserved as a comment prefix.
-    def forwardSlashOperator =
-      P(TokenParser.parseOrFail(Token.ForwardSlash) ~ !Token.ForwardSlash.lexeme)
-
-    infixOps | forwardSlashOperator
-  }
+  def InfixOperatorOrFail[Unknown: P]: P[SoftAST.TokenDocumented[Token.InfixOperator]] =
+    ParserUtil.orCombinator(
+      items = Token.infix.iterator,
+      parser = TokenParser.parseOrFail(_: Token.InfixOperator)
+    )
 
   /**
    * Reads characters until at least one of the input tokens is matched.

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParserSpec.scala
@@ -48,6 +48,14 @@ class TokenParserSpec extends AnyWordSpec {
       "++" in {
         Token.PlusEquals.otherReservedTokensWithThisPrefix shouldBe empty
       }
+
+      "/" in {
+        Token.ForwardSlash.otherReservedTokensWithThisPrefix should contain only Token.DoubleForwardSlash
+      }
+
+      "//" in {
+        Token.DoubleForwardSlash.otherReservedTokensWithThisPrefix shouldBe empty
+      }
     }
   }
 


### PR DESCRIPTION
- The manual check is no longer required because of PR #375.
- Towards #104.