### PR TITLE
Prepare release: Bump `ralphc` to `3.12.2`

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   lazy val scalaMock  = "org.scalamock"     %% "scalamock"       % "6.2.0"    % Test
 
   /** Core */
-  lazy val ralphc = "org.alephium" %% "alephium-ralphc" % "3.12.0" excludeAll (
+  lazy val ralphc = "org.alephium" %% "alephium-ralphc" % "3.12.2" excludeAll (
     ExclusionRule(organization = "org.rocksdb"),
     ExclusionRule(organization = "io.prometheus"),
     ExclusionRule(organization = "org.alephium", name = "alephium-api_2.13"),


### PR DESCRIPTION
Prepare stable release.

Release `0.2.15` from master so that a stable version is available with the latest ralphc.

Question for next PR: Should RC releases with soft-parser enabled remain on `0.2.14-rc[x]`?