### PR TITLE
Test constructors

### DIFF
--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AccessModifierParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AccessModifierParserSpec.scala
@@ -17,11 +17,7 @@ class AccessModifierParserSpec extends AnyWordSpec with Matchers {
 
       // Code "pubfn" should be recognised as a function. It is an identifier.
       root.parts should have size 1
-      root.parts.head shouldBe
-        Identifier(
-          index = indexOf(">>pubfn<<"),
-          text = "pubfn"
-        )
+      root.parts.head shouldBe Identifier(">>pubfn<<")
     }
   }
 
@@ -36,8 +32,8 @@ class AccessModifierParserSpec extends AnyWordSpec with Matchers {
       function.accessModifier.value shouldBe
         SoftAST.AccessModifier(
           index = indexOf(">>pub <<fn"),
-          pub = Pub(indexOf(">>pub<< fn")),
-          postTokenSpace = Some(SpaceOne(indexOf("pub>> <<fn")))
+          pub = Pub(">>pub<< fn"),
+          postTokenSpace = Some(Space("pub>> <<fn"))
         )
     }
 
@@ -48,7 +44,7 @@ class AccessModifierParserSpec extends AnyWordSpec with Matchers {
       accessModifier shouldBe
         SoftAST.AccessModifier(
           index = indexOf(">>pub<<"),
-          pub = Pub(indexOf(">>pub<<")),
+          pub = Pub(">>pub<<"),
           postTokenSpace = None
         )
     }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AnnotationParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AnnotationParserSpec.scala
@@ -35,9 +35,9 @@ class AnnotationParserSpec extends AnyWordSpec with Matchers {
       annotation shouldBe
         SoftAST.Annotation(
           index = indexOf(">>@<<"),
-          at = At(indexOf(">>@<<")),
+          at = At(">>@<<"),
           preIdentifierSpace = None,
-          identifier = SoftAST.IdentifierExpected(indexOf("@>><<")),
+          identifier = IdentifierExpected("@>><<"),
           postIdentifierSpace = None,
           tuple = None,
           postTupleSpace = None
@@ -49,7 +49,7 @@ class AnnotationParserSpec extends AnyWordSpec with Matchers {
         parseAnnotation("@anno(")
 
       // opening paren is parsed
-      annotation.tuple.value.openToken shouldBe OpenParen(indexOf("@anno>>(<<"))
+      annotation.tuple.value.openToken shouldBe OpenParen("@anno>>(<<")
       // closing paren is reported as expected
       annotation.tuple.value.closeToken shouldBe SoftAST.TokenExpected(indexOf("@anno(>><<"), Token.CloseParen)
     }
@@ -73,9 +73,9 @@ class AnnotationParserSpec extends AnyWordSpec with Matchers {
       annotation shouldBe
         SoftAST.Annotation(
           index = indexOf(">>@<<fn function()"),
-          at = At(indexOf(">>@<<fn function()")),
+          at = At(">>@<<fn function()"),
           preIdentifierSpace = None,
-          identifier = SoftAST.IdentifierExpected(indexOf("@>><<fn function()")),
+          identifier = IdentifierExpected("@>><<fn function()"),
           postIdentifierSpace = None,
           tuple = None,
           postTupleSpace = None
@@ -90,12 +90,9 @@ class AnnotationParserSpec extends AnyWordSpec with Matchers {
     annotation shouldBe
       SoftAST.Annotation(
         index = indexOf(">>@anno<<"),
-        at = At(indexOf(">>@<<anno")),
+        at = At(">>@<<anno"),
         preIdentifierSpace = None,
-        identifier = Identifier(
-          index = indexOf("@>>anno<<"),
-          text = "anno"
-        ),
+        identifier = Identifier("@>>anno<<"),
         postIdentifierSpace = None,
         tuple = None,
         postTupleSpace = None
@@ -109,12 +106,9 @@ class AnnotationParserSpec extends AnyWordSpec with Matchers {
     annotation shouldBe
       SoftAST.Annotation(
         index = indexOf(">>@anno(a, b, c + d)<<"),
-        at = At(indexOf(">>@<<anno(a, b, c + d)")),
+        at = At(">>@<<anno(a, b, c + d)"),
         preIdentifierSpace = None,
-        identifier = Identifier(
-          index = indexOf("@>>anno<<(a, b, c + d)"),
-          text = "anno"
-        ),
+        identifier = Identifier("@>>anno<<(a, b, c + d)"),
         postIdentifierSpace = None,
         // No need to test the AST for the Tuple. Simply test that a tuple is defined
         tuple = Some(annotation.tuple.value),
@@ -169,14 +163,11 @@ class AnnotationParserSpec extends AnyWordSpec with Matchers {
           )
         ),
         preIdentifierSpace = None,
-        identifier = Identifier(
-          index = indexOf {
-            """// documentation
-              |@>>anno<<
-              |""".stripMargin
-          },
-          text = "anno"
-        ),
+        identifier = Identifier {
+          """// documentation
+            |@>>anno<<
+            |""".stripMargin
+        },
         postIdentifierSpace = Some(
           SoftAST.Space(
             Code(
@@ -207,18 +198,18 @@ class AnnotationParserSpec extends AnyWordSpec with Matchers {
       Seq(
         SoftAST.Annotation(
           index = indexOf(">>@using<<@using"),
-          at = At(indexOf(">>@<<using@using")),
+          at = At(">>@<<using@using"),
           preIdentifierSpace = None,
-          identifier = Identifier(indexOf("@>>using<<@using"), "using"),
+          identifier = Identifier("@>>using<<@using"),
           postIdentifierSpace = None,
           tuple = None,
           postTupleSpace = None
         ),
         SoftAST.Annotation(
           index = indexOf("@using>>@using<<"),
-          at = At(indexOf("@using>>@<<using")),
+          at = At("@using>>@<<using"),
           preIdentifierSpace = None,
-          identifier = Identifier(indexOf("@using@>>using<<"), "using"),
+          identifier = Identifier("@using@>>using<<"),
           postIdentifierSpace = None,
           tuple = None,
           postTupleSpace = None

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentParserSpec.scala
@@ -39,11 +39,11 @@ class AssignmentParserSpec extends AnyWordSpec with Matchers {
         infix shouldBe
           SoftAST.InfixExpression(
             index = indexOf(">>variable ==<<"),
-            leftExpression = Identifier(indexOf(">>variable<< =="), "variable"),
-            preOperatorSpace = Some(SpaceOne(indexOf("variable>> <<=="))),
-            operator = EqualEqual(indexOf("variable >>==<<")),
+            leftExpression = Identifier(">>variable<< =="),
+            preOperatorSpace = Some(Space("variable>> <<==")),
+            operator = EqualEqual("variable >>==<<"),
             postOperatorSpace = None,
-            rightExpression = SoftAST.ExpressionExpected(indexOf("variable ==>><<"))
+            rightExpression = ExpressionExpected("variable ==>><<")
           )
       }
 
@@ -65,11 +65,11 @@ class AssignmentParserSpec extends AnyWordSpec with Matchers {
         assignment shouldBe
           SoftAST.Assignment(
             index = indexOf(">>variable =<<"),
-            expressionLeft = Identifier(indexOf(">>variable<<="), "variable"),
-            postIdentifierSpace = Some(SpaceOne(indexOf("variable>> <<="))),
-            equalToken = Equal(indexOf("variable >>=<<")),
+            expressionLeft = Identifier(">>variable<<="),
+            postIdentifierSpace = Some(Space("variable>> <<=")),
+            equalToken = Equal("variable >>=<<"),
             postEqualSpace = None,
-            expressionRight = SoftAST.ExpressionExpected(indexOf("variable =>><<"))
+            expressionRight = ExpressionExpected("variable =>><<")
           )
       }
     }
@@ -82,10 +82,10 @@ class AssignmentParserSpec extends AnyWordSpec with Matchers {
         assigment shouldBe
           SoftAST.Assignment(
             index = indexOf(">>variable = 1<<"),
-            expressionLeft = Identifier(indexOf(">>variable<< = 1"), "variable"),
-            postIdentifierSpace = Some(SpaceOne(indexOf("variable>> <<= 1"))),
-            equalToken = Equal(indexOf("variable >>=<< 1")),
-            postEqualSpace = Some(SpaceOne(indexOf("variable =>> <<1"))),
+            expressionLeft = Identifier(">>variable<< = 1"),
+            postIdentifierSpace = Some(Space("variable>> <<= 1")),
+            equalToken = Equal("variable >>=<< 1"),
+            postEqualSpace = Some(Space("variable =>> <<1")),
             expressionRight = Number(indexOf("variable = >>1<<"), "1")
           )
       }
@@ -97,16 +97,16 @@ class AssignmentParserSpec extends AnyWordSpec with Matchers {
         assigment shouldBe
           SoftAST.Assignment(
             index = indexOf(">>variable = variable + 1<<"),
-            expressionLeft = Identifier(indexOf(">>variable<< = variable + 1"), "variable"),
-            postIdentifierSpace = Some(SpaceOne(indexOf("variable>> <<= variable + 1"))),
-            equalToken = Equal(indexOf("variable >>=<< variable + 1")),
-            postEqualSpace = Some(SpaceOne(indexOf("variable =>> << variable + 1"))),
+            expressionLeft = Identifier(">>variable<< = variable + 1"),
+            postIdentifierSpace = Some(Space("variable>> <<= variable + 1")),
+            equalToken = Equal("variable >>=<< variable + 1"),
+            postEqualSpace = Some(Space("variable =>> << variable + 1")),
             expressionRight = SoftAST.InfixExpression(
               index = indexOf("variable = >>variable + 1<<"),
-              leftExpression = Identifier(indexOf("variable = >>variable<< + 1"), "variable"),
-              preOperatorSpace = Some(SpaceOne(indexOf("variable = variable>> <<+ 1"))),
-              operator = Plus(indexOf("variable = variable >>+<< 1")),
-              postOperatorSpace = Some(SpaceOne(indexOf("variable = variable +>> <<1"))),
+              leftExpression = Identifier("variable = >>variable<< + 1"),
+              preOperatorSpace = Some(Space("variable = variable>> <<+ 1")),
+              operator = Plus("variable = variable >>+<< 1"),
+              postOperatorSpace = Some(Space("variable = variable +>> <<1")),
               rightExpression = Number(indexOf("variable = variable + >>1<<"), "1")
             )
           )
@@ -166,7 +166,7 @@ class AssignmentParserSpec extends AnyWordSpec with Matchers {
 
         // right expression is a number
         assignment.expressionRight shouldBe
-          SoftAST.ExpressionExpected(indexOf("obj.func(param).counter =>><<"))
+          ExpressionExpected("obj.func(param).counter =>><<")
       }
     }
   }
@@ -209,7 +209,7 @@ class AssignmentParserSpec extends AnyWordSpec with Matchers {
         val left = assignment.expressionLeft.asInstanceOf[SoftAST.MutableBinding]
         left.toCode() shouldBe "mut number"
 
-        assignment.expressionRight shouldBe SoftAST.ExpressionExpected(indexOf("mut number = >><<#00112233"))
+        assignment.expressionRight shouldBe ExpressionExpected("mut number = >><<#00112233")
 
         unresolved shouldBe
           Unresolved(

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BStringParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BStringParserSpec.scala
@@ -30,9 +30,9 @@ class BStringParserSpec extends AnyWordSpec with Matchers {
       string shouldBe
         SoftAST.BString(
           index = indexOf(">>b`<<"),
-          b = B(indexOf(">>b<<`")),
+          b = B(">>b<<`"),
           postBSpace = None,
-          startTick = Tick(indexOf("b>>`<<")),
+          startTick = Tick("b>>`<<"),
           text = None,
           endTick = SoftAST.TokenExpected(indexOf("b`>><<"), Token.Tick)
         )
@@ -46,11 +46,11 @@ class BStringParserSpec extends AnyWordSpec with Matchers {
     string shouldBe
       SoftAST.BString(
         index = indexOf(">>b``<<"),
-        b = B(indexOf(">>b<<``")),
+        b = B(">>b<<``"),
         postBSpace = None,
-        startTick = Tick(indexOf("b>>`<<`")),
+        startTick = Tick("b>>`<<`"),
         text = None,
-        endTick = Tick(indexOf("b`>>`<<"))
+        endTick = Tick("b`>>`<<")
       )
   }
 
@@ -61,11 +61,11 @@ class BStringParserSpec extends AnyWordSpec with Matchers {
     string shouldBe
       SoftAST.BString(
         index = indexOf(">>b ` `<<"),
-        b = B(indexOf(">>b<< ` `")),
-        postBSpace = Some(SpaceOne(indexOf("b>> <<` `"))),
-        startTick = Tick(indexOf("b >>`<< `")),
+        b = B(">>b<< ` `"),
+        postBSpace = Some(Space("b>> <<` `")),
+        startTick = Tick("b >>`<< `"),
         text = Some(SoftAST.CodeString(indexOf("b `>> <<`"), " ")),
-        endTick = Tick(indexOf("b ` >>`<<"))
+        endTick = Tick("b ` >>`<<")
       )
   }
 
@@ -138,7 +138,8 @@ class BStringParserSpec extends AnyWordSpec with Matchers {
                 |a string value
                 |<<""".stripMargin
             },
-            text = """ this is
+            text =
+              """ this is
                 |
                 |a string value
                 |""".stripMargin

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BStringParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BStringParserSpec.scala
@@ -138,8 +138,7 @@ class BStringParserSpec extends AnyWordSpec with Matchers {
                 |a string value
                 |<<""".stripMargin
             },
-            text =
-              """ this is
+            text = """ this is
                 |
                 |a string value
                 |""".stripMargin

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BooleanParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BooleanParserSpec.scala
@@ -2,7 +2,6 @@ package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
-import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.OptionValues._
@@ -10,11 +9,11 @@ import org.scalatest.OptionValues._
 class BooleanParserSpec extends AnyWordSpec with Matchers {
 
   "true" in {
-    parseBoolean("true").token shouldBe True(indexOf(">>true<<"))
+    parseBoolean("true").token shouldBe True(">>true<<")
   }
 
   "false" in {
-    parseBoolean("false").token shouldBe False(indexOf(">>false<<"))
+    parseBoolean("false").token shouldBe False(">>false<<")
   }
 
   "boolean with comments" in {

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommentParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommentParserSpec.scala
@@ -38,7 +38,7 @@ class CommentParserSpec extends AnyWordSpec with Matchers {
           comments = Seq(
             SoftAST.Comment(
               index = indexOf(">>//<<"),
-              doubleForwardSlash = DoubleForwardSlash(indexOf(">>//<<")),
+              doubleForwardSlash = DoubleForwardSlash(">>//<<"),
               preTextSpace = None,
               text = None,
               postTextSpace = None
@@ -63,8 +63,8 @@ class CommentParserSpec extends AnyWordSpec with Matchers {
           comments = Seq(
             SoftAST.Comment(
               index = indexOf(">>// <<"),
-              doubleForwardSlash = DoubleForwardSlash(indexOf(">>//<< ")),
-              preTextSpace = Some(SpaceOne(indexOf("//>> <<"))),
+              doubleForwardSlash = DoubleForwardSlash(">>//<< "),
+              preTextSpace = Some(Space("//>> <<")),
               text = None,
               postTextSpace = None
             )
@@ -91,8 +91,8 @@ class CommentParserSpec extends AnyWordSpec with Matchers {
           comments = Seq(
             SoftAST.Comment(
               index = indexOf(s">>// my comment <<$newLine"),
-              doubleForwardSlash = DoubleForwardSlash(indexOf(s">>//<< my comment $newLine")),
-              preTextSpace = Some(SpaceOne(indexOf(s"//>> <<my comment $newLine"))),
+              doubleForwardSlash = DoubleForwardSlash(s">>//<< my comment $newLine"),
+              preTextSpace = Some(Space(s"//>> <<my comment $newLine")),
               text = Some(
                 SoftAST.CodeString(
                   index = indexOf(s"// >>my comment <<$newLine"),
@@ -102,7 +102,7 @@ class CommentParserSpec extends AnyWordSpec with Matchers {
               postTextSpace = None
             )
           ),
-          postCommentSpace = Some(SpaceNewline(indexOf(s"// my comment >>$newLine<<")))
+          postCommentSpace = Some(Space(s"// my comment >>$newLine<<"))
         )
 
       comment shouldBe expected
@@ -124,8 +124,8 @@ class CommentParserSpec extends AnyWordSpec with Matchers {
           comments = Seq(
             SoftAST.Comment(
               index = indexOf(s">>$code<<"),
-              doubleForwardSlash = DoubleForwardSlash(indexOf(">>//<< fn function()")),
-              preTextSpace = Some(SpaceOne(indexOf("//>> <<fn function()"))),
+              doubleForwardSlash = DoubleForwardSlash(">>//<< fn function()"),
+              preTextSpace = Some(Space("//>> <<fn function()")),
               text = Some(
                 SoftAST.CodeString(
                   index = indexOf("// >>fn function()<<"),
@@ -148,15 +148,15 @@ class CommentParserSpec extends AnyWordSpec with Matchers {
         val comment =
           parseSoft {
             """
-                |//
-                |let
-                |//
-                |counter
-                |//
-                |=
-                |//
-                |0
-                |""".stripMargin
+              |//
+              |let
+              |//
+              |counter
+              |//
+              |=
+              |//
+              |0
+              |""".stripMargin
           }
 
         val parts = comment.partsNonEmpty
@@ -201,9 +201,9 @@ class CommentParserSpec extends AnyWordSpec with Matchers {
         val comment =
           parseSoft {
             """
-                |//
-                |let counter = 0
-                |""".stripMargin
+              |//
+              |let counter = 0
+              |""".stripMargin
           }
 
         val parts = comment.partsNonEmpty
@@ -214,25 +214,25 @@ class CommentParserSpec extends AnyWordSpec with Matchers {
           SoftAST.Comments(
             index = indexOf {
               """
-                  |>>//
-                  |<<let counter = 0
-                  |""".stripMargin
+                |>>//
+                |<<let counter = 0
+                |""".stripMargin
             },
             preCommentSpace = None,
             comments = Seq(
               SoftAST.Comment(
                 index = indexOf {
                   """
-                      |>>//<<
-                      |let counter = 0
-                      |""".stripMargin
+                    |>>//<<
+                    |let counter = 0
+                    |""".stripMargin
                 },
                 doubleForwardSlash = DoubleForwardSlash {
                   indexOf {
                     """
-                        |>>//<<
-                        |let counter = 0
-                        |""".stripMargin
+                      |>>//<<
+                      |let counter = 0
+                      |""".stripMargin
                   }
                 },
                 preTextSpace = None,
@@ -241,14 +241,12 @@ class CommentParserSpec extends AnyWordSpec with Matchers {
               )
             ),
             postCommentSpace = Some(
-              SpaceNewline(
-                indexOf {
-                  """
-                      |//>>
-                      |<<let counter = 0
-                      |""".stripMargin
-                }
-              )
+              Space {
+                """
+                  |//>>
+                  |<<let counter = 0
+                  |""".stripMargin
+              }
             )
           )
       }
@@ -257,10 +255,10 @@ class CommentParserSpec extends AnyWordSpec with Matchers {
         val comment =
           parseSoft {
             """
-                |//
-                |//
-                |let counter = 0
-                |""".stripMargin
+              |//
+              |//
+              |let counter = 0
+              |""".stripMargin
           }
 
         val parts = comment.partsNonEmpty
@@ -271,59 +269,57 @@ class CommentParserSpec extends AnyWordSpec with Matchers {
           SoftAST.Comments(
             index = indexOf {
               """
-                  |>>//
-                  |//
-                  |<<let counter = 0
-                  |""".stripMargin
+                |>>//
+                |//
+                |<<let counter = 0
+                |""".stripMargin
             },
             preCommentSpace = None,
             comments = Seq(
               SoftAST.Comment(
                 index = indexOf {
                   """
-                      |>>//
-                      |<<//
-                      |let counter = 0
-                      |""".stripMargin
+                    |>>//
+                    |<<//
+                    |let counter = 0
+                    |""".stripMargin
                 },
                 doubleForwardSlash = DoubleForwardSlash {
                   indexOf {
                     """
-                        |>>//<<
-                        |//
-                        |let counter = 0
-                        |""".stripMargin
+                      |>>//<<
+                      |//
+                      |let counter = 0
+                      |""".stripMargin
                   }
                 },
                 preTextSpace = None,
                 text = None,
                 postTextSpace = Some(
-                  SpaceNewline(
-                    indexOf {
-                      """
-                            |//>>
-                            |<<//
-                            |let counter = 0
-                            |""".stripMargin
-                    }
-                  )
+                  Space {
+                    """
+                      |//>>
+                      |<<//
+                      |let counter = 0
+                      |""".stripMargin
+                  }
                 )
               ),
               SoftAST.Comment(
                 index = indexOf {
                   """
-                      |//
-                      |>>//<<
-                      |let counter = 0
-                      |""".stripMargin
+                    |//
+                    |>>//<<
+                    |let counter = 0
+                    |""".stripMargin
                 },
                 doubleForwardSlash = DoubleForwardSlash {
                   indexOf {
                     """
-                        |//
-                        |>>//<<
-                        |let counter = 0
-                        |""".stripMargin
+                      |//
+                      |>>//<<
+                      |let counter = 0
+                      |""".stripMargin
                   }
                 },
                 preTextSpace = None,
@@ -332,15 +328,13 @@ class CommentParserSpec extends AnyWordSpec with Matchers {
               )
             ),
             postCommentSpace = Some(
-              SpaceNewline(
-                indexOf {
-                  """
-                      |//
-                      |//>>
-                      |<<let counter = 0
-                      |""".stripMargin
-                }
-              )
+              Space {
+                """
+                  |//
+                  |//>>
+                  |<<let counter = 0
+                  |""".stripMargin
+              }
             )
           )
       }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommentsSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CommentsSpec.scala
@@ -33,13 +33,11 @@ class CommentsSpec extends AnyWordSpec with Matchers {
           }
         ),
         preTextSpace = Some(
-          SpaceOne(
-            indexOf {
-              """//>> <<one
-                |// two
-                |""".stripMargin
-            }
-          )
+          Space {
+            """//>> <<one
+              |// two
+              |""".stripMargin
+          }
         ),
         text = Some(
           SoftAST.CodeString(
@@ -52,13 +50,11 @@ class CommentsSpec extends AnyWordSpec with Matchers {
           )
         ),
         postTextSpace = Some(
-          SpaceNewline(
-            indexOf {
-              """// one>>
-                |<<// two
-                |""".stripMargin
-            }
-          )
+          Space {
+            """// one>>
+              |<<// two
+              |""".stripMargin
+          }
         )
       )
 
@@ -80,13 +76,11 @@ class CommentsSpec extends AnyWordSpec with Matchers {
           }
         ),
         preTextSpace = Some(
-          SpaceOne(
-            indexOf {
-              """// one
-                |//>> <<two
-                |""".stripMargin
-            }
-          )
+          Space {
+            """// one
+              |//>> <<two
+              |""".stripMargin
+          }
         ),
         text = Some(
           SoftAST.CodeString(
@@ -113,13 +107,11 @@ class CommentsSpec extends AnyWordSpec with Matchers {
           expectedSecondComment
         ),
         postCommentSpace = Some(
-          SpaceNewline(
-            index = indexOf {
-              """// one
-                |// two>>
-                |<<""".stripMargin
-            }
-          )
+          Space {
+            """// one
+              |// two>>
+              |<<""".stripMargin
+          }
         )
       )
 
@@ -141,8 +133,8 @@ class CommentsSpec extends AnyWordSpec with Matchers {
             comments = Seq(
               SoftAST.Comment(
                 index = indexOf(s">>$code<<"),
-                doubleForwardSlash = DoubleForwardSlash(indexOf(s">>//<< //")),
-                preTextSpace = Some(SpaceOne(indexOf(s"//>> <<//"))),
+                doubleForwardSlash = DoubleForwardSlash(s">>//<< //"),
+                preTextSpace = Some(Space(s"//>> <<//")),
                 text = Some(
                   SoftAST.CodeString(
                     index = indexOf(s"// >>//<<"),
@@ -187,12 +179,10 @@ class CommentsSpec extends AnyWordSpec with Matchers {
                 preTextSpace = None,
                 text = None,
                 postTextSpace = Some(
-                  SpaceNewline(
-                    indexOf {
-                      """//>>
-                        |<<//""".stripMargin
-                    }
-                  )
+                  Space {
+                    """//>>
+                      |<<//""".stripMargin
+                  }
                 )
               ),
               SoftAST.Comment(

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/EnumParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/EnumParserSpec.scala
@@ -42,7 +42,7 @@ class EnumParserSpec extends AnyWordSpec {
           index = indexOf(">>enum<<"),
           enumToken = Enum(">>enum<<"),
           preIdentifierSpace = None,
-          identifier = SoftAST.IdentifierExpected(indexOf("enum>><<")),
+          identifier = IdentifierExpected("enum>><<"),
           preBlockSpace = None,
           block = None
         )
@@ -56,7 +56,7 @@ class EnumParserSpec extends AnyWordSpec {
           index = indexOf(">>enum {}<<"),
           enumToken = Enum(">>enum<<"),
           preIdentifierSpace = Some(Space("enum>> <<{}")),
-          identifier = SoftAST.IdentifierExpected(indexOf("enum >><<{}")),
+          identifier = IdentifierExpected("enum >><<{}"),
           preBlockSpace = None,
           block = Some(
             SoftAST.Block(
@@ -77,7 +77,7 @@ class EnumParserSpec extends AnyWordSpec {
           index = indexOf(">>enum { }<<"),
           enumToken = Enum(">>enum<< { }"),
           preIdentifierSpace = Some(Space("enum>> <<{ }")),
-          identifier = SoftAST.IdentifierExpected(indexOf("enum >><<{ }")),
+          identifier = IdentifierExpected("enum >><<{ }"),
           preBlockSpace = None,
           block = Some(
             SoftAST.Block(
@@ -100,7 +100,7 @@ class EnumParserSpec extends AnyWordSpec {
           index = indexOf(">>enum { blah }<<"),
           enumToken = Enum(">>enum<< { blah }"),
           preIdentifierSpace = Some(Space("enum>> <<{ blah }")),
-          identifier = SoftAST.IdentifierExpected(indexOf("enum >><<{ blah }")),
+          identifier = IdentifierExpected("enum >><<{ blah }"),
           preBlockSpace = None,
           block = Some(
             SoftAST.Block(
@@ -125,7 +125,7 @@ class EnumParserSpec extends AnyWordSpec {
           index = indexOf(">>enum { value = 1 }<<"),
           enumToken = Enum(">>enum<< { value = 1 }"),
           preIdentifierSpace = Some(Space("enum>> <<{ value = 1 }")),
-          identifier = SoftAST.IdentifierExpected(indexOf("enum >><<{ value = 1 }")),
+          identifier = IdentifierExpected("enum >><<{ value = 1 }"),
           preBlockSpace = None,
           block = Some(
             SoftAST.Block(
@@ -157,7 +157,7 @@ class EnumParserSpec extends AnyWordSpec {
           index = indexOf(">>enum { one = 1 two = 2 }<<"),
           enumToken = Enum(">>enum<< { one = 1 two = 2 }"),
           preIdentifierSpace = Some(Space("enum>> <<{ one = 1 two = 2 }")),
-          identifier = SoftAST.IdentifierExpected(indexOf("enum >><<{ one = 1 two = 2 }")),
+          identifier = IdentifierExpected("enum >><<{ one = 1 two = 2 }"),
           preBlockSpace = None,
           block = Some(
             SoftAST.Block(
@@ -200,7 +200,7 @@ class EnumParserSpec extends AnyWordSpec {
           index = indexOf(">>enum { blah two = 2 }<<"),
           enumToken = Enum(">>enum<< { blah two = 2 }"),
           preIdentifierSpace = Some(Space("enum>> <<{ blah two = 2 }")),
-          identifier = SoftAST.IdentifierExpected(indexOf("enum >><<{ blah two = 2 }")),
+          identifier = IdentifierExpected("enum >><<{ blah two = 2 }"),
           preBlockSpace = None,
           block = Some(
             SoftAST.Block(

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/EventParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/EventParserSpec.scala
@@ -17,19 +17,15 @@ class EventParserSpec extends AnyWordSpec {
       root.parts should have size 1
       val identifier = root.parts.head
 
-      identifier shouldBe
-        Identifier(
-          index = indexOf(">>eventMyEvent<<"),
-          text = "eventMyEvent"
-        )
+      identifier shouldBe Identifier(">>eventMyEvent<<")
     }
   }
 
   "successfully parse an event" in {
     val event = parseEvent("event MyEvent(varName: TypeName")
 
-    event.eventToken shouldBe Event(indexOf(">>event<< MyEvent(varName: TypeName"))
-    event.identifier shouldBe Identifier(indexOf("event >>MyEvent<<(varName: TypeName"), "MyEvent")
+    event.eventToken shouldBe Event(">>event<< MyEvent(varName: TypeName")
+    event.identifier shouldBe Identifier("event >>MyEvent<<(varName: TypeName")
 
     // Tuples are tested in TupleSpec, test for the index and string code here.
     event.params.index shouldBe indexOf("event MyEvent>>(varName: TypeName<<")

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FnAnnotationSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FnAnnotationSpec.scala
@@ -49,21 +49,17 @@ class FnAnnotationSpec extends AnyWordSpec with Matchers {
             |<<fn function() -> ()
             |""".stripMargin
         },
-        at = At(
-          indexOf {
-            """>>@<<
-              |fn function() -> ()
+        at = At {
+          """>>@<<
+            |fn function() -> ()
+            |""".stripMargin
+        },
+        preIdentifierSpace = Some(
+          Space {
+            """@>>
+              |<<fn function() -> ()
               |""".stripMargin
           }
-        ),
-        preIdentifierSpace = Some(
-          SpaceNewline(
-            indexOf {
-              """@>>
-                |<<fn function() -> ()
-                |""".stripMargin
-            }
-          )
         ),
         identifier = SoftAST.IdentifierExpected(
           indexOf {
@@ -94,30 +90,23 @@ class FnAnnotationSpec extends AnyWordSpec with Matchers {
               |<<fn function() -> ()
               |""".stripMargin
           },
-          at = At(
-            indexOf {
-              """>>@<<annotation
-                |fn function() -> ()
+          At {
+            """>>@<<annotation
+              |fn function() -> ()
+              |""".stripMargin
+          },
+          preIdentifierSpace = None,
+          identifier = Identifier {
+            """@>>annotation<<
+              |fn function() -> ()
+              |""".stripMargin
+          },
+          postIdentifierSpace = Some(
+            Space {
+              """@annotation>>
+                |<<fn function() -> ()
                 |""".stripMargin
             }
-          ),
-          preIdentifierSpace = None,
-          identifier = Identifier(
-            index = indexOf {
-              """@>>annotation<<
-                |fn function() -> ()
-                |""".stripMargin
-            },
-            text = "annotation"
-          ),
-          postIdentifierSpace = Some(
-            SpaceNewline(
-              indexOf {
-                """@annotation>>
-                  |<<fn function() -> ()
-                  |""".stripMargin
-              }
-            )
           ),
           tuple = None,
           postTupleSpace = None
@@ -147,55 +136,44 @@ class FnAnnotationSpec extends AnyWordSpec with Matchers {
               |fn function() -> ()
               |""".stripMargin
           },
-          at = At(
-            indexOf {
-              """>>@<< annotation (a, b + c, c = 4)
+          at = At {
+            """>>@<< annotation (a, b + c, c = 4)
+              |@ last ()
+              |fn function() -> ()
+              |""".stripMargin
+          },
+          preIdentifierSpace = Some(
+            Space {
+              """@>> <<annotation (a, b + c, c = 4)
                 |@ last ()
                 |fn function() -> ()
                 |""".stripMargin
             }
           ),
-          preIdentifierSpace = Some(
-            SpaceOne(
-              indexOf {
-                """@>> <<annotation (a, b + c, c = 4)
-                  |@ last ()
-                  |fn function() -> ()
-                  |""".stripMargin
-              }
-            )
-          ),
-          identifier = Identifier(
-            index = indexOf {
-              """@ >>annotation<< (a, b + c, c = 4)
+          identifier = Identifier {
+            """@ >>annotation<< (a, b + c, c = 4)
+              |@ last ()
+              |fn function() -> ()
+              |""".stripMargin
+          },
+          postIdentifierSpace = Some(
+            Space {
+              """@ annotation>> <<(a, b + c, c = 4)
                 |@ last ()
                 |fn function() -> ()
                 |""".stripMargin
-            },
-            text = "annotation"
-          ),
-          postIdentifierSpace = Some(
-            SpaceOne(
-              index = indexOf {
-                """@ annotation>> <<(a, b + c, c = 4)
-                  |@ last ()
-                  |fn function() -> ()
-                  |""".stripMargin
-              }
-            )
+            }
           ),
           tuple =
             // This test case is not targeting Tuples AST, simply parse it.
             Some(findAnnotation("annotation")(code).flatMap(_.tuple).value),
           postTupleSpace = Some(
-            SpaceNewline(
-              index = indexOf {
-                """@ annotation (a, b + c, c = 4)>>
-                  |<<@ last ()
-                  |fn function() -> ()
-                  |""".stripMargin
-              }
-            )
+            Space {
+              """@ annotation (a, b + c, c = 4)>>
+                |<<@ last ()
+                |fn function() -> ()
+                |""".stripMargin
+            }
           )
         )
 
@@ -207,55 +185,44 @@ class FnAnnotationSpec extends AnyWordSpec with Matchers {
               |<<fn function() -> ()
               |""".stripMargin
           },
-          at = At(
-            indexOf {
+          at = At {
+            """@ annotation (a, b + c, c = 4)
+              |>>@<< last ()
+              |fn function() -> ()
+              |""".stripMargin
+          },
+          preIdentifierSpace = Some(
+            Space {
               """@ annotation (a, b + c, c = 4)
-                |>>@<< last ()
+                |@>> <<last ()
                 |fn function() -> ()
                 |""".stripMargin
             }
           ),
-          preIdentifierSpace = Some(
-            SpaceOne(
-              index = indexOf {
-                """@ annotation (a, b + c, c = 4)
-                  |@>> <<last ()
-                  |fn function() -> ()
-                  |""".stripMargin
-              }
-            )
-          ),
-          identifier = Identifier(
-            index = indexOf {
+          identifier = Identifier {
+            """@ annotation (a, b + c, c = 4)
+              |@ >>last<< ()
+              |fn function() -> ()
+              |""".stripMargin
+          },
+          postIdentifierSpace = Some(
+            Space {
               """@ annotation (a, b + c, c = 4)
-                |@ >>last<< ()
+                |@ last>> <<()
                 |fn function() -> ()
                 |""".stripMargin
-            },
-            text = "last"
-          ),
-          postIdentifierSpace = Some(
-            SpaceOne(
-              index = indexOf {
-                """@ annotation (a, b + c, c = 4)
-                  |@ last>> <<()
-                  |fn function() -> ()
-                  |""".stripMargin
-              }
-            )
+            }
           ),
           tuple =
             // This test case is not targeting Tuples AST, simply parse it.
             Some(findAnnotation("last")(code).flatMap(_.tuple).value),
           postTupleSpace = Some(
-            SpaceNewline(
-              indexOf {
-                """@ annotation (a, b + c, c = 4)
-                  |@ last ()>>
-                  |<<fn function() -> ()
-                  |""".stripMargin
-              }
-            )
+            Space {
+              """@ annotation (a, b + c, c = 4)
+                |@ last ()>>
+                |<<fn function() -> ()
+                |""".stripMargin
+            }
           )
         )
 

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FnDecelerationSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FnDecelerationSpec.scala
@@ -30,7 +30,7 @@ class FnDecelerationSpec extends AnyWordSpec with Matchers {
       val function =
         parseFunction("fn")
 
-      function.fn shouldBe Fn(indexOf(">>fn<<"))
+      function.fn shouldBe Fn(">>fn<<")
       function.preSignatureSpace shouldBe None
       function.postSignatureSpace shouldBe empty
       function.block shouldBe empty
@@ -48,7 +48,7 @@ class FnDecelerationSpec extends AnyWordSpec with Matchers {
       functions should have size 1
       val function = functions.head
 
-      function.fn shouldBe Fn(indexOf(" >>fn<<"))
+      function.fn shouldBe Fn(" >>fn<<")
       function.preSignatureSpace shouldBe None
       function.postSignatureSpace shouldBe empty
       function.block shouldBe empty
@@ -58,7 +58,7 @@ class FnDecelerationSpec extends AnyWordSpec with Matchers {
       val function =
         parseFunction("fn  ")
 
-      function.fn shouldBe Fn(indexOf(">>fn<<  "))
+      function.fn shouldBe Fn(">>fn<<  ")
 
       function.preSignatureSpace shouldBe
         Some(
@@ -128,11 +128,7 @@ class FnDecelerationSpec extends AnyWordSpec with Matchers {
       /**
        * Test first function
        */
-      functions.head.signature.fnName shouldBe
-        Identifier(
-          index = indexOf("fn >>function<<"),
-          text = "function"
-        )
+      functions.head.signature.fnName shouldBe Identifier("fn >>function<<")
 
       /**
        * Test second function

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ForParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ForParserSpec.scala
@@ -15,11 +15,7 @@ class ForParserSpec extends AnyWordSpec with Matchers {
         parseSoft("forloop")
 
       root.parts should have size 1
-      root.parts.head shouldBe
-        Identifier(
-          index = indexOf(">>forloop<<"),
-          text = "forloop"
-        )
+      root.parts.head shouldBe Identifier(">>forloop<<")
     }
   }
 
@@ -31,19 +27,19 @@ class ForParserSpec extends AnyWordSpec with Matchers {
       forExpression shouldBe
         SoftAST.For(
           index = indexOf(">>for <<"),
-          forToken = For(indexOf(">>for<< ")),
-          postForSpace = Some(SpaceOne(indexOf("for>> <<"))),
+          forToken = For(">>for<< "),
+          postForSpace = Some(Space("for>> <<")),
           openParen = SoftAST.TokenExpected(indexOf("for >><<"), Token.OpenParen),
           postOpenParenSpace = None,
-          expression1 = SoftAST.ExpressionExpected(indexOf("for >><<")),
+          expression1 = ExpressionExpected("for >><<"),
           postExpression1Space = None,
           postExpression1Semicolon = SoftAST.TokenExpected(indexOf("for >><<"), Token.Semicolon),
           postExpression1SemicolonSpace = None,
-          expression2 = SoftAST.ExpressionExpected(indexOf("for >><<")),
+          expression2 = ExpressionExpected("for >><<"),
           postExpression2Space = None,
           postExpression2Semicolon = SoftAST.TokenExpected(indexOf("for >><<"), Token.Semicolon),
           postExpression2SemicolonSpace = None,
-          expression3 = SoftAST.ExpressionExpected(indexOf("for >><<")),
+          expression3 = ExpressionExpected("for >><<"),
           postExpression3Space = None,
           closeParen = SoftAST.TokenExpected(indexOf("for >><<"), Token.CloseParen),
           postCloseParenSpace = None,
@@ -58,19 +54,19 @@ class ForParserSpec extends AnyWordSpec with Matchers {
       forExpression shouldBe
         SoftAST.For(
           index = indexOf(">>for(<<"),
-          forToken = For(indexOf(">>for<<(")),
+          forToken = For(">>for<<("),
           postForSpace = None,
-          openParen = OpenParen(indexOf("for>>(<<")),
+          openParen = OpenParen("for>>(<<"),
           postOpenParenSpace = None,
-          expression1 = SoftAST.ExpressionExpected(indexOf("for(>><<")),
+          expression1 = ExpressionExpected("for(>><<"),
           postExpression1Space = None,
           postExpression1Semicolon = SoftAST.TokenExpected(indexOf("for(>><<"), Token.Semicolon),
           postExpression1SemicolonSpace = None,
-          expression2 = SoftAST.ExpressionExpected(indexOf("for(>><<")),
+          expression2 = ExpressionExpected("for(>><<"),
           postExpression2Space = None,
           postExpression2Semicolon = SoftAST.TokenExpected(indexOf("for(>><<"), Token.Semicolon),
           postExpression2SemicolonSpace = None,
-          expression3 = SoftAST.ExpressionExpected(indexOf("for(>><<")),
+          expression3 = ExpressionExpected("for(>><<"),
           postExpression3Space = None,
           closeParen = SoftAST.TokenExpected(indexOf("for(>><<"), Token.CloseParen),
           postCloseParenSpace = None,

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionBlockSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionBlockSpec.scala
@@ -18,7 +18,7 @@ package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
-import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST.SpaceOne
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST.Space
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -44,7 +44,7 @@ class FunctionBlockSpec extends AnyWordSpec with Matchers {
 
         block.index shouldBe indexOf("fn -> >>{ }<<")
 
-        block.parts should contain only SpaceOne(indexOf("fn -> {>> <<}"))
+        block.parts should contain only Space("fn -> {>> <<}")
       }
 
       "closing curly is missing" in {

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionReturnClauseSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionReturnClauseSpec.scala
@@ -33,9 +33,9 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
           index = indexOf("fn >>-> <<"),
-          forwardArrow = ForwardArrow(indexOf("fn >>-><< ")),
-          space = Some(SpaceOne(indexOf("fn __>> <<"))),
-          tpe = SoftAST.ExpressionExpected(indexOf("fn -> >><<"))
+          forwardArrow = ForwardArrow("fn >>-><< "),
+          space = Some(Space("fn __>> <<")),
+          tpe = ExpressionExpected("fn -> >><<")
         )
     }
 
@@ -46,7 +46,7 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
           index = indexOf("fn >>-> type<<"),
-          forwardArrow = ForwardArrow(indexOf("fn >>-><< type")),
+          forwardArrow = ForwardArrow("fn >>-><< type"),
           space = Some(
             SoftAST.Space(
               SoftAST.CodeString(
@@ -77,9 +77,9 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
           index = indexOf("fn function >>-> <<"),
-          forwardArrow = ForwardArrow(indexOf("fn function >>-><< ")),
-          space = Some(SpaceOne(indexOf("fn function __>> <<"))),
-          tpe = SoftAST.ExpressionExpected(indexOf("fn function -> >><<"))
+          forwardArrow = ForwardArrow("fn function >>-><< "),
+          space = Some(Space("fn function __>> <<")),
+          tpe = ExpressionExpected("fn function -> >><<")
         )
     }
 
@@ -96,8 +96,8 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
           index = indexOf("fn function >>-> type<<"),
-          forwardArrow = ForwardArrow(indexOf("fn function >>-><< type")),
-          space = Some(SpaceOne(indexOf("fn function __>> <<type"))),
+          forwardArrow = ForwardArrow("fn function >>-><< type"),
+          space = Some(Space("fn function __>> <<type")),
           tpe = Identifier(
             index = indexOf("fn function -> >>type<<"),
             text = "type"
@@ -117,7 +117,7 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
           text = "function"
         )
 
-      function.signature.params.openToken shouldBe OpenParen(indexOf("fn function>>(<<-> "))
+      function.signature.params.openToken shouldBe OpenParen("fn function>>(<<-> ")
 
       function.signature.params.closeToken shouldBe
         SoftAST.TokenExpected(indexOf("fn function(>><<-> "), Token.CloseParen)
@@ -125,9 +125,9 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
           index = indexOf("fn function(>>-> <<"),
-          forwardArrow = ForwardArrow(indexOf("fn function(>>-><< ")),
-          space = Some(SpaceOne(indexOf("fn function(__>> <<"))),
-          tpe = SoftAST.ExpressionExpected(indexOf("fn function(-> >><<"))
+          forwardArrow = ForwardArrow("fn function(>>-><< "),
+          space = Some(Space("fn function(__>> <<")),
+          tpe = ExpressionExpected("fn function(-> >><<")
         )
     }
 
@@ -141,14 +141,14 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
           text = "function"
         )
 
-      function.signature.params.openToken shouldBe OpenParen(indexOf("fn function>>(<<-> Type"))
+      function.signature.params.openToken shouldBe OpenParen("fn function>>(<<-> Type")
       function.signature.params.closeToken shouldBe SoftAST.TokenExpected(indexOf("fn function(>><<-> Type"), Token.CloseParen)
 
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
           index = indexOf("fn function(>>-> Type<<"),
-          forwardArrow = ForwardArrow(indexOf("fn function(>>-><< Type")),
-          space = Some(SpaceOne(indexOf("fn function(__>> <<Type"))),
+          forwardArrow = ForwardArrow("fn function(>>-><< Type"),
+          space = Some(Space("fn function(__>> <<Type")),
           tpe = Identifier(
             index = indexOf("fn function(-> >>Type<<"),
             text = "Type"
@@ -169,15 +169,15 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
           text = "function"
         )
 
-      function.signature.params.openToken shouldBe OpenParen(indexOf("fn function>>(<<) -> "))
-      function.signature.params.closeToken shouldBe CloseParen(indexOf("fn function(>>)<< -> "))
+      function.signature.params.openToken shouldBe OpenParen("fn function>>(<<) -> ")
+      function.signature.params.closeToken shouldBe CloseParen("fn function(>>)<< -> ")
 
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
           index = indexOf("fn function() >>-> <<"),
-          forwardArrow = ForwardArrow(indexOf("fn function() >>-><< ")),
-          space = Some(SpaceOne(indexOf("fn function() __>> <<"))),
-          tpe = SoftAST.ExpressionExpected(indexOf("fn function() -> >><<"))
+          forwardArrow = ForwardArrow("fn function() >>-><< "),
+          space = Some(Space("fn function() __>> <<")),
+          tpe = ExpressionExpected("fn function() -> >><<")
         )
     }
 
@@ -191,14 +191,14 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
           text = "function"
         )
 
-      function.signature.params.openToken shouldBe OpenParen(indexOf("fn function>>(<<) -> type"))
-      function.signature.params.closeToken shouldBe CloseParen(indexOf("fn function(>>)<< -> type"))
+      function.signature.params.openToken shouldBe OpenParen("fn function>>(<<) -> type")
+      function.signature.params.closeToken shouldBe CloseParen("fn function(>>)<< -> type")
 
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
           index = indexOf("fn function() >>-> type<<"),
-          forwardArrow = ForwardArrow(indexOf("fn function() >>-><< type")),
-          space = Some(SpaceOne(indexOf("fn function() __>> <<type"))),
+          forwardArrow = ForwardArrow("fn function() >>-><< type"),
+          space = Some(Space("fn function() __>> <<type")),
           tpe = Identifier(
             index = indexOf("fn function() -> >>type<<"),
             text = "type"
@@ -225,8 +225,8 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
         text = "function"
       )
 
-    function.signature.params.openToken shouldBe OpenParen(indexOf("fn function>>(<<) => ABC"))
-    function.signature.params.closeToken shouldBe CloseParen(indexOf("fn function(>>)<< => ABC"))
+    function.signature.params.openToken shouldBe OpenParen("fn function>>(<<) => ABC")
+    function.signature.params.closeToken shouldBe CloseParen("fn function(>>)<< => ABC")
 
     /**
      * Second part is [[SoftAST.Unresolved]] arrow `=>`

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/GroupParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/GroupParserSpec.scala
@@ -31,14 +31,14 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
       parseTuple(")")
 
     tuple.openToken shouldBe SoftAST.TokenExpected(indexOf(">><<)"), Token.OpenParen)
-    tuple.closeToken shouldBe CloseParen(indexOf(">>)<<"))
+    tuple.closeToken shouldBe CloseParen(">>)<<")
   }
 
   "missing closing paren" in {
     val tuple =
       parseTuple("(")
 
-    tuple.openToken shouldBe OpenParen(indexOf(">>(<<"))
+    tuple.openToken shouldBe OpenParen(">>(<<")
     tuple.closeToken shouldBe SoftAST.TokenExpected(indexOf("(>><<"), Token.CloseParen)
   }
 
@@ -50,12 +50,12 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
       val expected =
         SoftAST.Group(
           index = indexOf(">>()<<"),
-          openToken = OpenParen(indexOf(">>(<<)")),
+          openToken = OpenParen(">>(<<)"),
           preHeadExpressionSpace = None,
           headExpression = None,
           postHeadExpressionSpace = None,
           tailExpressions = Seq.empty,
-          closeToken = CloseParen(indexOf("(>>)<<)"))
+          closeToken = CloseParen("(>>)<<)")
         )
 
       tuple shouldBe expected
@@ -68,12 +68,12 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
       val expected =
         SoftAST.Group(
           index = indexOf(">>( )<<"),
-          openToken = OpenParen(indexOf(">>(<< )")),
-          preHeadExpressionSpace = Some(SpaceOne(indexOf("(>> <<)"))),
+          openToken = OpenParen(">>(<< )"),
+          preHeadExpressionSpace = Some(Space("(>> <<)")),
           headExpression = None,
           postHeadExpressionSpace = None,
           tailExpressions = Seq.empty,
-          closeToken = CloseParen(indexOf("( >>)<<)"))
+          closeToken = CloseParen("( >>)<<)")
         )
 
       tuple shouldBe expected
@@ -91,7 +91,7 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
     val tuple =
       block.headExpression.asInstanceOf[SoftAST.Group[Token.OpenParen.type, Token.CloseParen.type]]
 
-    tuple.openToken shouldBe OpenParen(indexOf(">>(<<aaa typename"))
+    tuple.openToken shouldBe OpenParen(">>(<<aaa typename")
 
     tuple.headExpression.value.asInstanceOf[SoftAST.Identifier] shouldBe
       Identifier(
@@ -119,7 +119,7 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
   "valid type assignment expression exists" in {
     val tuple = parseTuple("(aaa: typename)")
 
-    tuple.openToken shouldBe OpenParen(indexOf(">>(<<aaa: typename"))
+    tuple.openToken shouldBe OpenParen(">>(<<aaa: typename")
 
     val headExpression =
       tuple.headExpression.value.asInstanceOf[SoftAST.TypeAssignment]
@@ -130,9 +130,9 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
         text = "aaa"
       )
 
-    headExpression.colon shouldBe Colon(indexOf("(aaa>>:<< typename"))
+    headExpression.colon shouldBe Colon("(aaa>>:<< typename")
 
-    headExpression.postColonSpace.value shouldBe SpaceOne(indexOf("(aaa:>> <<typename"))
+    headExpression.postColonSpace.value shouldBe Space("(aaa:>> <<typename")
 
     headExpression.expressionRight shouldBe
       Identifier(
@@ -140,7 +140,7 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
         text = "typename"
       )
 
-    tuple.closeToken shouldBe CloseParen(indexOf("(aaa: typename>>)<<"))
+    tuple.closeToken shouldBe CloseParen("(aaa: typename>>)<<")
   }
 
   "valid second type assignment expression exists" in {
@@ -149,9 +149,9 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
     tuple.tailExpressions should have size 1
     val bbb = tuple.tailExpressions.head
 
-    bbb.comma shouldBe Comma(indexOf("(aaa: typename>>,<< bbb: type2)"))
+    bbb.comma shouldBe Comma("(aaa: typename>>,<< bbb: type2)")
 
-    bbb.preExpressionSpace.value shouldBe SpaceOne(indexOf("(aaa: typename,>> <<bbb: type2)"))
+    bbb.preExpressionSpace.value shouldBe Space("(aaa: typename,>> <<bbb: type2)")
 
     val bbbTypeAssignment =
       bbb.expression.asInstanceOf[SoftAST.TypeAssignment]
@@ -177,9 +177,9 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
     tuple.tailExpressions should have size 1
     val tupleTail = tuple.tailExpressions.head
 
-    tupleTail.comma shouldBe Comma(indexOf("(aaa: typename>>,<< bbb: (tuple1, tuple2))"))
+    tupleTail.comma shouldBe Comma("(aaa: typename>>,<< bbb: (tuple1, tuple2))")
 
-    tupleTail.preExpressionSpace.value shouldBe SpaceOne(indexOf("(aaa: typename,>> <<bbb: (tuple1, tuple2))"))
+    tupleTail.preExpressionSpace.value shouldBe Space("(aaa: typename,>> <<bbb: (tuple1, tuple2))")
 
     val bbb = tupleTail.expression.asInstanceOf[SoftAST.TypeAssignment]
 
@@ -207,24 +207,24 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
       lastTuple shouldBe
         SoftAST.GroupTail(
           index = indexOf("(a>>, (b, c)<<)"),
-          comma = Comma(indexOf("(a>>,<< (b, c))")),
-          preExpressionSpace = Some(SpaceOne(indexOf("(a,>> <<(b, c))"))),
+          comma = Comma("(a>>,<< (b, c))"),
+          preExpressionSpace = Some(Space("(a,>> <<(b, c))")),
           expression = SoftAST.Group(
             index = indexOf("(a, >>(b, c)<<)"),
-            openToken = OpenParen(indexOf("(a, >>(<<b, c))")),
+            openToken = OpenParen("(a, >>(<<b, c))"),
             preHeadExpressionSpace = None,
-            headExpression = Some(Identifier(indexOf("(a, (>>b<<, c))"), "b")),
+            headExpression = Some(Identifier("(a, (>>b<<, c))")),
             postHeadExpressionSpace = None,
             tailExpressions = Seq(
               SoftAST.GroupTail(
                 index = indexOf("(a, (b>>, c<<))"),
-                comma = Comma(indexOf("(a, (b>>,<< c))")),
-                preExpressionSpace = Some(SpaceOne(indexOf("(a, (b,>> <<c))"))),
-                expression = Identifier(indexOf("(a, (b, >>c<<))"), "c"),
+                comma = Comma("(a, (b>>,<< c))"),
+                preExpressionSpace = Some(Space("(a, (b,>> <<c))")),
+                expression = Identifier("(a, (b, >>c<<))"),
                 postExpressionSpace = None
               )
             ),
-            closeToken = CloseParen(indexOf("(a, (b, c>>)<<)"))
+            closeToken = CloseParen("(a, (b, c>>)<<)")
           ),
           postExpressionSpace = None
         )
@@ -236,7 +236,7 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
       tuple shouldBe
         SoftAST.Group(
           index = indexOf(">>(a, , ( , z)<<"),
-          openToken = OpenParen(indexOf(">>(<<a, , ( , z)")),
+          openToken = OpenParen(">>(<<a, , ( , z)"),
           preHeadExpressionSpace = None,
           headExpression = Some(
             Identifier(
@@ -248,31 +248,31 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
           tailExpressions = Seq(
             SoftAST.GroupTail(
               index = indexOf("(a>>, <<, ( , z)"),
-              comma = Comma(indexOf("(a>>,<< , ( , z)")),
-              preExpressionSpace = Some(SpaceOne(indexOf("(a,>> <<, ( , z)"))),
-              expression = SoftAST.ExpressionExpected(indexOf("(a, >><<, ( , z)")),
+              comma = Comma("(a>>,<< , ( , z)"),
+              preExpressionSpace = Some(Space("(a,>> <<, ( , z)")),
+              expression = ExpressionExpected("(a, >><<, ( , z)"),
               postExpressionSpace = None
             ),
             SoftAST.GroupTail(
               index = indexOf("(a, >>, ( , z)<<"),
-              comma = Comma(indexOf("(a, >>,<< ( , z)")),
-              preExpressionSpace = Some(SpaceOne(indexOf("(a, ,>> <<( , z)"))),
+              comma = Comma("(a, >>,<< ( , z)"),
+              preExpressionSpace = Some(Space("(a, ,>> <<( , z)")),
               expression = SoftAST.Group(
                 index = indexOf("(a, , >>( , z)<<"),
-                openToken = OpenParen(indexOf("(a, , >>(<< , z)")),
-                preHeadExpressionSpace = Some(SpaceOne(indexOf("(a, , (>> <<, z)"))),
-                headExpression = Some(SoftAST.ExpressionExpected(indexOf("(a, , ( >><<, z)"))),
+                openToken = OpenParen("(a, , >>(<< , z)"),
+                preHeadExpressionSpace = Some(Space("(a, , (>> <<, z)")),
+                headExpression = Some(ExpressionExpected("(a, , ( >><<, z)")),
                 postHeadExpressionSpace = None,
                 tailExpressions = Seq(
                   SoftAST.GroupTail(
                     index = indexOf("(a, , ( >>, z<<)"),
-                    comma = Comma(indexOf("(a, , ( >>,<< z)")),
-                    preExpressionSpace = Some(SpaceOne(indexOf("(a, , ( ,>> <<z)"))),
-                    expression = Identifier(indexOf("(a, , ( , >>z<<)"), "z"),
+                    comma = Comma("(a, , ( >>,<< z)"),
+                    preExpressionSpace = Some(Space("(a, , ( ,>> <<z)")),
+                    expression = Identifier("(a, , ( , >>z<<)"),
                     postExpressionSpace = None
                   )
                 ),
-                closeToken = CloseParen(indexOf("(a, , ( , z>>)<<"))
+                closeToken = CloseParen("(a, , ( , z>>)<<")
               ),
               postExpressionSpace = None
             )

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ImportParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ImportParserSpec.scala
@@ -26,7 +26,7 @@ class ImportParserSpec extends AnyWordSpec with Matchers {
       importAST shouldBe
         SoftAST.Import(
           index = indexOf(">>import<<"),
-          importToken = Import(indexOf(">>import<<")),
+          importToken = Import(">>import<<"),
           postImportSpace = None,
           string = None
         )
@@ -39,8 +39,8 @@ class ImportParserSpec extends AnyWordSpec with Matchers {
       importAST shouldBe
         SoftAST.Import(
           index = indexOf(">>import <<"),
-          importToken = Import(indexOf(">>import<< ")),
-          postImportSpace = Some(SpaceOne(indexOf("import>> <<"))),
+          importToken = Import(">>import<< "),
+          postImportSpace = Some(Space("import>> <<")),
           string = None
         )
     }
@@ -52,12 +52,12 @@ class ImportParserSpec extends AnyWordSpec with Matchers {
       importAST shouldBe
         SoftAST.Import(
           index = indexOf(">>import\"<<"),
-          importToken = Import(indexOf(">>import<<")),
+          importToken = Import(">>import<<"),
           postImportSpace = None,
           string = Some(
             SoftAST.StringLiteral(
               index = indexOf("import>>\"<<"),
-              startQuote = Quote(indexOf("import>>\"<<")),
+              startQuote = Quote("import>>\"<<"),
               head = None,
               tail = Seq.empty,
               endQuote = SoftAST.TokenExpected(indexOf("import\">><<"), Token.Quote)
@@ -73,21 +73,21 @@ class ImportParserSpec extends AnyWordSpec with Matchers {
       importAST shouldBe
         SoftAST.Import(
           index = indexOf(""">>import "folder/file.ral"<<"""),
-          importToken = Import(indexOf(""">>import<< "folder/file.ral"""")),
-          postImportSpace = Some(SpaceOne(indexOf("""import>> <<"folder/file.ral""""))),
+          importToken = Import(""">>import<< "folder/file.ral""""),
+          postImportSpace = Some(Space("""import>> <<"folder/file.ral"""")),
           string = Some(
             SoftAST.StringLiteral(
               index = indexOf("""import >>"folder/file.ral"<<"""),
-              startQuote = Quote(indexOf("""import >>"<<folder/file.ral"""")),
+              startQuote = Quote("""import >>"<<folder/file.ral""""),
               head = Some(SoftAST.CodeString(indexOf("""import ">>folder<</file.ral""""), "folder")),
               tail = Seq(
                 SoftAST.Path(
                   index = indexOf("""import "folder>>/file.ral<<""""),
-                  slash = ForwardSlash(indexOf("""import "folder>>/<<file.ral"""")),
+                  slash = ForwardSlash("""import "folder>>/<<file.ral""""),
                   text = SoftAST.CodeString(indexOf("""import "folder/>>file.ral<<""""), "file.ral")
                 )
               ),
-              endQuote = Quote(indexOf("""import "folder/file.ral>>"<<"""))
+              endQuote = Quote("""import "folder/file.ral>>"<<""")
             )
           )
         )

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/InfixCallParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/InfixCallParserSpec.scala
@@ -16,12 +16,11 @@
 
 package org.alephium.ralph.lsp.access.compiler.parser.soft
 
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
-import TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
-import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class InfixCallParserSpec extends AnyWordSpec with Matchers {
 
@@ -36,7 +35,7 @@ class InfixCallParserSpec extends AnyWordSpec with Matchers {
       val right = infix.rightExpression.asInstanceOf[SoftAST.Group[_, _]]
       right.toCode() shouldBe "(this - that)"
 
-      infix.operator shouldBe LessThanOrEqual(indexOf("(one + one) >><=<< (this - that)"))
+      infix.operator shouldBe LessThanOrEqual("(one + one) >><=<< (this - that)")
     }
   }
 

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/InheritanceParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/InheritanceParserSpec.scala
@@ -35,7 +35,7 @@ class InheritanceParserSpec extends AnyWordSpec with Matchers {
             index = indexOf(s">>${token.lexeme}<<"),
             inheritanceType = TokenDocumented(indexOf(s">>${token.lexeme}<<"), token),
             postInheritanceTypeSpace = None,
-            headReference = SoftAST.IdentifierExpected(indexOf(s"${token.lexeme}>><<")),
+            headReference = IdentifierExpected(s"${token.lexeme}>><<"),
             tailReferencesOrSpace = None
           )
       }
@@ -58,19 +58,19 @@ class InheritanceParserSpec extends AnyWordSpec with Matchers {
           SoftAST.Inheritance(
             index = indexOf(s">>${token.lexeme} A(), B<<"),
             inheritanceType = TokenDocumented(indexOf(s">>${token.lexeme}<< A(), B"), token),
-            postInheritanceTypeSpace = Some(SpaceOne(indexOf(s"${token.lexeme}>> <<A(), B"))),
+            postInheritanceTypeSpace = Some(Space(s"${token.lexeme}>> <<A(), B")),
             headReference = SoftAST.ReferenceCall(
               index = indexOf(s"${token.lexeme} >>A()<<, B"),
-              reference = Identifier(indexOf(s"${token.lexeme} >>A<<(), B"), "A"),
+              reference = Identifier(s"${token.lexeme} >>A<<(), B"),
               preArgumentsSpace = None,
               arguments = SoftAST.Group(
                 index = indexOf(s"${token.lexeme} A>>()<<, B"),
-                openToken = OpenParen(indexOf(s"${token.lexeme} A>>(<<), B")),
+                openToken = OpenParen(s"${token.lexeme} A>>(<<), B"),
                 preHeadExpressionSpace = None,
                 headExpression = None,
                 postHeadExpressionSpace = None,
                 tailExpressions = Seq.empty,
-                closeToken = CloseParen(indexOf(s"${token.lexeme} A(>>)<<, B"))
+                closeToken = CloseParen(s"${token.lexeme} A(>>)<<, B")
               )
             ),
             tailReferencesOrSpace = Some(
@@ -78,9 +78,9 @@ class InheritanceParserSpec extends AnyWordSpec with Matchers {
                 Seq(
                   SoftAST.TailReferences(
                     index = indexOf(s"${token.lexeme} A()>>, B<<"),
-                    comma = Comma(indexOf(s"${token.lexeme} A()>>,<< B")),
-                    postCommaSpace = Some(SpaceOne(indexOf(s"${token.lexeme} A(),>> <<B"))),
-                    reference = Identifier(indexOf(s"${token.lexeme} A(), >>B<<"), "B"),
+                    comma = Comma(s"${token.lexeme} A()>>,<< B"),
+                    postCommaSpace = Some(Space(s"${token.lexeme} A(),>> <<B")),
+                    reference = Identifier(s"${token.lexeme} A(), >>B<<"),
                     postReferenceSpace = None
                   )
                 )

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MethodCallParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MethodCallParserSpec.scala
@@ -41,14 +41,14 @@ class MethodCallParserSpec extends AnyWordSpec with Matchers {
         dot shouldBe
           SoftAST.MethodCall(
             index = indexOf(">>.<<"),
-            leftExpression = SoftAST.ExpressionExpected(indexOf(">><<.")),
+            leftExpression = ExpressionExpected(">><<."),
             preDotSpace = None,
             dotCalls = Seq(
               SoftAST.DotCall(
                 index = indexOf(">>.<<"),
-                dot = Dot(indexOf(">>.<<")),
+                dot = Dot(">>.<<"),
                 postDotSpace = None,
-                rightExpression = SoftAST.ExpressionExpected(indexOf(".>><<"))
+                rightExpression = ExpressionExpected(".>><<")
               )
             )
           )
@@ -60,14 +60,14 @@ class MethodCallParserSpec extends AnyWordSpec with Matchers {
         dot shouldBe
           SoftAST.MethodCall(
             index = indexOf(">>.right<<"),
-            leftExpression = SoftAST.ExpressionExpected(indexOf(">><<.right")),
+            leftExpression = ExpressionExpected(">><<.right"),
             preDotSpace = None,
             dotCalls = Seq(
               SoftAST.DotCall(
                 index = indexOf(">>.right<<"),
-                dot = Dot(indexOf(">>.<<right")),
+                dot = Dot(">>.<<right"),
                 postDotSpace = None,
-                rightExpression = Identifier(indexOf(".>>right<<"), "right")
+                rightExpression = Identifier(".>>right<<")
               )
             )
           )
@@ -79,14 +79,14 @@ class MethodCallParserSpec extends AnyWordSpec with Matchers {
         dot shouldBe
           SoftAST.MethodCall(
             index = indexOf(">>left.<<"),
-            leftExpression = Identifier(indexOf(">>left<<."), "left"),
+            leftExpression = Identifier(">>left<<."),
             preDotSpace = None,
             dotCalls = Seq(
               SoftAST.DotCall(
                 index = indexOf("left>>.<<"),
-                dot = Dot(indexOf("left>>.<<")),
+                dot = Dot("left>>.<<"),
                 postDotSpace = None,
-                rightExpression = SoftAST.ExpressionExpected(indexOf("left.>><<"))
+                rightExpression = ExpressionExpected("left.>><<")
               )
             )
           )
@@ -98,14 +98,14 @@ class MethodCallParserSpec extends AnyWordSpec with Matchers {
         dot shouldBe
           SoftAST.MethodCall(
             index = indexOf(">>left.right<<"),
-            leftExpression = Identifier(indexOf(">>left<<.right"), "left"),
+            leftExpression = Identifier(">>left<<.right"),
             preDotSpace = None,
             dotCalls = Seq(
               SoftAST.DotCall(
                 index = indexOf("left>>.right<<"),
-                dot = Dot(indexOf("left>>.<<right")),
+                dot = Dot("left>>.<<right"),
                 postDotSpace = None,
-                rightExpression = Identifier(indexOf("left.>>right<<"), "right")
+                rightExpression = Identifier("left.>>right<<")
               )
             )
           )
@@ -130,10 +130,7 @@ class MethodCallParserSpec extends AnyWordSpec with Matchers {
           SoftAST.Number(
             index = indexOf(">>1.1<<"),
             documentation = None,
-            number = SoftAST.CodeString(
-              index = indexOf(">>1.1<<"),
-              text = "1.1"
-            ),
+            number = CodeString(">>1.1<<"),
             unit = None
           )
       }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MutableBindingParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MutableBindingParserSpec.scala
@@ -49,9 +49,9 @@ class MutableBindingParserSpec extends AnyWordSpec with Matchers {
       mut shouldBe
         SoftAST.MutableBinding(
           index = indexOf(">>mut<<"),
-          mut = Mut(indexOf(">>mut<<")),
+          mut = Mut(">>mut<<"),
           space = None,
-          identifier = SoftAST.IdentifierExpected(indexOf("mut>><<"))
+          identifier = IdentifierExpected("mut>><<")
         )
     }
 
@@ -62,9 +62,9 @@ class MutableBindingParserSpec extends AnyWordSpec with Matchers {
       mut shouldBe
         SoftAST.MutableBinding(
           index = indexOf(">>mut variable<<"),
-          mut = Mut(indexOf(">>mut<< variable")),
-          space = Some(SpaceOne(indexOf("mut>> <<variable"))),
-          identifier = Identifier(indexOf("mut >>variable<<"), "variable")
+          mut = Mut(">>mut<< variable"),
+          space = Some(Space("mut>> <<variable")),
+          identifier = Identifier("mut >>variable<<")
         )
     }
 
@@ -82,9 +82,9 @@ class MutableBindingParserSpec extends AnyWordSpec with Matchers {
       lastExpression shouldBe
         SoftAST.MutableBinding(
           index = indexOf("(a, b, >>mut variable<<)"),
-          mut = Mut(indexOf("(a, b, >>mut<< variable)")),
-          space = Some(SpaceOne(indexOf("(a, b, mut>> <<variable)"))),
-          identifier = Identifier(indexOf("(a, b, mut >>variable<<)"), "variable")
+          mut = Mut("(a, b, >>mut<< variable)"),
+          space = Some(Space("(a, b, mut>> <<variable)")),
+          identifier = Identifier("(a, b, mut >>variable<<)")
         )
     }
 

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/NumberParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/NumberParserSpec.scala
@@ -82,7 +82,7 @@ class NumberParserSpec extends AnyWordSpec with Matchers {
                 SoftAST.UnitAlph(
                   index = indexOf(s"$numberOnly>>alph<<"),
                   space = None,
-                  unit = AlphLowercase(indexOf(s"$numberOnly>>alph<<"))
+                  unit = AlphLowercase(s"$numberOnly>>alph<<")
                 )
               )
             )
@@ -119,8 +119,8 @@ class NumberParserSpec extends AnyWordSpec with Matchers {
               unit = Some(
                 SoftAST.UnitAlph(
                   index = indexOf(s"$numberOnly>> alph<<"),
-                  space = Some(SpaceOne(indexOf(s"$numberOnly>> <<alph"))),
-                  unit = AlphLowercase(indexOf(s"$numberOnly >>alph<<"))
+                  space = Some(Space(s"$numberOnly>> <<alph")),
+                  unit = AlphLowercase(s"$numberOnly >>alph<<")
                 )
               )
             )
@@ -159,7 +159,7 @@ class NumberParserSpec extends AnyWordSpec with Matchers {
                   SoftAST.UnitAlph(
                     index = indexOf("1e-18>>alph<<"),
                     space = None,
-                    unit = AlphLowercase(indexOf("1e-18>>alph<<"))
+                    unit = AlphLowercase("1e-18>>alph<<")
                   )
                 )
               )
@@ -192,8 +192,8 @@ class NumberParserSpec extends AnyWordSpec with Matchers {
                 unit = Some(
                   SoftAST.UnitAlph(
                     index = indexOf("1e-18>> alph<<"),
-                    space = Some(SpaceOne(indexOf("1e-18>> <<alph"))),
-                    unit = AlphLowercase(indexOf("1e-18 >>alph<<"))
+                    space = Some(Space("1e-18>> <<alph")),
+                    unit = AlphLowercase("1e-18 >>alph<<")
                   )
                 )
               )

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReturnParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReturnParserSpec.scala
@@ -32,9 +32,9 @@ class ReturnParserSpec extends AnyWordSpec with Matchers {
     returned shouldBe
       SoftAST.Return(
         index = indexOf(">>return<<"),
-        returnToken = Return(indexOf(">>return<<")),
+        returnToken = Return(">>return<<"),
         preExpressionSpace = None,
-        rightExpression = SoftAST.ExpressionExpected(indexOf("return>><<"))
+        rightExpression = ExpressionExpected("return>><<")
       )
   }
 
@@ -45,9 +45,9 @@ class ReturnParserSpec extends AnyWordSpec with Matchers {
     returned shouldBe
       SoftAST.Return(
         index = indexOf(">>return value<<"),
-        returnToken = Return(indexOf(">>return<< value")),
-        preExpressionSpace = Some(SpaceOne(indexOf("return>> <<value"))),
-        rightExpression = Identifier(indexOf("return >>value<<"), "value")
+        returnToken = Return(">>return<< value"),
+        preExpressionSpace = Some(Space("return>> <<value")),
+        rightExpression = Identifier("return >>value<<")
       )
 
   }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringLiteralParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringLiteralParserSpec.scala
@@ -43,7 +43,7 @@ class StringLiteralParserSpec extends AnyWordSpec with Matchers {
         string shouldBe
           SoftAST.StringLiteral(
             index = indexOf(">>\"<<"),
-            startQuote = Quote(indexOf(">>\"<<")),
+            startQuote = Quote(">>\"<<"),
             head = None,
             tail = Seq.empty,
             endQuote = SoftAST.TokenExpected(indexOf("\">><<"), Token.Quote)
@@ -57,7 +57,7 @@ class StringLiteralParserSpec extends AnyWordSpec with Matchers {
         string shouldBe
           SoftAST.StringLiteral(
             index = indexOf(">>\" a b c <<"),
-            startQuote = Quote(indexOf(">>\"<< a b c ")),
+            startQuote = Quote(">>\"<< a b c "),
             head = Some(SoftAST.CodeString(indexOf("\">> a b c <<"), " a b c ")),
             tail = Seq.empty,
             endQuote = SoftAST.TokenExpected(indexOf("\" a b c >><<"), Token.Quote)
@@ -71,7 +71,7 @@ class StringLiteralParserSpec extends AnyWordSpec with Matchers {
         string shouldBe
           SoftAST.StringLiteral(
             index = indexOf(s">>\" $newline a b c $newline <<"),
-            startQuote = Quote(indexOf(s">>\"<< $newline a b c $newline ")),
+            startQuote = Quote(s">>\"<< $newline a b c $newline "),
             head = Some(SoftAST.CodeString(indexOf(s"\">> $newline a b c $newline <<"), s" $newline a b c $newline ")),
             tail = Seq.empty,
             endQuote = SoftAST.TokenExpected(indexOf(s"\" $newline a b c $newline >><<"), Token.Quote)
@@ -87,7 +87,7 @@ class StringLiteralParserSpec extends AnyWordSpec with Matchers {
         string shouldBe
           SoftAST.StringLiteral(
             index = indexOf(s">>\" $newline a b c $newline \"<<"),
-            startQuote = Quote(indexOf(s">>\"<< $newline a b c $newline \"")),
+            startQuote = Quote(s">>\"<< $newline a b c $newline \""),
             head = Some(
               SoftAST.CodeString(
                 index = indexOf(s"\">> $newline a b c $newline <<\""),
@@ -95,7 +95,7 @@ class StringLiteralParserSpec extends AnyWordSpec with Matchers {
               )
             ),
             tail = Seq.empty,
-            endQuote = Quote(indexOf(s"\" $newline a b c $newline >>\"<<"))
+            endQuote = Quote(s"\" $newline a b c $newline >>\"<<")
           )
       }
     }
@@ -110,12 +110,12 @@ class StringLiteralParserSpec extends AnyWordSpec with Matchers {
         string shouldBe
           SoftAST.StringLiteral(
             index = indexOf(">>\"/b<<"),
-            startQuote = Quote(indexOf(">>\"<</b")),
+            startQuote = Quote(">>\"<</b"),
             head = Some(SoftAST.CodeStringExpected(indexOf("\">><</b"))),
             tail = Seq(
               SoftAST.Path(
                 index = indexOf("\">>/b<<"),
-                slash = ForwardSlash(indexOf("\">>/<<b")),
+                slash = ForwardSlash("\">>/<<b"),
                 text = SoftAST.CodeString(indexOf("\"/>>b<<"), "b")
               )
             ),
@@ -130,12 +130,12 @@ class StringLiteralParserSpec extends AnyWordSpec with Matchers {
         string shouldBe
           SoftAST.StringLiteral(
             index = indexOf(">>\"a/<<"),
-            startQuote = Quote(indexOf(">>\"<<a/")),
+            startQuote = Quote(">>\"<<a/"),
             head = Some(SoftAST.CodeString(indexOf("\">>a<</"), "a")),
             tail = Seq(
               SoftAST.Path(
                 index = indexOf("\"a>>/<<"),
-                slash = ForwardSlash(indexOf("\"a>>/<<")),
+                slash = ForwardSlash("\"a>>/<<"),
                 text = SoftAST.CodeStringExpected(indexOf("\"a/>><<"))
               )
             ),
@@ -150,17 +150,17 @@ class StringLiteralParserSpec extends AnyWordSpec with Matchers {
         string shouldBe
           SoftAST.StringLiteral(
             index = indexOf(">>\" a / b / c <<"),
-            startQuote = Quote(indexOf(">>\"<< a / b / c ")),
+            startQuote = Quote(">>\"<< a / b / c "),
             head = Some(SoftAST.CodeString(indexOf("\">> a <</ b / c "), " a ")),
             tail = Seq(
               SoftAST.Path(
                 index = indexOf("\" a >>/ b <</ c "),
-                slash = ForwardSlash(indexOf("\" a >>/<< b / c ")),
+                slash = ForwardSlash("\" a >>/<< b / c "),
                 text = SoftAST.CodeString(indexOf("\" a />> b <</ c "), " b ")
               ),
               SoftAST.Path(
                 index = indexOf("\" a / b >>/ c <<"),
-                slash = ForwardSlash(indexOf("\" a / b >>/<< c ")),
+                slash = ForwardSlash("\" a / b >>/<< c "),
                 text = SoftAST.CodeString(indexOf("\" a / b />> c <<"), " c ")
               )
             ),
@@ -178,7 +178,7 @@ class StringLiteralParserSpec extends AnyWordSpec with Matchers {
           string shouldBe
             SoftAST.StringLiteral(
               index = indexOf(s">>\" $newline a b c $newline \"<<"),
-              startQuote = Quote(indexOf(s">>\"<< $newline a b c $newline \"")),
+              startQuote = Quote(s">>\"<< $newline a b c $newline \""),
               head = Some(
                 SoftAST.CodeString(
                   index = indexOf(s"\">> $newline a b c $newline <<\""),
@@ -186,7 +186,7 @@ class StringLiteralParserSpec extends AnyWordSpec with Matchers {
                 )
               ),
               tail = Seq.empty,
-              endQuote = Quote(indexOf(s"\" $newline a b c $newline >>\"<<"))
+              endQuote = Quote(s"\" $newline a b c $newline >>\"<<")
             )
         }
 
@@ -197,21 +197,21 @@ class StringLiteralParserSpec extends AnyWordSpec with Matchers {
           string shouldBe
             SoftAST.StringLiteral(
               index = indexOf(">>\" a / b / c \"<<"),
-              startQuote = Quote(indexOf(">>\"<< a / b / c \"")),
+              startQuote = Quote(">>\"<< a / b / c \""),
               head = Some(SoftAST.CodeString(indexOf("\">> a <</ b / c \""), " a ")),
               tail = Seq(
                 SoftAST.Path(
                   index = indexOf("\" a >>/ b <</ c \""),
-                  slash = ForwardSlash(indexOf("\" a >>/<< b / c \"")),
+                  slash = ForwardSlash("\" a >>/<< b / c \""),
                   text = SoftAST.CodeString(indexOf("\" a />> b <</ c \""), " b ")
                 ),
                 SoftAST.Path(
                   index = indexOf("\" a / b >>/ c <<\""),
-                  slash = ForwardSlash(indexOf("\" a / b >>/<< c \"")),
+                  slash = ForwardSlash("\" a / b >>/<< c \""),
                   text = SoftAST.CodeString(indexOf("\" a / b />> c <<\""), " c ")
                 )
               ),
-              endQuote = Quote(indexOf("\" a / b / c >>\"<<"))
+              endQuote = Quote("\" a / b / c >>\"<<")
             )
         }
       }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StructParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StructParserSpec.scala
@@ -29,9 +29,9 @@ class StructParserSpec extends AnyWordSpec {
       struct shouldBe
         SoftAST.Struct(
           index = indexOf(">>struct<<"),
-          structToken = Struct(indexOf(">>struct<<")),
+          structToken = Struct(">>struct<<"),
           preIdentifierSpace = None,
-          identifier = SoftAST.IdentifierExpected(indexOf("struct>><<")),
+          identifier = IdentifierExpected("struct>><<"),
           preParamSpace = None,
           params = SoftAST.Group(
             index = indexOf("struct>><<"),
@@ -48,8 +48,8 @@ class StructParserSpec extends AnyWordSpec {
     "closing curly is missing" in {
       val struct = parseStruct("struct MyStruct{varName: TypeName")
 
-      struct.structToken shouldBe Struct(indexOf(">>struct<< MyStruct{varName: TypeName"))
-      struct.identifier shouldBe Identifier(indexOf("struct >>MyStruct<<{varName: TypeName"), "MyStruct")
+      struct.structToken shouldBe Struct(">>struct<< MyStruct{varName: TypeName")
+      struct.identifier shouldBe Identifier("struct >>MyStruct<<{varName: TypeName")
 
       // Tuples are tested in TupleSpec, test for the index and string code here.
       struct.params.index shouldBe indexOf("struct MyStruct>>{varName: TypeName<<")
@@ -60,14 +60,14 @@ class StructParserSpec extends AnyWordSpec {
     "well defined struct" in {
       val struct = parseStruct("struct Bar { z: U256, mut foo: Foo }")
 
-      struct.structToken shouldBe Struct(indexOf(">>struct<< Bar { z: U256, mut foo: Foo }"))
-      struct.identifier shouldBe Identifier(indexOf("struct >>Bar<< { z: U256, mut foo: Foo }"), "Bar")
+      struct.structToken shouldBe Struct(">>struct<< Bar { z: U256, mut foo: Foo }")
+      struct.identifier shouldBe Identifier("struct >>Bar<< { z: U256, mut foo: Foo }")
 
       // Tuples are tested in TupleSpec, test for the index and string code here.
       struct.params.index shouldBe indexOf("struct Bar >>{ z: U256, mut foo: Foo }<<")
       struct.params.toCode() shouldBe "{ z: U256, mut foo: Foo }"
-      struct.params.openToken shouldBe OpenCurly(indexOf("struct Bar >>{<< z: U256, mut foo: Foo }"))
-      struct.params.closeToken shouldBe CloseCurly(indexOf("struct Bar { z: U256, mut foo: Foo >>}<<"))
+      struct.params.openToken shouldBe OpenCurly("struct Bar >>{<< z: U256, mut foo: Foo }")
+      struct.params.closeToken shouldBe CloseCurly("struct Bar { z: U256, mut foo: Foo >>}<<")
 
     }
   }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateParserSpec.scala
@@ -48,9 +48,9 @@ class TemplateParserSpec extends AnyWordSpec with Matchers {
           parseTemplate(templateToken)
 
         template.index shouldBe indexOf(s">>$templateToken<<")
-        template.templateType shouldBe Contract(indexOf(s">>$templateToken<<"))
+        template.templateType shouldBe Contract(s">>$templateToken<<")
         template.preIdentifierSpace shouldBe None
-        template.identifier shouldBe SoftAST.IdentifierExpected(indexOf(s"$templateToken>><<"))
+        template.identifier shouldBe IdentifierExpected(s"$templateToken>><<")
         template.preParamSpace shouldBe None
         template.params shouldBe empty
         template.postParamSpace shouldBe None
@@ -71,9 +71,9 @@ class TemplateParserSpec extends AnyWordSpec with Matchers {
           parseTemplate(templateToken)
 
         template.index shouldBe indexOf(s">>$templateToken<<")
-        template.templateType shouldBe TxScript(indexOf(s">>$templateToken<<"))
+        template.templateType shouldBe TxScript(s">>$templateToken<<")
         template.preIdentifierSpace shouldBe None
-        template.identifier shouldBe SoftAST.IdentifierExpected(indexOf(s"$templateToken>><<"))
+        template.identifier shouldBe IdentifierExpected(s"$templateToken>><<")
         template.preParamSpace shouldBe empty
         template.params shouldBe empty
         template.postParamSpace shouldBe empty
@@ -103,7 +103,7 @@ class TemplateParserSpec extends AnyWordSpec with Matchers {
         parseTemplate("Contract mycontract(")
 
       val params = template.params.value
-      params.openToken shouldBe OpenParen(indexOf("Contract mycontract>>(<<"))
+      params.openToken shouldBe OpenParen("Contract mycontract>>(<<")
       params.closeToken shouldBe SoftAST.TokenExpected(indexOf("Contract mycontract(>><<"), Token.CloseParen)
     }
 
@@ -113,7 +113,7 @@ class TemplateParserSpec extends AnyWordSpec with Matchers {
 
       val params = template.params.value
 
-      params.preHeadExpressionSpace.value shouldBe SpaceOne(indexOf("Contract mycontract(>> <<)"))
+      params.preHeadExpressionSpace.value shouldBe Space("Contract mycontract(>> <<)")
     }
   }
 
@@ -125,9 +125,9 @@ class TemplateParserSpec extends AnyWordSpec with Matchers {
       template.inheritance should contain only
         SoftAST.Inheritance(
           index = indexOf("Contract MyContract >>implements<<"),
-          inheritanceType = Implements(indexOf("Contract MyContract >>implements<<")),
+          inheritanceType = Implements("Contract MyContract >>implements<<"),
           postInheritanceTypeSpace = None,
-          headReference = SoftAST.IdentifierExpected(indexOf("Contract MyContract implements>><<")),
+          headReference = IdentifierExpected("Contract MyContract implements>><<"),
           tailReferencesOrSpace = None
         )
     }
@@ -145,19 +145,19 @@ class TemplateParserSpec extends AnyWordSpec with Matchers {
       extended shouldBe
         SoftAST.Inheritance(
           index = indexOf("Contract HelloWorld >>extends Class <<implements Trait"),
-          inheritanceType = Extends(indexOf("Contract HelloWorld >>extends<< Class implements Trait")),
-          postInheritanceTypeSpace = Some(SpaceOne(indexOf("Contract HelloWorld extends>> <<Class implements Trait"))),
-          headReference = Identifier(indexOf("Contract HelloWorld extends >>Class<< implements Trait"), "Class"),
-          tailReferencesOrSpace = Some(Left(SpaceOne(indexOf("Contract HelloWorld extends Class>> <<implements Trait"))))
+          inheritanceType = Extends("Contract HelloWorld >>extends<< Class implements Trait"),
+          postInheritanceTypeSpace = Some(Space("Contract HelloWorld extends>> <<Class implements Trait")),
+          headReference = Identifier("Contract HelloWorld extends >>Class<< implements Trait"),
+          tailReferencesOrSpace = Some(Left(Space("Contract HelloWorld extends Class>> <<implements Trait")))
         )
 
       /** Assert implements */
       implements shouldBe
         SoftAST.Inheritance(
           index = indexOf("Contract HelloWorld extends Class >>implements Trait<<"),
-          inheritanceType = Implements(indexOf("Contract HelloWorld extends Class >>implements<< Trait")),
-          postInheritanceTypeSpace = Some(SpaceOne(indexOf("Contract HelloWorld extends Class implements>> <<Trait"))),
-          headReference = Identifier(indexOf("Contract HelloWorld extends Class implements >>Trait<<"), "Trait"),
+          inheritanceType = Implements("Contract HelloWorld extends Class >>implements<< Trait"),
+          postInheritanceTypeSpace = Some(Space("Contract HelloWorld extends Class implements>> <<Trait")),
+          headReference = Identifier("Contract HelloWorld extends Class implements >>Trait<<"),
           tailReferencesOrSpace = None
         )
     }
@@ -176,25 +176,25 @@ class TemplateParserSpec extends AnyWordSpec with Matchers {
       implements shouldBe
         SoftAST.Inheritance(
           index = indexOf("Contract MyContract >>implements A, B, C <<extends D, E"),
-          inheritanceType = Implements(indexOf("Contract MyContract >>implements<< A, B, C extends D, E")),
-          postInheritanceTypeSpace = Some(SpaceOne(indexOf("Contract MyContract implements>> <<A, B, C extends D, E"))),
-          headReference = Identifier(indexOf("Contract MyContract implements >>A<<, B, C extends D, E"), "A"),
+          inheritanceType = Implements("Contract MyContract >>implements<< A, B, C extends D, E"),
+          postInheritanceTypeSpace = Some(Space("Contract MyContract implements>> <<A, B, C extends D, E")),
+          headReference = Identifier("Contract MyContract implements >>A<<, B, C extends D, E"),
           tailReferencesOrSpace = Some(
             Right(
               Seq(
                 SoftAST.TailReferences(
                   index = indexOf("Contract MyContract implements A>>, B<<, C extends D, E"),
-                  comma = Comma(indexOf("Contract MyContract implements A>>,<< B, C extends D, E")),
-                  postCommaSpace = Some(SpaceOne(indexOf("Contract MyContract implements A,>> <<B, C extends D, E"))),
-                  reference = Identifier(indexOf("Contract MyContract implements A, >>B<<, C extends D, E"), "B"),
+                  comma = Comma("Contract MyContract implements A>>,<< B, C extends D, E"),
+                  postCommaSpace = Some(Space("Contract MyContract implements A,>> <<B, C extends D, E")),
+                  reference = Identifier("Contract MyContract implements A, >>B<<, C extends D, E"),
                   postReferenceSpace = None
                 ),
                 SoftAST.TailReferences(
                   index = indexOf("Contract MyContract implements A, B>>, C <<extends D, E"),
-                  comma = Comma(indexOf("Contract MyContract implements A, B>>,<< C extends D, E")),
-                  postCommaSpace = Some(SpaceOne(indexOf("Contract MyContract implements A, B,>> <<C extends D, E"))),
-                  reference = Identifier(indexOf("Contract MyContract implements A, B, >>C<< extends D, E"), "C"),
-                  postReferenceSpace = Some(SpaceOne(indexOf("Contract MyContract implements A, B, C>> <<extends D, E")))
+                  comma = Comma("Contract MyContract implements A, B>>,<< C extends D, E"),
+                  postCommaSpace = Some(Space("Contract MyContract implements A, B,>> <<C extends D, E")),
+                  reference = Identifier("Contract MyContract implements A, B, >>C<< extends D, E"),
+                  postReferenceSpace = Some(Space("Contract MyContract implements A, B, C>> <<extends D, E"))
                 )
               )
             )
@@ -205,17 +205,17 @@ class TemplateParserSpec extends AnyWordSpec with Matchers {
       `extends` shouldBe
         SoftAST.Inheritance(
           index = indexOf("Contract MyContract implements A, B, C >>extends D, E<<"),
-          inheritanceType = Extends(indexOf("Contract MyContract implements A, B, C >>extends<< D, E")),
-          postInheritanceTypeSpace = Some(SpaceOne(indexOf("Contract MyContract implements A, B, C extends>> <<D, E"))),
-          headReference = Identifier(indexOf("Contract MyContract implements A, B, C extends >>D<<, E"), "D"),
+          inheritanceType = Extends("Contract MyContract implements A, B, C >>extends<< D, E"),
+          postInheritanceTypeSpace = Some(Space("Contract MyContract implements A, B, C extends>> <<D, E")),
+          headReference = Identifier("Contract MyContract implements A, B, C extends >>D<<, E"),
           tailReferencesOrSpace = Some(
             Right(
               Seq(
                 SoftAST.TailReferences(
                   index = indexOf("Contract MyContract implements A, B, C extends D>>, E<<"),
-                  comma = Comma(indexOf("Contract MyContract implements A, B, C extends D>>,<< E")),
-                  postCommaSpace = Some(SpaceOne(indexOf("Contract MyContract implements A, B, C extends D,>> <<E"))),
-                  reference = Identifier(indexOf("Contract MyContract implements A, B, C extends D, >>E<<"), "E"),
+                  comma = Comma("Contract MyContract implements A, B, C extends D>>,<< E"),
+                  postCommaSpace = Some(Space("Contract MyContract implements A, B, C extends D,>> <<E")),
+                  reference = Identifier("Contract MyContract implements A, B, C extends D, >>E<<"),
                   postReferenceSpace = None
                 )
               )
@@ -247,11 +247,11 @@ class TemplateParserSpec extends AnyWordSpec with Matchers {
       val template =
         parseTemplate("Contract {")
 
-      template.identifier shouldBe SoftAST.IdentifierExpected(indexOf("Contract >><<{"))
+      template.identifier shouldBe IdentifierExpected("Contract >><<{")
 
-      template.preIdentifierSpace shouldBe Some(SpaceOne(indexOf("Contract>> <<{")))
+      template.preIdentifierSpace shouldBe Some(Space("Contract>> <<{"))
 
-      template.block.value.openCurly shouldBe OpenCurly(indexOf("Contract >>{<<"))
+      template.block.value.openCurly shouldBe OpenCurly("Contract >>{<<")
       template.block.value.closeCurly shouldBe SoftAST.TokenExpected(indexOf("Contract {>><<"), Token.CloseCurly)
     }
 
@@ -264,10 +264,10 @@ class TemplateParserSpec extends AnyWordSpec with Matchers {
             |""".stripMargin
         }
 
-      template.identifier shouldBe SoftAST.IdentifierExpected(indexOf("Contract >><<{"))
-      template.preIdentifierSpace shouldBe Some(SpaceOne(indexOf("Contract>> <<{")))
+      template.identifier shouldBe IdentifierExpected("Contract >><<{")
+      template.preIdentifierSpace shouldBe Some(Space("Contract>> <<{"))
       // block
-      template.block.value.openCurly shouldBe OpenCurly(indexOf("Contract >>{<<"))
+      template.block.value.openCurly shouldBe OpenCurly("Contract >>{<<")
 
       template.block.value.closeCurly shouldBe
         SoftAST.TokenExpected(
@@ -319,10 +319,10 @@ class TemplateParserSpec extends AnyWordSpec with Matchers {
             |""".stripMargin
         }
 
-      template.identifier shouldBe SoftAST.IdentifierExpected(indexOf("Contract >><<{"))
-      template.preIdentifierSpace shouldBe Some(SpaceOne(indexOf("Contract>> <<{")))
+      template.identifier shouldBe IdentifierExpected("Contract >><<{")
+      template.preIdentifierSpace shouldBe Some(Space("Contract>> <<{"))
       // block
-      template.block.value.openCurly shouldBe OpenCurly(indexOf("Contract >>{<<"))
+      template.block.value.openCurly shouldBe OpenCurly("Contract >>{<<")
 
       template.block.value.closeCurly shouldBe
         SoftAST.TokenExpected(

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeAssignmentParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeAssignmentParserSpec.scala
@@ -19,11 +19,11 @@ class TypeAssignmentParserSpec extends AnyWordSpec {
           SoftAST.TypeAssignment(
             index = indexOf(">>: Type<<"),
             annotations = Seq.empty,
-            expressionLeft = SoftAST.ExpressionExpected(indexOf(">><<: Type")),
+            expressionLeft = ExpressionExpected(">><<: Type"),
             preColonSpace = None,
-            colon = Colon(indexOf(">>:<< Type")),
-            postColonSpace = Some(SpaceOne(indexOf(":>> <<Type"))),
-            expressionRight = Identifier(indexOf(": >>Type<<"), "Type")
+            colon = Colon(">>:<< Type"),
+            postColonSpace = Some(Space(":>> <<Type")),
+            expressionRight = Identifier(": >>Type<<")
           )
       }
 
@@ -37,19 +37,19 @@ class TypeAssignmentParserSpec extends AnyWordSpec {
             annotations = Seq(
               SoftAST.Annotation(
                 index = indexOf(">>@using <<: Type"),
-                at = At(indexOf(">>@<<using : Type")),
+                at = At(">>@<<using : Type"),
                 preIdentifierSpace = None,
-                identifier = Identifier(indexOf("@>>using<< : Type"), "using"),
-                postIdentifierSpace = Some(SpaceOne(indexOf("@using>> <<: Type"))),
+                identifier = Identifier("@>>using<< : Type"),
+                postIdentifierSpace = Some(Space("@using>> <<: Type")),
                 tuple = None,
                 postTupleSpace = None
               )
             ),
-            expressionLeft = SoftAST.ExpressionExpected(indexOf("@using >><<: Type")),
+            expressionLeft = ExpressionExpected("@using >><<: Type"),
             preColonSpace = None,
-            colon = Colon(indexOf("@using >>:<< Type")),
-            postColonSpace = Some(SpaceOne(indexOf("@using :>> <<Type"))),
-            expressionRight = Identifier(indexOf("@using : >>Type<<"), "Type")
+            colon = Colon("@using >>:<< Type"),
+            postColonSpace = Some(Space("@using :>> <<Type")),
+            expressionRight = Identifier("@using : >>Type<<")
           )
       }
     }
@@ -65,11 +65,11 @@ class TypeAssignmentParserSpec extends AnyWordSpec {
           SoftAST.TypeAssignment(
             index = indexOf(">>name : Type<<"),
             annotations = Seq.empty,
-            expressionLeft = Identifier(indexOf(">>name<< : Type"), "name"),
-            preColonSpace = Some(SpaceOne(indexOf("name>> <<: Type"))),
-            colon = Colon(indexOf("name >>:<< Type")),
-            postColonSpace = Some(SpaceOne(indexOf("name :>> <<Type"))),
-            expressionRight = Identifier(indexOf("name : >>Type<<"), "Type")
+            expressionLeft = Identifier(">>name<< : Type"),
+            preColonSpace = Some(Space("name>> <<: Type")),
+            colon = Colon("name >>:<< Type"),
+            postColonSpace = Some(Space("name :>> <<Type")),
+            expressionRight = Identifier("name : >>Type<<")
           )
       }
 
@@ -83,19 +83,19 @@ class TypeAssignmentParserSpec extends AnyWordSpec {
             annotations = Seq(
               SoftAST.Annotation(
                 index = indexOf(">>@using <<name : Type"),
-                at = At(indexOf(">>@<<using name : Type")),
+                at = At(">>@<<using name : Type"),
                 preIdentifierSpace = None,
-                identifier = Identifier(indexOf("@>>using<< name : Type"), "using"),
-                postIdentifierSpace = Some(SpaceOne(indexOf("@using>> <<name : Type"))),
+                identifier = Identifier("@>>using<< name : Type"),
+                postIdentifierSpace = Some(Space("@using>> <<name : Type")),
                 tuple = None,
                 postTupleSpace = None
               )
             ),
-            expressionLeft = Identifier(indexOf("@using >>name<< : Type"), "name"),
-            preColonSpace = Some(SpaceOne(indexOf("@using name>> <<: Type"))),
-            colon = Colon(indexOf("@using name >>:<< Type")),
-            postColonSpace = Some(SpaceOne(indexOf("@using name :>> <<Type"))),
-            expressionRight = Identifier(indexOf("@using name : >>Type<<"), "Type")
+            expressionLeft = Identifier("@using >>name<< : Type"),
+            preColonSpace = Some(Space("@using name>> <<: Type")),
+            colon = Colon("@using name >>:<< Type"),
+            postColonSpace = Some(Space("@using name :>> <<Type")),
+            expressionRight = Identifier("@using name : >>Type<<")
           )
       }
 
@@ -109,28 +109,28 @@ class TypeAssignmentParserSpec extends AnyWordSpec {
             annotations = Seq(
               SoftAST.Annotation(
                 index = indexOf(">>@using <<@another name : Type"),
-                at = At(indexOf(">>@<<using @another name : Type")),
+                at = At(">>@<<using @another name : Type"),
                 preIdentifierSpace = None,
-                identifier = Identifier(indexOf("@>>using<< @another name : Type"), "using"),
-                postIdentifierSpace = Some(SpaceOne(indexOf("@using>> <<@another name : Type"))),
+                identifier = Identifier("@>>using<< @another name : Type"),
+                postIdentifierSpace = Some(Space("@using>> <<@another name : Type")),
                 tuple = None,
                 postTupleSpace = None
               ),
               SoftAST.Annotation(
                 index = indexOf("@using >>@another <<name : Type"),
-                at = At(indexOf("@using >>@<<another name : Type")),
+                at = At("@using >>@<<another name : Type"),
                 preIdentifierSpace = None,
-                identifier = Identifier(indexOf("@using @>>another<< name : Type"), "another"),
-                postIdentifierSpace = Some(SpaceOne(indexOf("@using @another>> <<name : Type"))),
+                identifier = Identifier("@using @>>another<< name : Type"),
+                postIdentifierSpace = Some(Space("@using @another>> <<name : Type")),
                 tuple = None,
                 postTupleSpace = None
               )
             ),
-            expressionLeft = Identifier(indexOf("@using @another >>name<< : Type"), "name"),
-            preColonSpace = Some(SpaceOne(indexOf("@using @another name>> <<: Type"))),
-            colon = Colon(indexOf("@using @another name >>:<< Type")),
-            postColonSpace = Some(SpaceOne(indexOf("@using @another name :>> <<Type"))),
-            expressionRight = Identifier(indexOf("@using @another name : >>Type<<"), "Type")
+            expressionLeft = Identifier("@using @another >>name<< : Type"),
+            preColonSpace = Some(Space("@using @another name>> <<: Type")),
+            colon = Colon("@using @another name >>:<< Type"),
+            postColonSpace = Some(Space("@using @another name :>> <<Type")),
+            expressionRight = Identifier("@using @another name : >>Type<<")
           )
       }
     }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/VariableDeclarationParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/VariableDeclarationParserSpec.scala
@@ -33,19 +33,19 @@ class VariableDeclarationParserSpec extends AnyWordSpec with Matchers {
       varDec shouldBe
         SoftAST.VariableDeclaration(
           index = indexOf(">>let mut variable = 1<<"),
-          let = Let(indexOf(">>let<< mut variable = 1")),
-          postLetSpace = Some(SpaceOne(indexOf("let>> <<mut variable = 1"))),
+          let = Let(">>let<< mut variable = 1"),
+          postLetSpace = Some(Space("let>> <<mut variable = 1")),
           assignment = SoftAST.Assignment(
             index = indexOf("let >>mut variable = 1<<"),
             expressionLeft = SoftAST.MutableBinding(
               index = indexOf("let >>mut variable<< = 1"),
-              mut = Mut(indexOf("let >>mut<< variable = 1")),
-              space = Some(SpaceOne(indexOf("let mut>> <<variable = 1"))),
-              identifier = Identifier(indexOf("let mut >>variable<< = 1"), "variable")
+              mut = Mut("let >>mut<< variable = 1"),
+              space = Some(Space("let mut>> <<variable = 1")),
+              identifier = Identifier("let mut >>variable<< = 1")
             ),
-            postIdentifierSpace = Some(SpaceOne(indexOf("let mut variable>> <<= 1"))),
-            equalToken = Equal(indexOf("let mut variable >>=<< 1")),
-            postEqualSpace = Some(SpaceOne(indexOf("let mut variable =>> <<1"))),
+            postIdentifierSpace = Some(Space("let mut variable>> <<= 1")),
+            equalToken = Equal("let mut variable >>=<< 1"),
+            postEqualSpace = Some(Space("let mut variable =>> <<1")),
             expressionRight = Number(indexOf("let mut variable = >>1<<"), "1")
           )
         )
@@ -61,20 +61,20 @@ class VariableDeclarationParserSpec extends AnyWordSpec with Matchers {
         varDec shouldBe
           SoftAST.VariableDeclaration(
             index = indexOf(">>let mut variable = <<"),
-            let = Let(indexOf(">>let<< mut variable = ")),
-            postLetSpace = Some(SpaceOne(indexOf("let>> <<mut variable = "))),
+            let = Let(">>let<< mut variable = "),
+            postLetSpace = Some(Space("let>> <<mut variable = ")),
             assignment = SoftAST.Assignment(
               index = indexOf("let >>mut variable = <<"),
               expressionLeft = SoftAST.MutableBinding(
                 index = indexOf("let >>mut variable<< = "),
-                mut = Mut(indexOf("let >>mut<< variable = ")),
-                space = Some(SpaceOne(indexOf("let mut>> <<variable = "))),
-                identifier = Identifier(indexOf("let mut >>variable<< = "), "variable")
+                mut = Mut("let >>mut<< variable = "),
+                space = Some(Space("let mut>> <<variable = ")),
+                identifier = Identifier("let mut >>variable<< = ")
               ),
-              postIdentifierSpace = Some(SpaceOne(indexOf("let mut variable>> <<= "))),
-              equalToken = Equal(indexOf("let mut variable >>=<< ")),
-              postEqualSpace = Some(SpaceOne(indexOf("let mut variable =>> <<"))),
-              expressionRight = SoftAST.ExpressionExpected(indexOf("let mut variable = >><<"))
+              postIdentifierSpace = Some(Space("let mut variable>> <<= ")),
+              equalToken = Equal("let mut variable >>=<< "),
+              postEqualSpace = Some(Space("let mut variable =>> <<")),
+              expressionRight = ExpressionExpected("let mut variable = >><<")
             )
           )
       }
@@ -87,20 +87,20 @@ class VariableDeclarationParserSpec extends AnyWordSpec with Matchers {
       varDec shouldBe
         SoftAST.VariableDeclaration(
           index = indexOf(">>let mut variable<<"),
-          let = Let(indexOf(">>let<< mut variable")),
-          postLetSpace = Some(SpaceOne(indexOf("let>> <<mut variable"))),
+          let = Let(">>let<< mut variable"),
+          postLetSpace = Some(Space("let>> <<mut variable")),
           assignment = SoftAST.Assignment(
             index = indexOf("let >>mut variable<<"),
             expressionLeft = SoftAST.MutableBinding(
               index = indexOf("let >>mut variable<<"),
-              mut = Mut(indexOf("let >>mut<< variable")),
-              space = Some(SpaceOne(indexOf("let mut>> <<variable"))),
-              identifier = Identifier(indexOf("let mut >>variable<<"), "variable")
+              mut = Mut("let >>mut<< variable"),
+              space = Some(Space("let mut>> <<variable")),
+              identifier = Identifier("let mut >>variable<<")
             ),
             postIdentifierSpace = None,
             equalToken = SoftAST.TokenExpected(indexOf("let mut variable>><<"), Token.Equal),
             postEqualSpace = None,
-            expressionRight = SoftAST.ExpressionExpected(indexOf("let mut variable>><<"))
+            expressionRight = ExpressionExpected("let mut variable>><<")
           )
         )
     }
@@ -112,20 +112,20 @@ class VariableDeclarationParserSpec extends AnyWordSpec with Matchers {
       varDec shouldBe
         SoftAST.VariableDeclaration(
           index = indexOf(">>let mut<<"),
-          let = Let(indexOf(">>let<< mut")),
-          postLetSpace = Some(SpaceOne(indexOf("let>> <<mut"))),
+          let = Let(">>let<< mut"),
+          postLetSpace = Some(Space("let>> <<mut")),
           assignment = SoftAST.Assignment(
             index = indexOf("let >>mut<<"),
             expressionLeft = SoftAST.MutableBinding(
               index = indexOf("let >>mut<<"),
-              mut = Mut(indexOf("let >>mut<<")),
+              mut = Mut("let >>mut<<"),
               space = None,
-              identifier = SoftAST.IdentifierExpected(indexOf("let mut>><<"))
+              identifier = IdentifierExpected("let mut>><<")
             ),
             postIdentifierSpace = None,
             equalToken = SoftAST.TokenExpected(indexOf("let mut>><<"), Token.Equal),
             postEqualSpace = None,
-            expressionRight = SoftAST.ExpressionExpected(indexOf("let mut>><<"))
+            expressionRight = ExpressionExpected("let mut>><<")
           )
         )
     }
@@ -137,15 +137,15 @@ class VariableDeclarationParserSpec extends AnyWordSpec with Matchers {
       varDec shouldBe
         SoftAST.VariableDeclaration(
           index = indexOf(">>let<<"),
-          let = Let(indexOf(">>let<<")),
+          let = Let(">>let<<"),
           postLetSpace = None,
           assignment = SoftAST.Assignment(
             index = indexOf("let>><<"),
-            expressionLeft = SoftAST.ExpressionExpected(indexOf("let>><<")),
+            expressionLeft = ExpressionExpected("let>><<"),
             postIdentifierSpace = None,
             equalToken = SoftAST.TokenExpected(indexOf("let>><<"), Token.Equal),
             postEqualSpace = None,
-            expressionRight = SoftAST.ExpressionExpected(indexOf("let>><<"))
+            expressionRight = ExpressionExpected("let>><<")
           )
         )
     }
@@ -188,8 +188,8 @@ class VariableDeclarationParserSpec extends AnyWordSpec with Matchers {
       val tupleVarDec =
         parseVariableDeclaration("let (a, b, c) = blah")
 
-      tupleVarDec.let shouldBe Let(indexOf(">>let<< (a, b, c) = blah"))
-      tupleVarDec.postLetSpace shouldBe Some(SpaceOne(indexOf("let>> <<(a, b, c) = blah")))
+      tupleVarDec.let shouldBe Let(">>let<< (a, b, c) = blah")
+      tupleVarDec.postLetSpace shouldBe Some(Space("let>> <<(a, b, c) = blah"))
 
       // left is a tuple
       val left = tupleVarDec.assignment.expressionLeft.asInstanceOf[SoftAST.Group[Token.OpenParen.type, Token.CloseParen.type]]

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/WhileParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/WhileParserSpec.scala
@@ -31,11 +31,11 @@ class WhileParserSpec extends AnyWordSpec with Matchers {
       actual shouldBe
         SoftAST.While(
           index = indexOf(">>while<<"),
-          whileToken = While(indexOf(">>while<<")),
+          whileToken = While(">>while<<"),
           postWhileSpace = None,
           openParen = SoftAST.TokenExpected(indexOf("while>><<"), Token.OpenParen),
           postOpenParenSpace = None,
-          expression = SoftAST.ExpressionExpected(indexOf("while>><<")),
+          expression = ExpressionExpected("while>><<"),
           postExpressionSpace = None,
           closeParen = SoftAST.TokenExpected(indexOf("while>><<"), Token.CloseParen),
           postCloseParenSpace = None,
@@ -50,11 +50,11 @@ class WhileParserSpec extends AnyWordSpec with Matchers {
       actual shouldBe
         SoftAST.While(
           index = indexOf(">>while <<"),
-          whileToken = While(indexOf(">>while<< ")),
-          postWhileSpace = Some(SpaceOne(indexOf("while>> <<"))),
+          whileToken = While(">>while<< "),
+          postWhileSpace = Some(Space("while>> <<")),
           openParen = SoftAST.TokenExpected(indexOf("while >><<"), Token.OpenParen),
           postOpenParenSpace = None,
-          expression = SoftAST.ExpressionExpected(indexOf("while >><<")),
+          expression = ExpressionExpected("while >><<"),
           postExpressionSpace = None,
           closeParen = SoftAST.TokenExpected(indexOf("while >><<"), Token.CloseParen),
           postCloseParenSpace = None,
@@ -69,11 +69,11 @@ class WhileParserSpec extends AnyWordSpec with Matchers {
       actual shouldBe
         SoftAST.While(
           index = indexOf(">>while(<<"),
-          whileToken = While(indexOf(">>while<<")),
+          whileToken = While(">>while<<"),
           postWhileSpace = None,
-          openParen = OpenParen(indexOf("while>>(<<")),
+          openParen = OpenParen("while>>(<<"),
           postOpenParenSpace = None,
-          expression = SoftAST.ExpressionExpected(indexOf("while(>><<")),
+          expression = ExpressionExpected("while(>><<"),
           postExpressionSpace = None,
           closeParen = SoftAST.TokenExpected(indexOf("while(>><<"), Token.CloseParen),
           postCloseParenSpace = None,

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -755,6 +755,12 @@ object TestSoftAST {
       )
     )
 
+  def IdentifierExpected(text: String): SoftAST.IdentifierExpected =
+    SoftAST.IdentifierExpected(indexOf(text))
+
+  def ExpressionExpected(text: String): SoftAST.ExpressionExpected =
+    SoftAST.ExpressionExpected(indexOf(text))
+
   def Space(text: String): SoftAST.Space =
     Space(indexChunkOf(text))
 
@@ -774,28 +780,29 @@ object TestSoftAST {
       )
     )
 
-  def SpaceOne(index: SourceIndex): SoftAST.Space =
-    SoftAST.Space(
-      code = SoftAST.CodeString(
-        index = index,
-        text = " "
-      )
-    )
-
-  def SpaceNewline(index: SourceIndex): SoftAST.Space =
-    SoftAST.Space(
-      code = Code(
-        index = index,
-        token = Token.Newline
-      )
-    )
-
   def Code(
       index: SourceIndex,
       token: Token): SoftAST.CodeString =
     SoftAST.CodeString(
       index = index,
       text = token.lexeme
+    )
+
+  def CodeString(text: String): SoftAST.CodeString =
+    CodeString(indexChunkOf(text))
+
+  def CodeString(indexText: (SourceIndex, String)): SoftAST.CodeString =
+    CodeString(
+      index = indexText._1,
+      text = indexText._2
+    )
+
+  def CodeString(
+      index: SourceIndex,
+      text: String): SoftAST.CodeString =
+    SoftAST.CodeString(
+      index = index,
+      text = text
     )
 
   def TokenDocumented[T <: Token](

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -5,17 +5,359 @@ import org.alephium.ralph.lsp.access.util.TestCodeUtil.{indexChunkOf, indexOf}
 
 object TestSoftAST {
 
-  def Fn(index: SourceIndex): SoftAST.TokenDocumented[Token.Fn.type] =
+  def EqualEqual(code: String): SoftAST.TokenDocumented[Token.EqualEqual.type] =
+    EqualEqual(indexOf(code))
+
+  def EqualEqual(index: SourceIndex): SoftAST.TokenDocumented[Token.EqualEqual.type] =
     TokenDocumented(
       index = index,
-      token = Token.Fn
+      token = Token.EqualEqual
     )
+
+  def GreaterThanOrEqual(code: String): SoftAST.TokenDocumented[Token.GreaterThanOrEqual.type] =
+    GreaterThanOrEqual(indexOf(code))
+
+  def GreaterThanOrEqual(index: SourceIndex): SoftAST.TokenDocumented[Token.GreaterThanOrEqual.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.GreaterThanOrEqual
+    )
+
+  def PlusPlus(code: String): SoftAST.TokenDocumented[Token.PlusPlus.type] =
+    PlusPlus(indexOf(code))
+
+  def PlusPlus(index: SourceIndex): SoftAST.TokenDocumented[Token.PlusPlus.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.PlusPlus
+    )
+
+  def PlusEquals(code: String): SoftAST.TokenDocumented[Token.PlusEquals.type] =
+    PlusEquals(indexOf(code))
+
+  def PlusEquals(index: SourceIndex): SoftAST.TokenDocumented[Token.PlusEquals.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.PlusEquals
+    )
+
+  def MinusEquals(code: String): SoftAST.TokenDocumented[Token.MinusEquals.type] =
+    MinusEquals(indexOf(code))
+
+  def MinusEquals(index: SourceIndex): SoftAST.TokenDocumented[Token.MinusEquals.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.MinusEquals
+    )
+
+  def LessThanOrEqual(code: String): SoftAST.TokenDocumented[Token.LessThanOrEqual.type] =
+    LessThanOrEqual(indexOf(code))
+
+  def LessThanOrEqual(index: SourceIndex): SoftAST.TokenDocumented[Token.LessThanOrEqual.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.LessThanOrEqual
+    )
+
+  def NotEqual(code: String): SoftAST.TokenDocumented[Token.NotEqual.type] =
+    NotEqual(indexOf(code))
+
+  def NotEqual(index: SourceIndex): SoftAST.TokenDocumented[Token.NotEqual.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.NotEqual
+    )
+
+  def ForwardArrow(code: String): SoftAST.TokenDocumented[Token.ForwardArrow.type] =
+    ForwardArrow(indexOf(code))
+
+  def ForwardArrow(index: SourceIndex): SoftAST.TokenDocumented[Token.ForwardArrow.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.ForwardArrow
+    )
+
+  def Or(code: String): SoftAST.TokenDocumented[Token.Or.type] =
+    Or(indexOf(code))
+
+  def Or(index: SourceIndex): SoftAST.TokenDocumented[Token.Or.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Or
+    )
+
+  def And(code: String): SoftAST.TokenDocumented[Token.And.type] =
+    And(indexOf(code))
+
+  def And(index: SourceIndex): SoftAST.TokenDocumented[Token.And.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.And
+    )
+
+  def ShiftLeft(code: String): SoftAST.TokenDocumented[Token.ShiftLeft.type] =
+    ShiftLeft(indexOf(code))
+
+  def ShiftLeft(index: SourceIndex): SoftAST.TokenDocumented[Token.ShiftLeft.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.ShiftLeft
+    )
+
+  def ShiftRight(code: String): SoftAST.TokenDocumented[Token.ShiftRight.type] =
+    ShiftRight(indexOf(code))
+
+  def ShiftRight(index: SourceIndex): SoftAST.TokenDocumented[Token.ShiftRight.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.ShiftRight
+    )
+
+  def ModuloAddition(code: String): SoftAST.TokenDocumented[Token.ModuloAddition.type] =
+    ModuloAddition(indexOf(code))
+
+  def ModuloAddition(index: SourceIndex): SoftAST.TokenDocumented[Token.ModuloAddition.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.ModuloAddition
+    )
+
+  def ModuloSubtraction(code: String): SoftAST.TokenDocumented[Token.ModuloSubtraction.type] =
+    ModuloSubtraction(indexOf(code))
+
+  def ModuloSubtraction(index: SourceIndex): SoftAST.TokenDocumented[Token.ModuloSubtraction.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.ModuloSubtraction
+    )
+
+  def ModuloExponentiation(code: String): SoftAST.TokenDocumented[Token.ModuloExponentiation.type] =
+    ModuloExponentiation(indexOf(code))
+
+  def ModuloExponentiation(index: SourceIndex): SoftAST.TokenDocumented[Token.ModuloExponentiation.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.ModuloExponentiation
+    )
+
+  def ModuloMultiplication(code: String): SoftAST.TokenDocumented[Token.ModuloMultiplication.type] =
+    ModuloMultiplication(indexOf(code))
+
+  def ModuloMultiplication(index: SourceIndex): SoftAST.TokenDocumented[Token.ModuloMultiplication.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.ModuloMultiplication
+    )
+
+  def Exponentiation(code: String): SoftAST.TokenDocumented[Token.Exponentiation.type] =
+    Exponentiation(indexOf(code))
+
+  def Exponentiation(index: SourceIndex): SoftAST.TokenDocumented[Token.Exponentiation.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Exponentiation
+    )
+
+  def Minus(code: String): SoftAST.TokenDocumented[Token.Minus.type] =
+    Minus(indexOf(code))
+
+  def Minus(index: SourceIndex): SoftAST.TokenDocumented[Token.Minus.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Minus
+    )
+
+  def Plus(code: String): SoftAST.TokenDocumented[Token.Plus.type] =
+    Plus(indexOf(code))
+
+  def Plus(index: SourceIndex): SoftAST.TokenDocumented[Token.Plus.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Plus
+    )
+
+  def Asterisk(code: String): SoftAST.TokenDocumented[Token.Asterisk.type] =
+    Asterisk(indexOf(code))
+
+  def Asterisk(index: SourceIndex): SoftAST.TokenDocumented[Token.Asterisk.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Asterisk
+    )
+
+  def ForwardSlash(code: String): SoftAST.TokenDocumented[Token.ForwardSlash.type] =
+    ForwardSlash(indexOf(code))
+
+  def ForwardSlash(index: SourceIndex): SoftAST.TokenDocumented[Token.ForwardSlash.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.ForwardSlash
+    )
+
+  def GreaterThan(code: String): SoftAST.TokenDocumented[Token.GreaterThan.type] =
+    GreaterThan(indexOf(code))
+
+  def GreaterThan(index: SourceIndex): SoftAST.TokenDocumented[Token.GreaterThan.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.GreaterThan
+    )
+
+  def LessThan(code: String): SoftAST.TokenDocumented[Token.LessThan.type] =
+    LessThan(indexOf(code))
+
+  def LessThan(index: SourceIndex): SoftAST.TokenDocumented[Token.LessThan.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.LessThan
+    )
+
+  def Equal(code: String): SoftAST.TokenDocumented[Token.Equal.type] =
+    Equal(indexOf(code))
+
+  def Equal(index: SourceIndex): SoftAST.TokenDocumented[Token.Equal.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Equal
+    )
+
+  def Exclamation(code: String): SoftAST.TokenDocumented[Token.Exclamation.type] =
+    Exclamation(indexOf(code))
+
+  def Exclamation(index: SourceIndex): SoftAST.TokenDocumented[Token.Exclamation.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Exclamation
+    )
+
+  def Bar(code: String): SoftAST.TokenDocumented[Token.Bar.type] =
+    Bar(indexOf(code))
+
+  def Bar(index: SourceIndex): SoftAST.TokenDocumented[Token.Bar.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Bar
+    )
+
+  def Ampersand(code: String): SoftAST.TokenDocumented[Token.Ampersand.type] =
+    Ampersand(indexOf(code))
+
+  def Ampersand(index: SourceIndex): SoftAST.TokenDocumented[Token.Ampersand.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Ampersand
+    )
+
+  def Caret(code: String): SoftAST.TokenDocumented[Token.Caret.type] =
+    Caret(indexOf(code))
+
+  def Caret(index: SourceIndex): SoftAST.TokenDocumented[Token.Caret.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Caret
+    )
+
+  def Percent(code: String): SoftAST.TokenDocumented[Token.Percent.type] =
+    Percent(indexOf(code))
+
+  def Percent(index: SourceIndex): SoftAST.TokenDocumented[Token.Percent.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Percent
+    )
+
+  def OpenParen(code: String): SoftAST.TokenDocumented[Token.OpenParen.type] =
+    OpenParen(indexOf(code))
+
+  def OpenParen(index: SourceIndex): SoftAST.TokenDocumented[Token.OpenParen.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.OpenParen
+    )
+
+  def CloseParen(code: String): SoftAST.TokenDocumented[Token.CloseParen.type] =
+    CloseParen(indexOf(code))
+
+  def CloseParen(index: SourceIndex): SoftAST.TokenDocumented[Token.CloseParen.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.CloseParen
+    )
+
+  def OpenCurly(code: String): SoftAST.TokenDocumented[Token.OpenCurly.type] =
+    OpenCurly(indexOf(code))
+
+  def OpenCurly(index: SourceIndex): SoftAST.TokenDocumented[Token.OpenCurly.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.OpenCurly
+    )
+
+  def CloseCurly(code: String): SoftAST.TokenDocumented[Token.CloseCurly.type] =
+    CloseCurly(indexOf(code))
+
+  def CloseCurly(index: SourceIndex): SoftAST.TokenDocumented[Token.CloseCurly.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.CloseCurly
+    )
+
+  def OpenBracket(code: String): SoftAST.TokenDocumented[Token.OpenBracket.type] =
+    OpenBracket(indexOf(code))
+
+  def OpenBracket(index: SourceIndex): SoftAST.TokenDocumented[Token.OpenBracket.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.OpenBracket
+    )
+
+  def BlockBracket(code: String): SoftAST.TokenDocumented[Token.BlockBracket.type] =
+    BlockBracket(indexOf(code))
+
+  def BlockBracket(index: SourceIndex): SoftAST.TokenDocumented[Token.BlockBracket.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.BlockBracket
+    )
+
+  def Comma(code: String): SoftAST.TokenDocumented[Token.Comma.type] =
+    Comma(indexOf(code))
 
   def Comma(index: SourceIndex): SoftAST.TokenDocumented[Token.Comma.type] =
     TokenDocumented(
       index = index,
       token = Token.Comma
     )
+
+  def Dot(code: String): SoftAST.TokenDocumented[Token.Dot.type] =
+    Dot(indexOf(code))
+
+  def Dot(index: SourceIndex): SoftAST.TokenDocumented[Token.Dot.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Dot
+    )
+
+  def Colon(code: String): SoftAST.TokenDocumented[Token.Colon.type] =
+    Colon(indexOf(code))
+
+  def Colon(index: SourceIndex): SoftAST.TokenDocumented[Token.Colon.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Colon
+    )
+
+  def Semicolon(code: String): SoftAST.TokenDocumented[Token.Semicolon.type] =
+    Semicolon(indexOf(code))
+
+  def Semicolon(index: SourceIndex): SoftAST.TokenDocumented[Token.Semicolon.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Semicolon
+    )
+
+  def DoubleForwardSlash(code: String): SoftAST.TokenUndocumented[Token.DoubleForwardSlash.type] =
+    DoubleForwardSlash(indexOf(code))
 
   def DoubleForwardSlash(index: SourceIndex): SoftAST.TokenUndocumented[Token.DoubleForwardSlash.type] =
     SoftAST.TokenUndocumented(
@@ -25,137 +367,53 @@ object TestSoftAST {
       )
     )
 
+  def Newline(code: String): SoftAST.TokenDocumented[Token.Newline.type] =
+    Newline(indexOf(code))
+
+  def Newline(index: SourceIndex): SoftAST.TokenDocumented[Token.Newline.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Newline
+    )
+
+  def Tab(code: String): SoftAST.TokenDocumented[Token.Tab.type] =
+    Tab(indexOf(code))
+
+  def Tab(index: SourceIndex): SoftAST.TokenDocumented[Token.Tab.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Tab
+    )
+
+  def Hash(code: String): SoftAST.TokenDocumented[Token.Hash.type] =
+    Hash(indexOf(code))
+
+  def Hash(index: SourceIndex): SoftAST.TokenDocumented[Token.Hash.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Hash
+    )
+
+  def Underscore(code: String): SoftAST.TokenDocumented[Token.Underscore.type] =
+    Underscore(indexOf(code))
+
+  def Underscore(index: SourceIndex): SoftAST.TokenDocumented[Token.Underscore.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Underscore
+    )
+
+  def At(code: String): SoftAST.TokenDocumented[Token.At.type] =
+    At(indexOf(code))
+
   def At(index: SourceIndex): SoftAST.TokenDocumented[Token.At.type] =
     TokenDocumented(
       index = index,
       token = Token.At
     )
 
-  def Contract(index: SourceIndex): SoftAST.TokenDocumented[Token.Contract.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.Contract
-    )
-
-  def TxScript(index: SourceIndex): SoftAST.TokenDocumented[Token.TxScript.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.TxScript
-    )
-
-  def Colon(index: SourceIndex): SoftAST.TokenDocumented[Token.Colon.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.Colon
-    )
-
-  def ForwardArrow(index: SourceIndex): SoftAST.TokenDocumented[Token.ForwardArrow.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.ForwardArrow
-    )
-
-  def OpenParen(index: SourceIndex): SoftAST.TokenDocumented[Token.OpenParen.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.OpenParen
-    )
-
-  def CloseParen(index: SourceIndex): SoftAST.TokenDocumented[Token.CloseParen.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.CloseParen
-    )
-
-  def OpenCurly(code: String): SoftAST.TokenDocumented[Token.OpenCurly.type] =
-    TokenDocumented(
-      index = indexOf(code),
-      token = Token.OpenCurly
-    )
-
-  def OpenCurly(index: SourceIndex): SoftAST.TokenDocumented[Token.OpenCurly.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.OpenCurly
-    )
-
-  def CloseCurly(code: String): SoftAST.TokenDocumented[Token.CloseCurly.type] =
-    TokenDocumented(
-      index = indexOf(code),
-      token = Token.CloseCurly
-    )
-
-  def CloseCurly(index: SourceIndex): SoftAST.TokenDocumented[Token.CloseCurly.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.CloseCurly
-    )
-
-  def True(index: SourceIndex): SoftAST.TokenDocumented[Token.True.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.True
-    )
-
-  def False(index: SourceIndex): SoftAST.TokenDocumented[Token.False.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.False
-    )
-
-  def AlphLowercase(index: SourceIndex): SoftAST.TokenDocumented[Token.AlphLowercase.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.AlphLowercase
-    )
-
-  def AlphUppercase(index: SourceIndex): SoftAST.TokenDocumented[Token.AlphUppercase.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.AlphUppercase
-    )
-
-  def Let(index: SourceIndex): SoftAST.TokenDocumented[Token.Let.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.Let
-    )
-
-  def Mut(index: SourceIndex): SoftAST.TokenDocumented[Token.Mut.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.Mut
-    )
-
-  def Equal(code: String): SoftAST.TokenDocumented[Token.Equal.type] =
-    TokenDocumented(
-      index = indexOf(code),
-      token = Token.Equal
-    )
-
-  def Equal(index: SourceIndex): SoftAST.TokenDocumented[Token.Equal.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.Equal
-    )
-
-  def EqualEqual(index: SourceIndex): SoftAST.TokenDocumented[Token.EqualEqual.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.EqualEqual
-    )
-
-  def Plus(index: SourceIndex): SoftAST.TokenDocumented[Token.Plus.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.Plus
-    )
-
-  def B(index: SourceIndex): SoftAST.TokenDocumented[Token.B.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.B
-    )
+  def Tick(code: String): SoftAST.TokenDocumented[Token.Tick.type] =
+    Tick(indexOf(code))
 
   def Tick(index: SourceIndex): SoftAST.TokenDocumented[Token.Tick.type] =
     TokenDocumented(
@@ -163,11 +421,8 @@ object TestSoftAST {
       token = Token.Tick
     )
 
-  def ForwardSlash(index: SourceIndex): SoftAST.TokenDocumented[Token.ForwardSlash.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.ForwardSlash
-    )
+  def Quote(code: String): SoftAST.TokenDocumented[Token.Quote.type] =
+    Quote(indexOf(code))
 
   def Quote(index: SourceIndex): SoftAST.TokenDocumented[Token.Quote.type] =
     TokenDocumented(
@@ -175,17 +430,44 @@ object TestSoftAST {
       token = Token.Quote
     )
 
-  def Import(index: SourceIndex): SoftAST.TokenDocumented[Token.Import.type] =
+  def B(code: String): SoftAST.TokenDocumented[Token.B.type] =
+    B(indexOf(code))
+
+  def B(index: SourceIndex): SoftAST.TokenDocumented[Token.B.type] =
     TokenDocumented(
       index = index,
-      token = Token.Import
+      token = Token.B
     )
 
-  def Event(index: SourceIndex): SoftAST.TokenDocumented[Token.Event.type] =
+  def Const(code: String): SoftAST.TokenDocumented[Token.Const.type] =
+    Const(indexOf(code))
+
+  def Const(index: SourceIndex): SoftAST.TokenDocumented[Token.Const.type] =
     TokenDocumented(
       index = index,
-      token = Token.Event
+      token = Token.Const
     )
+
+  def Let(code: String): SoftAST.TokenDocumented[Token.Let.type] =
+    Let(indexOf(code))
+
+  def Let(index: SourceIndex): SoftAST.TokenDocumented[Token.Let.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Let
+    )
+
+  def Mut(code: String): SoftAST.TokenDocumented[Token.Mut.type] =
+    Mut(indexOf(code))
+
+  def Mut(index: SourceIndex): SoftAST.TokenDocumented[Token.Mut.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Mut
+    )
+
+  def Struct(code: String): SoftAST.TokenDocumented[Token.Struct.type] =
+    Struct(indexOf(code))
 
   def Struct(index: SourceIndex): SoftAST.TokenDocumented[Token.Struct.type] =
     TokenDocumented(
@@ -194,10 +476,7 @@ object TestSoftAST {
     )
 
   def Enum(code: String): SoftAST.TokenDocumented[Token.Enum.type] =
-    TokenDocumented(
-      index = indexOf(code),
-      token = Token.Enum
-    )
+    Enum(indexOf(code))
 
   def Enum(index: SourceIndex): SoftAST.TokenDocumented[Token.Enum.type] =
     TokenDocumented(
@@ -205,29 +484,35 @@ object TestSoftAST {
       token = Token.Enum
     )
 
-  def Implements(index: SourceIndex): SoftAST.TokenDocumented[Token.Implements.type] =
+  def Event(code: String): SoftAST.TokenDocumented[Token.Event.type] =
+    Event(indexOf(code))
+
+  def Event(index: SourceIndex): SoftAST.TokenDocumented[Token.Event.type] =
     TokenDocumented(
       index = index,
-      token = Token.Implements
+      token = Token.Event
     )
 
-  def Extends(index: SourceIndex): SoftAST.TokenDocumented[Token.Extends.type] =
+  def If(code: String): SoftAST.TokenDocumented[Token.If.type] =
+    If(indexOf(code))
+
+  def If(index: SourceIndex): SoftAST.TokenDocumented[Token.If.type] =
     TokenDocumented(
       index = index,
-      token = Token.Extends
+      token = Token.If
     )
 
-  def Pub(index: SourceIndex): SoftAST.TokenDocumented[Token.Pub.type] =
+  def Else(code: String): SoftAST.TokenDocumented[Token.Else.type] =
+    Else(indexOf(code))
+
+  def Else(index: SourceIndex): SoftAST.TokenDocumented[Token.Else.type] =
     TokenDocumented(
       index = index,
-      token = Token.Pub
+      token = Token.Else
     )
 
-  def For(index: SourceIndex): SoftAST.TokenDocumented[Token.For.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.For
-    )
+  def While(code: String): SoftAST.TokenDocumented[Token.While.type] =
+    While(indexOf(code))
 
   def While(index: SourceIndex): SoftAST.TokenDocumented[Token.While.type] =
     TokenDocumented(
@@ -235,11 +520,8 @@ object TestSoftAST {
       token = Token.While
     )
 
-  def Dot(index: SourceIndex): SoftAST.TokenDocumented[Token.Dot.type] =
-    TokenDocumented(
-      index = index,
-      token = Token.Dot
-    )
+  def Return(code: String): SoftAST.TokenDocumented[Token.Return.type] =
+    Return(indexOf(code))
 
   def Return(index: SourceIndex): SoftAST.TokenDocumented[Token.Return.type] =
     TokenDocumented(
@@ -247,10 +529,166 @@ object TestSoftAST {
       token = Token.Return
     )
 
-  def LessThanOrEqual(index: SourceIndex): SoftAST.TokenDocumented[Token.LessThanOrEqual.type] =
+  def For(code: String): SoftAST.TokenDocumented[Token.For.type] =
+    For(indexOf(code))
+
+  def For(index: SourceIndex): SoftAST.TokenDocumented[Token.For.type] =
     TokenDocumented(
       index = index,
-      token = Token.LessThanOrEqual
+      token = Token.For
+    )
+
+  def Pub(code: String): SoftAST.TokenDocumented[Token.Pub.type] =
+    Pub(indexOf(code))
+
+  def Pub(index: SourceIndex): SoftAST.TokenDocumented[Token.Pub.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Pub
+    )
+
+  def Fn(code: String): SoftAST.TokenDocumented[Token.Fn.type] =
+    Fn(indexOf(code))
+
+  def Fn(index: SourceIndex): SoftAST.TokenDocumented[Token.Fn.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Fn
+    )
+
+  def Import(code: String): SoftAST.TokenDocumented[Token.Import.type] =
+    Import(indexOf(code))
+
+  def Import(index: SourceIndex): SoftAST.TokenDocumented[Token.Import.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Import
+    )
+
+  def Abstract(code: String): SoftAST.TokenDocumented[Token.Abstract.type] =
+    Abstract(indexOf(code))
+
+  def Abstract(index: SourceIndex): SoftAST.TokenDocumented[Token.Abstract.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Abstract
+    )
+
+  def Contract(code: String): SoftAST.TokenDocumented[Token.Contract.type] =
+    Contract(indexOf(code))
+
+  def Contract(index: SourceIndex): SoftAST.TokenDocumented[Token.Contract.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Contract
+    )
+
+  def TxScript(code: String): SoftAST.TokenDocumented[Token.TxScript.type] =
+    TxScript(indexOf(code))
+
+  def TxScript(index: SourceIndex): SoftAST.TokenDocumented[Token.TxScript.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.TxScript
+    )
+
+  def AssetScript(code: String): SoftAST.TokenDocumented[Token.AssetScript.type] =
+    AssetScript(indexOf(code))
+
+  def AssetScript(index: SourceIndex): SoftAST.TokenDocumented[Token.AssetScript.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.AssetScript
+    )
+
+  def Interface(code: String): SoftAST.TokenDocumented[Token.Interface.type] =
+    Interface(indexOf(code))
+
+  def Interface(index: SourceIndex): SoftAST.TokenDocumented[Token.Interface.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Interface
+    )
+
+  def Extends(code: String): SoftAST.TokenDocumented[Token.Extends.type] =
+    Extends(indexOf(code))
+
+  def Extends(index: SourceIndex): SoftAST.TokenDocumented[Token.Extends.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Extends
+    )
+
+  def Implements(code: String): SoftAST.TokenDocumented[Token.Implements.type] =
+    Implements(indexOf(code))
+
+  def Implements(index: SourceIndex): SoftAST.TokenDocumented[Token.Implements.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Implements
+    )
+
+  def Using(code: String): SoftAST.TokenDocumented[Token.Using.type] =
+    Using(indexOf(code))
+
+  def Using(index: SourceIndex): SoftAST.TokenDocumented[Token.Using.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Using
+    )
+
+  def Emit(code: String): SoftAST.TokenDocumented[Token.Emit.type] =
+    Emit(indexOf(code))
+
+  def Emit(index: SourceIndex): SoftAST.TokenDocumented[Token.Emit.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Emit
+    )
+
+  def Embeds(code: String): SoftAST.TokenDocumented[Token.Embeds.type] =
+    Embeds(indexOf(code))
+
+  def Embeds(index: SourceIndex): SoftAST.TokenDocumented[Token.Embeds.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Embeds
+    )
+
+  def True(code: String): SoftAST.TokenDocumented[Token.True.type] =
+    True(indexOf(code))
+
+  def True(index: SourceIndex): SoftAST.TokenDocumented[Token.True.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.True
+    )
+
+  def False(code: String): SoftAST.TokenDocumented[Token.False.type] =
+    False(indexOf(code))
+
+  def False(index: SourceIndex): SoftAST.TokenDocumented[Token.False.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.False
+    )
+
+  def AlphLowercase(code: String): SoftAST.TokenDocumented[Token.AlphLowercase.type] =
+    AlphLowercase(indexOf(code))
+
+  def AlphLowercase(index: SourceIndex): SoftAST.TokenDocumented[Token.AlphLowercase.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.AlphLowercase
+    )
+
+  def AlphUppercase(code: String): SoftAST.TokenDocumented[Token.AlphUppercase.type] =
+    AlphUppercase(indexOf(code))
+
+  def AlphUppercase(index: SourceIndex): SoftAST.TokenDocumented[Token.AlphUppercase.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.AlphUppercase
     )
 
   def Identifier(code: String): SoftAST.Identifier =


### PR DESCRIPTION
Implements test-constructors for all `Token` types with additional test constructors, removing the need for the `indexOf` function call in most tests. This makes test cases a bit quicker to write and shorter in width. 

The constructors were generated, and existing calls to `indexOf` were replaced wherever a simple regex-replace could do the job. The remaining can be replaced later.

Towards #104.