### PR TITLE
Return tuple

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/Demo.scala
@@ -55,6 +55,8 @@ object Demo extends App {
         |       b`some text 🎸
         |         some text in the middle
         |         some more text 🤙`
+        |
+        |    return a + b, method.call(), (1, 2)
         |  }
         |
         |  🚀

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/GroupParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/GroupParser.scala
@@ -58,9 +58,9 @@ private object GroupParser {
     }
 
   /**
-   * Parses a sequence of arguments enclosed within parentheses.
+   * Parses a sequence of expressions enclosed within the given open and close tokens.
    *
-   * Syntax: (arg1, arg2, (arg3, arg4), arg5)
+   * Syntax: (expr1, expr2, (expr3, expr4), ...)
    *
    * @param required Determines if the parser should fail when the opening parenthesis is missing.
    * @return An instance of [[SoftAST.Group]].
@@ -81,25 +81,38 @@ private object GroupParser {
         Index
     } map {
       case (from, openParen, preHeadSpace, headParamIndex, headExpression, postHeadSpace, tailParams, closeParen, to) =>
-        // Look ahead check: If tail param is provided, but head param is missing, report the head param as required.
-        // For example, in the case of `(, tailArgs)`, head param is missing which is required.
         val headExpressionAdjusted =
-          if (tailParams.nonEmpty && headExpression.isEmpty)
-            Some(SoftAST.ExpressionExpected(point(headParamIndex)))
-          else
-            headExpression
+          adjustHeadExpression(
+            headParamIndex = headParamIndex,
+            headExpression = headExpression,
+            tailParams = tailParams
+          )
 
         SoftAST.Group(
           index = range(from, to),
-          openToken = openParen,
+          openToken = Some(openParen),
           preHeadExpressionSpace = preHeadSpace,
           headExpression = headExpressionAdjusted,
           postHeadExpressionSpace = postHeadSpace,
           tailExpressions = tailParams,
-          closeToken = closeParen
+          closeToken = Some(closeParen)
         )
 
     }
+
+  /**
+   * Look ahead check: If tail param is provided, but head param is missing, report the head param as required.
+   *
+   * For example, in the case of `(, tailArgs)`, head param is missing which is required.
+   */
+  private def adjustHeadExpression(
+      headParamIndex: Int,
+      headExpression: Option[SoftAST.ExpressionAST],
+      tailParams: Seq[SoftAST.GroupTail]): Option[SoftAST.ExpressionAST] =
+    if (tailParams.nonEmpty && headExpression.isEmpty)
+      Some(SoftAST.ExpressionExpected(point(headParamIndex)))
+    else
+      headExpression
 
   /**
    * Parses a "tail param" which may contain nested arguments.

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReturnParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReturnParser.scala
@@ -27,9 +27,8 @@ private object ReturnParser {
 
   private def expression[Unknown: P]: P[SoftAST.ExpressionAST] =
     P {
-      // TODO: Handle comma separated tuples but without enclosing parentheses
-      //       For example: return 1, 2, 3
-      InfixCallParser.parseOrFail |
+      GroupParser.parseOrFail |
+        InfixCallParser.parseOrFail |
         MethodCallParser.parseOrFail |
         AnnotationParser.parseOrFail |
         ParameterParser.parseOrFail |

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -341,12 +341,12 @@ object SoftAST {
    */
   case class Group[O <: Token, C <: Token](
       index: SourceIndex,
-      openToken: TokenDocExpectedAST[O],
+      openToken: Option[TokenDocExpectedAST[O]],
       preHeadExpressionSpace: Option[Space],
       headExpression: Option[ExpressionAST],
       postHeadExpressionSpace: Option[Space],
       tailExpressions: Seq[GroupTail],
-      closeToken: TokenDocExpectedAST[C])
+      closeToken: Option[TokenDocExpectedAST[C]])
     extends ExpressionAST {
 
     /** Collects all expressions defined in this group */

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AnnotationParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AnnotationParserSpec.scala
@@ -49,9 +49,9 @@ class AnnotationParserSpec extends AnyWordSpec with Matchers {
         parseAnnotation("@anno(")
 
       // opening paren is parsed
-      annotation.tuple.value.openToken shouldBe OpenParen("@anno>>(<<")
+      annotation.tuple.value.openToken.value shouldBe OpenParen("@anno>>(<<")
       // closing paren is reported as expected
-      annotation.tuple.value.closeToken shouldBe SoftAST.TokenExpected(indexOf("@anno(>><<"), Token.CloseParen)
+      annotation.tuple.value.closeToken.value shouldBe SoftAST.TokenExpected(indexOf("@anno(>><<"), Token.CloseParen)
     }
 
     "reject reserved keyword as annotation identifier" in {

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/EventParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/EventParserSpec.scala
@@ -6,6 +6,7 @@ import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.OptionValues._
 
 class EventParserSpec extends AnyWordSpec {
 
@@ -30,7 +31,7 @@ class EventParserSpec extends AnyWordSpec {
     // Tuples are tested in TupleSpec, test for the index and string code here.
     event.params.index shouldBe indexOf("event MyEvent>>(varName: TypeName<<")
     event.params.toCode() shouldBe "(varName: TypeName"
-    event.params.closeToken shouldBe SoftAST.TokenExpected(indexOf("event MyEvent(varName: TypeName>><<"), Token.CloseParen)
+    event.params.closeToken.value shouldBe SoftAST.TokenExpected(indexOf("event MyEvent(varName: TypeName>><<"), Token.CloseParen)
   }
 
 }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionNameSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionNameSpec.scala
@@ -22,6 +22,7 @@ import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.OptionValues._
 
 class FunctionNameSpec extends AnyWordSpec with Matchers {
 
@@ -168,7 +169,8 @@ class FunctionNameSpec extends AnyWordSpec with Matchers {
     function
       .signature
       .params
-      .closeToken shouldBe SoftAST.TokenExpected(indexOf("fn abcd(>><<"), Token.CloseParen)
+      .closeToken
+      .value shouldBe SoftAST.TokenExpected(indexOf("fn abcd(>><<"), Token.CloseParen)
   }
 
   "missing opening parentheses" in {
@@ -184,7 +186,8 @@ class FunctionNameSpec extends AnyWordSpec with Matchers {
     function
       .signature
       .params
-      .openToken shouldBe SoftAST.TokenExpected(indexOf("fn abcd>><<)"), Token.OpenParen)
+      .openToken
+      .value shouldBe SoftAST.TokenExpected(indexOf("fn abcd>><<)"), Token.OpenParen)
   }
 
 }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionReturnClauseSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionReturnClauseSpec.scala
@@ -22,6 +22,7 @@ import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.OptionValues._
 
 class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
 
@@ -117,9 +118,9 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
           text = "function"
         )
 
-      function.signature.params.openToken shouldBe OpenParen("fn function>>(<<-> ")
+      function.signature.params.openToken.value shouldBe OpenParen("fn function>>(<<-> ")
 
-      function.signature.params.closeToken shouldBe
+      function.signature.params.closeToken.value shouldBe
         SoftAST.TokenExpected(indexOf("fn function(>><<-> "), Token.CloseParen)
 
       function.signature.returned shouldBe
@@ -141,8 +142,8 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
           text = "function"
         )
 
-      function.signature.params.openToken shouldBe OpenParen("fn function>>(<<-> Type")
-      function.signature.params.closeToken shouldBe SoftAST.TokenExpected(indexOf("fn function(>><<-> Type"), Token.CloseParen)
+      function.signature.params.openToken.value shouldBe OpenParen("fn function>>(<<-> Type")
+      function.signature.params.closeToken.value shouldBe SoftAST.TokenExpected(indexOf("fn function(>><<-> Type"), Token.CloseParen)
 
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
@@ -169,8 +170,8 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
           text = "function"
         )
 
-      function.signature.params.openToken shouldBe OpenParen("fn function>>(<<) -> ")
-      function.signature.params.closeToken shouldBe CloseParen("fn function(>>)<< -> ")
+      function.signature.params.openToken.value shouldBe OpenParen("fn function>>(<<) -> ")
+      function.signature.params.closeToken.value shouldBe CloseParen("fn function(>>)<< -> ")
 
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
@@ -191,8 +192,8 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
           text = "function"
         )
 
-      function.signature.params.openToken shouldBe OpenParen("fn function>>(<<) -> type")
-      function.signature.params.closeToken shouldBe CloseParen("fn function(>>)<< -> type")
+      function.signature.params.openToken.value shouldBe OpenParen("fn function>>(<<) -> type")
+      function.signature.params.closeToken.value shouldBe CloseParen("fn function(>>)<< -> type")
 
       function.signature.returned shouldBe
         SoftAST.FunctionReturn(
@@ -225,8 +226,8 @@ class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
         text = "function"
       )
 
-    function.signature.params.openToken shouldBe OpenParen("fn function>>(<<) => ABC")
-    function.signature.params.closeToken shouldBe CloseParen("fn function(>>)<< => ABC")
+    function.signature.params.openToken.value shouldBe OpenParen("fn function>>(<<) => ABC")
+    function.signature.params.closeToken.value shouldBe CloseParen("fn function(>>)<< => ABC")
 
     /**
      * Second part is [[SoftAST.Unresolved]] arrow `=>`

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionReturnSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionReturnSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.OptionValues._
 
-class FunctionReturnClauseSpec extends AnyWordSpec with Matchers {
+class FunctionReturnSpec extends AnyWordSpec with Matchers {
 
   "function name is not defined" when {
     "arrow is defined" in {

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/GroupParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/GroupParserSpec.scala
@@ -30,16 +30,16 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
     val tuple =
       parseTuple(")")
 
-    tuple.openToken shouldBe SoftAST.TokenExpected(indexOf(">><<)"), Token.OpenParen)
-    tuple.closeToken shouldBe CloseParen(">>)<<")
+    tuple.openToken.value shouldBe SoftAST.TokenExpected(indexOf(">><<)"), Token.OpenParen)
+    tuple.closeToken.value shouldBe CloseParen(">>)<<")
   }
 
   "missing closing paren" in {
     val tuple =
       parseTuple("(")
 
-    tuple.openToken shouldBe OpenParen(">>(<<")
-    tuple.closeToken shouldBe SoftAST.TokenExpected(indexOf("(>><<"), Token.CloseParen)
+    tuple.openToken.value shouldBe OpenParen(">>(<<")
+    tuple.closeToken.value shouldBe SoftAST.TokenExpected(indexOf("(>><<"), Token.CloseParen)
   }
 
   "empty tuple" when {
@@ -50,12 +50,12 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
       val expected =
         SoftAST.Group(
           index = indexOf(">>()<<"),
-          openToken = OpenParen(">>(<<)"),
+          openToken = Some(OpenParen(">>(<<)")),
           preHeadExpressionSpace = None,
           headExpression = None,
           postHeadExpressionSpace = None,
           tailExpressions = Seq.empty,
-          closeToken = CloseParen("(>>)<<)")
+          closeToken = Some(CloseParen("(>>)<<)"))
         )
 
       tuple shouldBe expected
@@ -68,12 +68,12 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
       val expected =
         SoftAST.Group(
           index = indexOf(">>( )<<"),
-          openToken = OpenParen(">>(<< )"),
+          openToken = Some(OpenParen(">>(<< )")),
           preHeadExpressionSpace = Some(Space("(>> <<)")),
           headExpression = None,
           postHeadExpressionSpace = None,
           tailExpressions = Seq.empty,
-          closeToken = CloseParen("( >>)<<)")
+          closeToken = Some(CloseParen("( >>)<<)"))
         )
 
       tuple shouldBe expected
@@ -91,7 +91,7 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
     val tuple =
       block.headExpression.asInstanceOf[SoftAST.Group[Token.OpenParen.type, Token.CloseParen.type]]
 
-    tuple.openToken shouldBe OpenParen(">>(<<aaa typename")
+    tuple.openToken.value shouldBe OpenParen(">>(<<aaa typename")
 
     tuple.headExpression.value.asInstanceOf[SoftAST.Identifier] shouldBe
       Identifier(
@@ -99,7 +99,7 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
         text = "aaa"
       )
 
-    tuple.closeToken shouldBe SoftAST.TokenExpected(indexOf("(aaa >><<typename"), Token.CloseParen)
+    tuple.closeToken.value shouldBe SoftAST.TokenExpected(indexOf("(aaa >><<typename"), Token.CloseParen)
 
     /**
      * Second root part is an Identifier
@@ -119,7 +119,7 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
   "valid type assignment expression exists" in {
     val tuple = parseTuple("(aaa: typename)")
 
-    tuple.openToken shouldBe OpenParen(">>(<<aaa: typename")
+    tuple.openToken.value shouldBe OpenParen(">>(<<aaa: typename")
 
     val headExpression =
       tuple.headExpression.value.asInstanceOf[SoftAST.TypeAssignment]
@@ -140,7 +140,7 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
         text = "typename"
       )
 
-    tuple.closeToken shouldBe CloseParen("(aaa: typename>>)<<")
+    tuple.closeToken.value shouldBe CloseParen("(aaa: typename>>)<<")
   }
 
   "valid second type assignment expression exists" in {
@@ -211,7 +211,7 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
           preExpressionSpace = Some(Space("(a,>> <<(b, c))")),
           expression = SoftAST.Group(
             index = indexOf("(a, >>(b, c)<<)"),
-            openToken = OpenParen("(a, >>(<<b, c))"),
+            openToken = Some(OpenParen("(a, >>(<<b, c))")),
             preHeadExpressionSpace = None,
             headExpression = Some(Identifier("(a, (>>b<<, c))")),
             postHeadExpressionSpace = None,
@@ -224,7 +224,7 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
                 postExpressionSpace = None
               )
             ),
-            closeToken = CloseParen("(a, (b, c>>)<<)")
+            closeToken = Some(CloseParen("(a, (b, c>>)<<)"))
           ),
           postExpressionSpace = None
         )
@@ -236,7 +236,7 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
       tuple shouldBe
         SoftAST.Group(
           index = indexOf(">>(a, , ( , z)<<"),
-          openToken = OpenParen(">>(<<a, , ( , z)"),
+          openToken = Some(OpenParen(">>(<<a, , ( , z)")),
           preHeadExpressionSpace = None,
           headExpression = Some(
             Identifier(
@@ -259,7 +259,7 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
               preExpressionSpace = Some(Space("(a, ,>> <<( , z)")),
               expression = SoftAST.Group(
                 index = indexOf("(a, , >>( , z)<<"),
-                openToken = OpenParen("(a, , >>(<< , z)"),
+                openToken = Some(OpenParen("(a, , >>(<< , z)")),
                 preHeadExpressionSpace = Some(Space("(a, , (>> <<, z)")),
                 headExpression = Some(ExpressionExpected("(a, , ( >><<, z)")),
                 postHeadExpressionSpace = None,
@@ -272,12 +272,12 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
                     postExpressionSpace = None
                   )
                 ),
-                closeToken = CloseParen("(a, , ( , z>>)<<")
+                closeToken = Some(CloseParen("(a, , ( , z>>)<<"))
               ),
               postExpressionSpace = None
             )
           ),
-          closeToken = SoftAST.TokenExpected(indexOf("(a, , ( , z)>><<"), Token.CloseParen)
+          closeToken = Some(SoftAST.TokenExpected(indexOf("(a, , ( , z)>><<"), Token.CloseParen))
         )
     }
 

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/InheritanceParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/InheritanceParserSpec.scala
@@ -65,12 +65,12 @@ class InheritanceParserSpec extends AnyWordSpec with Matchers {
               preArgumentsSpace = None,
               arguments = SoftAST.Group(
                 index = indexOf(s"${token.lexeme} A>>()<<, B"),
-                openToken = OpenParen(s"${token.lexeme} A>>(<<), B"),
+                openToken = Some(OpenParen(s"${token.lexeme} A>>(<<), B")),
                 preHeadExpressionSpace = None,
                 headExpression = None,
                 postHeadExpressionSpace = None,
                 tailExpressions = Seq.empty,
-                closeToken = CloseParen(s"${token.lexeme} A(>>)<<, B")
+                closeToken = Some(CloseParen(s"${token.lexeme} A(>>)<<, B"))
               )
             ),
             tailReferencesOrSpace = Some(

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReturnParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReturnParserSpec.scala
@@ -22,6 +22,7 @@ import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.OptionValues._
 
 class ReturnParserSpec extends AnyWordSpec with Matchers {
 
@@ -49,7 +50,89 @@ class ReturnParserSpec extends AnyWordSpec with Matchers {
         preExpressionSpace = Some(Space("return>> <<value")),
         rightExpression = Identifier("return >>value<<")
       )
+  }
 
+  "successfully parse a returned tuple" when {
+    "tail element is not provided" in {
+      val returned =
+        parseReturn("return value,")
+
+      returned shouldBe
+        SoftAST.Return(
+          index = indexOf(">>return value,<<"),
+          returnToken = Return(">>return<< value,"),
+          preExpressionSpace = Some(Space("return>> <<value,")),
+          rightExpression = SoftAST.Group(
+            index = indexOf("return >>value,<<"),
+            openToken = None,
+            preHeadExpressionSpace = None,
+            headExpression = Some(Identifier("return >>value<<,")),
+            postHeadExpressionSpace = None,
+            tailExpressions = Seq(
+              SoftAST.GroupTail(
+                index = indexOf("return value>>,<<"),
+                comma = Comma("return value>>,<<"),
+                preExpressionSpace = None,
+                expression = ExpressionExpected("return value,>><<"),
+                postExpressionSpace = None
+              )
+            ),
+            closeToken = None
+          )
+        )
+    }
+
+    "head element is not provided" in {
+      val returned =
+        parseReturn("return ,value")
+
+      returned shouldBe
+        SoftAST.Return(
+          index = indexOf(">>return ,value<<"),
+          returnToken = Return(">>return<< ,value"),
+          preExpressionSpace = Some(Space("return>> <<,value")),
+          rightExpression = SoftAST.Group(
+            index = indexOf("return >>,value<<"),
+            openToken = None,
+            preHeadExpressionSpace = None,
+            headExpression = Some(ExpressionExpected("return >><<,value")),
+            postHeadExpressionSpace = None,
+            tailExpressions = Seq(
+              SoftAST.GroupTail(
+                index = indexOf("return >>,value<<"),
+                comma = Comma("return >>,<<value"),
+                preExpressionSpace = None,
+                expression = Identifier("return ,>>value<<"),
+                postExpressionSpace = None
+              )
+            ),
+            closeToken = None
+          )
+        )
+    }
+
+    "valid tuple is provided" in {
+      val returned =
+        parseReturn("return value, (1 + 2), function.get(1)")
+
+      returned.returnToken shouldBe Return(">>return<< value, (1 + 2), function.get(1)")
+
+      // Assert the Group's code
+      val group = returned.rightExpression.asInstanceOf[SoftAST.Group[Nothing, Nothing]]
+      group.toCode() shouldBe "value, (1 + 2), function.get(1)"
+
+      // Assert the Group's head expression
+      group.headExpression.value.toCode() shouldBe "value"
+
+      // Assert the Group's tail expressions
+      group.tailExpressions should have size 2
+      // Tail's head expression
+      group.tailExpressions.head.expression shouldBe a[SoftAST.Group[_, _]]
+      group.tailExpressions.head.expression.toCode() shouldBe "(1 + 2)"
+      // Tail's last expression
+      group.tailExpressions.last.expression shouldBe a[SoftAST.MethodCall]
+      group.tailExpressions.last.expression.toCode() shouldBe "function.get(1)"
+    }
   }
 
 }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StructParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StructParserSpec.scala
@@ -6,6 +6,7 @@ import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
 import org.alephium.ralph.lsp.access.util.TestCodeUtil._
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.OptionValues._
 
 class StructParserSpec extends AnyWordSpec {
 
@@ -35,12 +36,12 @@ class StructParserSpec extends AnyWordSpec {
           preParamSpace = None,
           params = SoftAST.Group(
             index = indexOf("struct>><<"),
-            openToken = SoftAST.TokenExpected(indexOf("struct>><<"), Token.OpenCurly),
+            openToken = Some(SoftAST.TokenExpected(indexOf("struct>><<"), Token.OpenCurly)),
             preHeadExpressionSpace = None,
             headExpression = None,
             postHeadExpressionSpace = None,
             tailExpressions = Seq.empty,
-            closeToken = SoftAST.TokenExpected(indexOf("struct>><<"), Token.CloseCurly)
+            closeToken = Some(SoftAST.TokenExpected(indexOf("struct>><<"), Token.CloseCurly))
           )
         )
     }
@@ -54,7 +55,7 @@ class StructParserSpec extends AnyWordSpec {
       // Tuples are tested in TupleSpec, test for the index and string code here.
       struct.params.index shouldBe indexOf("struct MyStruct>>{varName: TypeName<<")
       struct.params.toCode() shouldBe "{varName: TypeName"
-      struct.params.closeToken shouldBe SoftAST.TokenExpected(indexOf("struct MyStruct{varName: TypeName>><<"), Token.CloseCurly)
+      struct.params.closeToken.value shouldBe SoftAST.TokenExpected(indexOf("struct MyStruct{varName: TypeName>><<"), Token.CloseCurly)
     }
 
     "well defined struct" in {
@@ -66,8 +67,8 @@ class StructParserSpec extends AnyWordSpec {
       // Tuples are tested in TupleSpec, test for the index and string code here.
       struct.params.index shouldBe indexOf("struct Bar >>{ z: U256, mut foo: Foo }<<")
       struct.params.toCode() shouldBe "{ z: U256, mut foo: Foo }"
-      struct.params.openToken shouldBe OpenCurly("struct Bar >>{<< z: U256, mut foo: Foo }")
-      struct.params.closeToken shouldBe CloseCurly("struct Bar { z: U256, mut foo: Foo >>}<<")
+      struct.params.openToken.value shouldBe OpenCurly("struct Bar >>{<< z: U256, mut foo: Foo }")
+      struct.params.closeToken.value shouldBe CloseCurly("struct Bar { z: U256, mut foo: Foo >>}<<")
 
     }
   }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TemplateParserSpec.scala
@@ -103,8 +103,8 @@ class TemplateParserSpec extends AnyWordSpec with Matchers {
         parseTemplate("Contract mycontract(")
 
       val params = template.params.value
-      params.openToken shouldBe OpenParen("Contract mycontract>>(<<")
-      params.closeToken shouldBe SoftAST.TokenExpected(indexOf("Contract mycontract(>><<"), Token.CloseParen)
+      params.openToken.value shouldBe OpenParen("Contract mycontract>>(<<")
+      params.closeToken.value shouldBe SoftAST.TokenExpected(indexOf("Contract mycontract(>><<"), Token.CloseParen)
     }
 
     "params are empty" in {


### PR DESCRIPTION
Implements parser for returning tuples without enclosing parentheses `(...)`.

```rust
return a + b, true, method.call()
```


Towards #104.