### PR TITLE
Type param annotation parser

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala
@@ -20,7 +20,7 @@ object Demo extends App {
         |  // This multiline comment
         |  // documents this function
         |  @using(left = right)
-        |  fn function(nested_tuple: (A, (B, C))) -> ABC {
+        |  fn function(@using nested_tuple: (A, (B, C))) -> ABC {
         |
         |     // document this
         |     let int = 1

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionParser.scala
@@ -33,7 +33,6 @@ private object FunctionParser {
     P {
       Index ~
         AnnotationParser.parseOrFail.rep ~
-        SpaceParser.parseOrFail.? ~
         AccessModifierParser.parseOrFail.? ~
         TokenParser.parseOrFail(Token.Fn) ~
         TokenParser.isBoundary() ~
@@ -43,11 +42,10 @@ private object FunctionParser {
         BlockParser.parseOrFail.? ~
         Index
     } map {
-      case (from, annotation, postAnnotationSpace, accessModifier, fnDeceleration, headSpace, signature, tailSpace, block, to) =>
+      case (from, annotation, accessModifier, fnDeceleration, headSpace, signature, tailSpace, block, to) =>
         SoftAST.Function(
           index = range(from, to),
           annotations = annotation,
-          postAnnotationSpace = postAnnotationSpace,
           accessModifier = accessModifier,
           fn = fnDeceleration,
           preSignatureSpace = headSpace,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeAssignmentParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeAssignmentParser.scala
@@ -10,6 +10,7 @@ private object TypeAssignmentParser {
   def parseOrFail[Unknown: P]: P[SoftAST.TypeAssignment] =
     P {
       Index ~
+        AnnotationParser.parseOrFail.rep ~
         ExpressionParser.parseSubset(leftExpression) ~
         SpaceParser.parseOrFail.? ~
         TokenParser.parseOrFail(Token.Colon) ~
@@ -17,9 +18,10 @@ private object TypeAssignmentParser {
         ExpressionParser.parseSubset(rightExpression) ~
         Index
     } map {
-      case (from, left, postIdentifierSpace, equalToken, postEqualSpace, right, to) =>
+      case (from, annotations, left, postIdentifierSpace, equalToken, postEqualSpace, right, to) =>
         SoftAST.TypeAssignment(
           index = range(from, to),
+          annotations = annotations,
           expressionLeft = left,
           preColonSpace = postIdentifierSpace,
           colon = equalToken,

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -287,7 +287,12 @@ object SoftAST {
       index: SourceIndex,
       headExpression: ExpressionAST,
       tailExpressions: Seq[TailExpressionBlock])
-    extends BlockPartAST
+    extends BlockPartAST {
+
+    def expressions: Seq[ExpressionAST] =
+      headExpression +: tailExpressions.map(_.expression)
+
+  }
 
   case class TailExpressionBlock(
       index: SourceIndex,
@@ -298,7 +303,6 @@ object SoftAST {
   case class Function(
       index: SourceIndex,
       annotations: Seq[Annotation],
-      postAnnotationSpace: Option[Space],
       accessModifier: Option[AccessModifier],
       fn: TokenDocumented[Token.Fn.type],
       preSignatureSpace: Option[Space],
@@ -511,6 +515,7 @@ object SoftAST {
 
   case class TypeAssignment(
       index: SourceIndex,
+      annotations: Seq[Annotation],
       expressionLeft: ExpressionAST,
       preColonSpace: Option[Space],
       colon: TokenDocumented[Token.Colon.type],

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AnnotationParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AnnotationParserSpec.scala
@@ -194,4 +194,37 @@ class AnnotationParserSpec extends AnyWordSpec with Matchers {
       )
   }
 
+  "annotations without spaces" in {
+    val root = parseSoft("@using@using")
+
+    val parts = root.partsNonEmpty
+    parts should have size 1
+
+    val expressions = parts.head.asInstanceOf[SoftAST.ExpressionBlock].expressions
+    expressions should have size 2
+
+    expressions shouldBe
+      Seq(
+        SoftAST.Annotation(
+          index = indexOf(">>@using<<@using"),
+          at = At(indexOf(">>@<<using@using")),
+          preIdentifierSpace = None,
+          identifier = Identifier(indexOf("@>>using<<@using"), "using"),
+          postIdentifierSpace = None,
+          tuple = None,
+          postTupleSpace = None
+        ),
+        SoftAST.Annotation(
+          index = indexOf("@using>>@using<<"),
+          at = At(indexOf("@using>>@<<using")),
+          preIdentifierSpace = None,
+          identifier = Identifier(indexOf("@using@>>using<<"), "using"),
+          postIdentifierSpace = None,
+          tuple = None,
+          postTupleSpace = None
+        )
+      )
+
+  }
+
 }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeAssignmentParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeAssignmentParserSpec.scala
@@ -10,36 +10,127 @@ import org.scalatest.wordspec.AnyWordSpec
 class TypeAssignmentParserSpec extends AnyWordSpec {
 
   "report error" when {
-    "type name is not supplied" in {
-      val assignment =
-        parseTypeAssignment(": Type")
+    "type name is not supplied" when {
+      "without annotation" in {
+        val assignment =
+          parseTypeAssignment(": Type")
 
-      assignment shouldBe
-        SoftAST.TypeAssignment(
-          index = indexOf(">>: Type<<"),
-          expressionLeft = SoftAST.ExpressionExpected(indexOf(">><<: Type")),
-          preColonSpace = None,
-          colon = Colon(indexOf(">>:<< Type")),
-          postColonSpace = Some(SpaceOne(indexOf(":>> <<Type"))),
-          expressionRight = Identifier(indexOf(": >>Type<<"), "Type")
-        )
+        assignment shouldBe
+          SoftAST.TypeAssignment(
+            index = indexOf(">>: Type<<"),
+            annotations = Seq.empty,
+            expressionLeft = SoftAST.ExpressionExpected(indexOf(">><<: Type")),
+            preColonSpace = None,
+            colon = Colon(indexOf(">>:<< Type")),
+            postColonSpace = Some(SpaceOne(indexOf(":>> <<Type"))),
+            expressionRight = Identifier(indexOf(": >>Type<<"), "Type")
+          )
+      }
+
+      "with annotation" in {
+        val assignment =
+          parseTypeAssignment("@using : Type")
+
+        assignment shouldBe
+          SoftAST.TypeAssignment(
+            index = indexOf(">>@using : Type<<"),
+            annotations = Seq(
+              SoftAST.Annotation(
+                index = indexOf(">>@using <<: Type"),
+                at = At(indexOf(">>@<<using : Type")),
+                preIdentifierSpace = None,
+                identifier = Identifier(indexOf("@>>using<< : Type"), "using"),
+                postIdentifierSpace = Some(SpaceOne(indexOf("@using>> <<: Type"))),
+                tuple = None,
+                postTupleSpace = None
+              )
+            ),
+            expressionLeft = SoftAST.ExpressionExpected(indexOf("@using >><<: Type")),
+            preColonSpace = None,
+            colon = Colon(indexOf("@using >>:<< Type")),
+            postColonSpace = Some(SpaceOne(indexOf("@using :>> <<Type"))),
+            expressionRight = Identifier(indexOf("@using : >>Type<<"), "Type")
+          )
+      }
     }
   }
 
   "success" when {
     "type assignment is fully defined" when {
-      "defined as identifier" in {
+      "without annotation" in {
         val assignment =
           parseTypeAssignment("name : Type")
 
         assignment shouldBe
           SoftAST.TypeAssignment(
             index = indexOf(">>name : Type<<"),
+            annotations = Seq.empty,
             expressionLeft = Identifier(indexOf(">>name<< : Type"), "name"),
             preColonSpace = Some(SpaceOne(indexOf("name>> <<: Type"))),
             colon = Colon(indexOf("name >>:<< Type")),
             postColonSpace = Some(SpaceOne(indexOf("name :>> <<Type"))),
             expressionRight = Identifier(indexOf("name : >>Type<<"), "Type")
+          )
+      }
+
+      "with annotation" in {
+        val assignment =
+          parseTypeAssignment("@using name : Type")
+
+        assignment shouldBe
+          SoftAST.TypeAssignment(
+            index = indexOf(">>@using name : Type<<"),
+            annotations = Seq(
+              SoftAST.Annotation(
+                index = indexOf(">>@using <<name : Type"),
+                at = At(indexOf(">>@<<using name : Type")),
+                preIdentifierSpace = None,
+                identifier = Identifier(indexOf("@>>using<< name : Type"), "using"),
+                postIdentifierSpace = Some(SpaceOne(indexOf("@using>> <<name : Type"))),
+                tuple = None,
+                postTupleSpace = None
+              )
+            ),
+            expressionLeft = Identifier(indexOf("@using >>name<< : Type"), "name"),
+            preColonSpace = Some(SpaceOne(indexOf("@using name>> <<: Type"))),
+            colon = Colon(indexOf("@using name >>:<< Type")),
+            postColonSpace = Some(SpaceOne(indexOf("@using name :>> <<Type"))),
+            expressionRight = Identifier(indexOf("@using name : >>Type<<"), "Type")
+          )
+      }
+
+      "with multiple annotations" in {
+        val assignment =
+          parseTypeAssignment("@using @another name : Type")
+
+        assignment shouldBe
+          SoftAST.TypeAssignment(
+            index = indexOf(">>@using @another name : Type<<"),
+            annotations = Seq(
+              SoftAST.Annotation(
+                index = indexOf(">>@using <<@another name : Type"),
+                at = At(indexOf(">>@<<using @another name : Type")),
+                preIdentifierSpace = None,
+                identifier = Identifier(indexOf("@>>using<< @another name : Type"), "using"),
+                postIdentifierSpace = Some(SpaceOne(indexOf("@using>> <<@another name : Type"))),
+                tuple = None,
+                postTupleSpace = None
+              ),
+              SoftAST.Annotation(
+                index = indexOf("@using >>@another <<name : Type"),
+                at = At(indexOf("@using >>@<<another name : Type")),
+                preIdentifierSpace = None,
+                identifier = Identifier(indexOf("@using @>>another<< name : Type"), "another"),
+                postIdentifierSpace = Some(SpaceOne(indexOf("@using @another>> <<name : Type"))),
+                tuple = None,
+                postTupleSpace = None
+              )
+            ),
+            expressionLeft = Identifier(indexOf("@using @another >>name<< : Type"), "name"),
+            preColonSpace = Some(SpaceOne(indexOf("@using @another name>> <<: Type"))),
+            colon = Colon(indexOf("@using @another name >>:<< Type")),
+            postColonSpace = Some(SpaceOne(indexOf("@using @another name :>> <<Type"))),
+            expressionRight = Identifier(indexOf("@using @another name : >>Type<<"), "Type")
           )
       }
     }


### PR DESCRIPTION
Towards #104.

# Update

Only three parsers remain. 

- Brace syntax
- `if-else`
- `return a, b, c` - returning tuples without enclosing parens `()`.