### PR TITLE
Fix the order of expressions in `GroupParser`

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/GroupParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/GroupParser.scala
@@ -181,13 +181,13 @@ private object GroupParser {
       open: O,
       close: C): P[SoftAST.ExpressionAST] =
     P {
-      GroupParser.parseOrFail(open, close) |
-        TypeAssignmentParser.parseOrFail |
+      TypeAssignmentParser.parseOrFail |
         AssignmentParser.parseOrFail |
         InfixCallParser.parseOrFail |
         MethodCallParser.parseOrFail |
         MutableBindingParser.parseOrFail |
         ReferenceCallParser.parseOrFail |
+        GroupParser.parseOrFail(open, close) |
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |
         BStringParser.parseOrFail |

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/GroupParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/GroupParserSpec.scala
@@ -281,6 +281,48 @@ class GroupParserSpec extends AnyWordSpec with Matchers {
         )
     }
 
+    "the element is an infix expression" in {
+      val tuple = parseTuple("((1 + 2) * 3)")
+
+      tuple shouldBe
+        SoftAST.Group(
+          index = indexOf(">>((1 + 2) * 3)<<"),
+          openToken = Some(OpenParen(">>(<<(1 + 2) * 3)")),
+          preHeadExpressionSpace = None,
+          headExpression = Some(
+            SoftAST.InfixExpression(
+              index = indexOf("(>>(1 + 2) * 3<<)"),
+              leftExpression = SoftAST.Group(
+                index = indexOf("(>>(1 + 2)<< * 3)"),
+                openToken = Some(OpenParen("(>>(<<1 + 2) * 3)")),
+                preHeadExpressionSpace = None,
+                headExpression = Some(
+                  SoftAST.InfixExpression(
+                    index = indexOf("((>>1 + 2<<) * 3)"),
+                    leftExpression = Number("((>>1<< + 2) * 3)"),
+                    preOperatorSpace = Some(Space("((1>> <<+ 2) * 3)")),
+                    operator = Plus("((1 >>+<< 2) * 3)"),
+                    postOperatorSpace = Some(Space("((1 +>> <<2) * 3)")),
+                    rightExpression = Number("((1 + >>2<<) * 3)")
+                  )
+                ),
+                postHeadExpressionSpace = None,
+                tailExpressions = Seq.empty,
+                closeToken = Some(CloseParen("((1 + 2>>)<< * 3)"))
+              ),
+              preOperatorSpace = Some(Space("((1 + 2)>> <<* 3)")),
+              operator = Asterisk("((1 + 2) >>*<< 3)"),
+              postOperatorSpace = Some(Space("((1 + 2) *>> <<3)")),
+              rightExpression = Number("((1 + 2) * >>3<<)")
+            )
+          ),
+          postHeadExpressionSpace = None,
+          tailExpressions = Seq.empty,
+          closeToken = Some(CloseParen("((1 + 2) * 3>>)<<"))
+        )
+
+    }
+
   }
 
 }


### PR DESCRIPTION
And added a test to assert order of `GroupParser`.

Towards #104.

# Pending parsers
-  Debug messages \`${x} + ${y} = ${x + y}\`.
- `if`-`else`
- `const`
- brace syntax
- `ByteVec`
- `mapping`