### PR TITLE
`Import` in `import`

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringLiteralParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringLiteralParser.scala
@@ -48,7 +48,7 @@ private object StringLiteralParser {
     P {
       Index ~
         TokenParser.parseOrFail(Token.ForwardSlash) ~
-        TextParser.parse(Token.ForwardSlash, Token.Quote) ~
+        TextParser.parse(Token.ForwardSlash, Token.Quote, Token.Import) ~
         Index
     } map {
       case (from, slash, text, to) =>

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringLiteralParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringLiteralParser.scala
@@ -18,7 +18,9 @@ private object StringLiteralParser {
       Index ~
         TokenParser.parseOrFail(Token.Quote) ~
         Index ~
-        TextParser.parseOrFail(Token.ForwardSlash, Token.Quote).? ~
+        // TODO: Other keywords such as `Contract`, `Abstract` etc might also need stopping here.
+        //       Add them only if LSP features require them.
+        TextParser.parseOrFail(Token.ForwardSlash, Token.Quote, Token.Import).? ~
         path.rep ~
         TokenParser.parse(Token.Quote) ~
         Index

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ImportParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ImportParserSpec.scala
@@ -94,4 +94,41 @@ class ImportParserSpec extends AnyWordSpec with Matchers {
     }
   }
 
+  "stop" when {
+    "the head path is the `import` keyword" in {
+      val root =
+        parseSoft("import \"import")
+
+      // both `import` statements are parsed as individual `import` ASTs
+      root.parts should have size 2
+
+      root shouldBe
+        SoftAST.RootBlock(
+          index = indexOf(">>import \"import<<"),
+          parts = Seq(
+            SoftAST.Import(
+              index = indexOf(">>import \"<<import"),
+              importToken = Import(">>import<< \"import"),
+              postImportSpace = Some(Space("import>> <<\"import")),
+              string = Some(
+                SoftAST.StringLiteral(
+                  index = indexOf("import >>\"<<import"),
+                  startQuote = Quote("import >>\"<<import"),
+                  head = None,
+                  tail = Seq.empty,
+                  endQuote = TokenExpected("import \">><<import", Token.Quote)
+                )
+              )
+            ),
+            SoftAST.Import(
+              index = indexOf("import \">>import<<"),
+              importToken = Import("import \">>import<<"),
+              postImportSpace = None,
+              string = None
+            )
+          )
+        )
+    }
+  }
+
 }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ImportParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ImportParserSpec.scala
@@ -129,6 +129,47 @@ class ImportParserSpec extends AnyWordSpec with Matchers {
           )
         )
     }
+
+    "the second path is the `import` keyword" in {
+      val root =
+        parseSoft("import \"nft/import")
+
+      // both `import` statements are parsed as individual `import` ASTs
+      root.parts should have size 2
+
+      root shouldBe
+        SoftAST.RootBlock(
+          index = indexOf(">>import \"nft/import<<"),
+          parts = Seq(
+            SoftAST.Import(
+              index = indexOf(">>import \"nft/<<import"),
+              importToken = Import(">>import<< \"nft/import"),
+              postImportSpace = Some(Space("import>> <<\"nft/import")),
+              string = Some(
+                SoftAST.StringLiteral(
+                  index = indexOf("import >>\"nft/<<import"),
+                  startQuote = Quote("import >>\"<<nft/import"),
+                  head = Some(CodeString("import \">>nft<</import")),
+                  tail = Seq(
+                    SoftAST.Path(
+                      index = indexOf("import \"nft>>/<<import"),
+                      slash = ForwardSlash("import \"nft>>/<<import"),
+                      text = CodeStringExpected("import \"nft/>><<import")
+                    )
+                  ),
+                  endQuote = TokenExpected("import \"nft/>><<import", Token.Quote)
+                )
+              )
+            ),
+            SoftAST.Import(
+              index = indexOf("import \"nft/>>import<<"),
+              importToken = Import("import \"nft/>>import<<"),
+              postImportSpace = None,
+              string = None
+            )
+          )
+        )
+    }
   }
 
 }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ImportParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ImportParserSpec.scala
@@ -130,45 +130,96 @@ class ImportParserSpec extends AnyWordSpec with Matchers {
         )
     }
 
-    "the second path is the `import` keyword" in {
-      val root =
-        parseSoft("import \"nft/import")
+    "the second path is the `import` keyword" when {
+      "without closing quote" in {
+        val root =
+          parseSoft("import \"nft/import")
 
-      // both `import` statements are parsed as individual `import` ASTs
-      root.parts should have size 2
+        // both `import` statements are parsed as individual `import` ASTs
+        root.parts should have size 2
 
-      root shouldBe
-        SoftAST.RootBlock(
-          index = indexOf(">>import \"nft/import<<"),
-          parts = Seq(
-            SoftAST.Import(
-              index = indexOf(">>import \"nft/<<import"),
-              importToken = Import(">>import<< \"nft/import"),
-              postImportSpace = Some(Space("import>> <<\"nft/import")),
-              string = Some(
-                SoftAST.StringLiteral(
-                  index = indexOf("import >>\"nft/<<import"),
-                  startQuote = Quote("import >>\"<<nft/import"),
-                  head = Some(CodeString("import \">>nft<</import")),
-                  tail = Seq(
-                    SoftAST.Path(
-                      index = indexOf("import \"nft>>/<<import"),
-                      slash = ForwardSlash("import \"nft>>/<<import"),
-                      text = CodeStringExpected("import \"nft/>><<import")
-                    )
-                  ),
-                  endQuote = TokenExpected("import \"nft/>><<import", Token.Quote)
+        root shouldBe
+          SoftAST.RootBlock(
+            index = indexOf(">>import \"nft/import<<"),
+            parts = Seq(
+              SoftAST.Import(
+                index = indexOf(">>import \"nft/<<import"),
+                importToken = Import(">>import<< \"nft/import"),
+                postImportSpace = Some(Space("import>> <<\"nft/import")),
+                string = Some(
+                  SoftAST.StringLiteral(
+                    index = indexOf("import >>\"nft/<<import"),
+                    startQuote = Quote("import >>\"<<nft/import"),
+                    head = Some(CodeString("import \">>nft<</import")),
+                    tail = Seq(
+                      SoftAST.Path(
+                        index = indexOf("import \"nft>>/<<import"),
+                        slash = ForwardSlash("import \"nft>>/<<import"),
+                        text = CodeStringExpected("import \"nft/>><<import")
+                      )
+                    ),
+                    endQuote = TokenExpected("import \"nft/>><<import", Token.Quote)
+                  )
                 )
+              ),
+              SoftAST.Import(
+                index = indexOf("import \"nft/>>import<<"),
+                importToken = Import("import \"nft/>>import<<"),
+                postImportSpace = None,
+                string = None
               )
-            ),
-            SoftAST.Import(
-              index = indexOf("import \"nft/>>import<<"),
-              importToken = Import("import \"nft/>>import<<"),
-              postImportSpace = None,
-              string = None
             )
           )
-        )
+      }
+
+      "with closing quote" in {
+        val root =
+          parseSoft("import \"nft/import\"")
+
+        // both `import` statements are parsed as individual `import` ASTs
+        root.parts should have size 2
+
+        root shouldBe
+          SoftAST.RootBlock(
+            index = indexOf(">>import \"nft/import\"<<"),
+            parts = Seq(
+              SoftAST.Import(
+                index = indexOf(">>import \"nft/<<import\""),
+                importToken = Import(">>import<< \"nft/import\""),
+                postImportSpace = Some(Space("import>> <<\"nft/import\"")),
+                string = Some(
+                  SoftAST.StringLiteral(
+                    index = indexOf("import >>\"nft/<<import\""),
+                    startQuote = Quote("import >>\"<<nft/import\""),
+                    head = Some(CodeString("import \">>nft<</import\"")),
+                    tail = Seq(
+                      SoftAST.Path(
+                        index = indexOf("import \"nft>>/<<import\""),
+                        slash = ForwardSlash("import \"nft>>/<<import\""),
+                        text = CodeStringExpected("import \"nft/>><<import\"")
+                      )
+                    ),
+                    endQuote = TokenExpected("import \"nft/>><<import\"", Token.Quote)
+                  )
+                )
+              ),
+              SoftAST.Import(
+                index = indexOf("import \"nft/>>import\"<<"),
+                importToken = Import("import \"nft/>>import<<\""),
+                postImportSpace = None,
+                string = Some(
+                  SoftAST.StringLiteral(
+                    index = indexOf("import \"nft/import>>\"<<"),
+                    startQuote = Quote("import \"nft/import>>\"<<"),
+                    head = None,
+                    tail = Seq.empty,
+                    endQuote = TokenExpected("import \"nft/import\">><<", Token.Quote)
+                  )
+                )
+              )
+            )
+          )
+      }
     }
   }
 

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -813,6 +813,9 @@ object TestSoftAST {
       text = text
     )
 
+  def CodeStringExpected(text: String): SoftAST.CodeStringExpected =
+    SoftAST.CodeStringExpected(indexOf(text))
+
   def TokenDocumented[T <: Token](
       index: SourceIndex,
       token: T): SoftAST.TokenDocumented[T] =


### PR DESCRIPTION
Handles cases where the `import` keyword is within the `import` path.

```rust
import "nft/import"
```