### PR TITLE
Implements `workspaceFolders` specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Language server for Ralph.
 - [Find References](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_references)
 - [Completion](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion)
 - [Rename](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_rename)
+- [Workspace Folders](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_workspaceFolders)
 - More to come...
 
 # Requirements

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
@@ -30,7 +30,6 @@ import java.net.URI
 import java.nio.file.Paths
 import java.util
 import java.util.concurrent.{CompletableFuture, Future => JFuture}
-import scala.annotation.nowarn
 import scala.collection.immutable.ArraySeq
 import scala.jdk.CollectionConverters.{IterableHasAsScala, MapHasAsJava, SeqHasAsJava}
 import scala.jdk.OptionConverters.RichOptional
@@ -48,7 +47,7 @@ object RalphLangServer extends StrictImplicitLogging {
       ServerState(
         client = Some(client),
         listener = Some(listener),
-        pcState = None,
+        pcState = ArraySeq.empty,
         clientAllowsWatchedFilesDynamicRegistration = clientAllowsWatchedFilesDynamicRegistration,
         trace = Trace.Off,
         shutdownReceived = false
@@ -64,24 +63,36 @@ object RalphLangServer extends StrictImplicitLogging {
       ServerState(
         client = None,
         listener = None,
-        pcState = None,
+        pcState = ArraySeq.empty,
         clientAllowsWatchedFilesDynamicRegistration = false,
         trace = Trace.Off,
         shutdownReceived = false
       )
     )
 
-  @nowarn("cat=deprecation")
-  def getRootUri(params: InitializeParams): Option[URI] =
-    Option(params.getRootUri)
-      .orElse(Option(params.getRootPath))
-      .map(URI.create)
-      // Some LSP clients aren't providing `rootUri` or `rootPath`, like in nvim, so we fall back on `user.dir`
-      .orElse {
-        Option(System.getProperty("user.dir"))
-          .map(Paths.get(_))
-          .map(_.toUri)
+  def getWorkspaceFolders(params: InitializeParams): Option[Iterable[URI]] = {
+    // fetch workspaces folders
+    val folders =
+      Option(params.getWorkspaceFolders) match {
+        case Some(workspaceFolders) =>
+          workspaceFolders.asScala map {
+            folder =>
+              URI.create(folder.getUri)
+          }
+
+        case None =>
+          Iterable.empty
       }
+
+    if (folders.isEmpty)
+      // Some LSP clients aren't providing `rootUri` or `rootPath`, like in nvim, so we fall back on `user.dir`
+      Option(System.getProperty("user.dir"))
+        .map(Paths.get(_))
+        .map(_.toUri)
+        .map(Iterable(_))
+    else
+      Some(folders)
+  }
 
   /** Build capabilities supported by the LSP server */
   def serverCapabilities(): ServerCapabilities = {
@@ -92,6 +103,13 @@ object RalphLangServer extends StrictImplicitLogging {
     capabilities.setDefinitionProvider(true)
     capabilities.setReferencesProvider(true)
     capabilities.setRenameProvider(true)
+
+    // Workspace Capabilities
+    val workspaceCapabilities  = new WorkspaceServerCapabilities()
+    val workspaceFolderOptions = new WorkspaceFoldersOptions()
+    workspaceFolderOptions.setChangeNotifications(true)
+    workspaceCapabilities.setWorkspaceFolders(workspaceFolderOptions)
+    capabilities.setWorkspace(workspaceCapabilities)
 
     capabilities
   }
@@ -253,16 +271,16 @@ class RalphLangServer private (
         shutdownOnProcessExit(params.getProcessId)
 
         // Previous commit uses the non-deprecated API but that does not work in vim.
-        val rootURI =
-          RalphLangServer.getRootUri(params)
+        val workspaceFolderURIs =
+          RalphLangServer.getWorkspaceFolders(params)
 
-        val workspaceURI =
-          rootURI getOrElse notifyAndThrow(ResponseError.WorkspaceFolderNotSupplied)
+        val workspaceURIs =
+          workspaceFolderURIs getOrElse notifyAndThrow(ResponseError.WorkspaceFolderNotSupplied)
 
-        val pcState =
-          PC.initialise(workspaceURI)
-
-        setPCState(pcState)
+        workspaceURIs foreach {
+          workspaceURI =>
+            putPCState(PC.initialise(workspaceURI))
+        }
 
         val maybeDynamicRegistration =
           getAllowsWatchedFilesDynamicRegistration(params)
@@ -280,7 +298,7 @@ class RalphLangServer private (
       logger.debug("Client initialized")
       registerClientCapabilities()
       // Invoke initial compilation. Trigger it as a build file changed.
-      triggerInitialBuild()
+      getAllPCStates() foreach triggerInitialBuild
     }
 
   /**
@@ -288,10 +306,10 @@ class RalphLangServer private (
    *
    * Both build files get processed from disk.
    */
-  def triggerInitialBuild(): Unit = {
+  def triggerInitialBuild(pcState: PCState): Unit = {
     // Trigger the build of `alephium.config.ts` first, which, if it exists, will generate `ralph.json`.
     didChangeAndPublish(
-      fileURI = getPCState().workspace.tsBuildURI,
+      fileURI = pcState.workspace.tsBuildURI,
       code = None
     )
 
@@ -299,7 +317,7 @@ class RalphLangServer private (
     // The cost here is relatively low because rebuilding `ralph.json` will be
     // cancelled immediately if it's already built by the above call.
     didChangeAndPublish(
-      fileURI = getPCState().workspace.buildURI,
+      fileURI = getPCStateOrFail(pcState.workspace.workspaceURI).workspace.buildURI,
       code = None
     )
   }
@@ -387,43 +405,52 @@ class RalphLangServer private (
       logger.debug(s"didChangeWatchedFiles: ${changes.mkString("\n", "\n", "")}")
 
       val events =
-        changes collect {
-          case fileEvent if isFileScheme(uri(fileEvent.getUri)) =>
-            val fileURI = uri(fileEvent.getUri)
+        changes
+          .collect {
+            case fileEvent if isFileScheme(uri(fileEvent.getUri)) =>
+              val fileURI = uri(fileEvent.getUri)
 
-            fileEvent.getType match {
-              case FileChangeType.Created =>
-                WorkspaceFileEvent.Created(fileURI)
+              fileEvent.getType match {
+                case FileChangeType.Created =>
+                  WorkspaceFileEvent.Created(fileURI)
 
-              case FileChangeType.Changed =>
-                WorkspaceFileEvent.Changed(fileURI)
+                case FileChangeType.Changed =>
+                  WorkspaceFileEvent.Changed(fileURI)
 
-              case FileChangeType.Deleted =>
-                WorkspaceFileEvent.Deleted(fileURI)
-            }
-        }
+                case FileChangeType.Deleted =>
+                  WorkspaceFileEvent.Deleted(fileURI)
+              }
+          }
+          .groupBy {
+            event =>
+              getPCStateOrNone(event.uri)
+          }
 
-      if (events.nonEmpty) {
-        val currentPCState =
-          getPCState()
+      events foreach {
+        case (Some(currentPCState), events) =>
+          if (events.nonEmpty) {
+            // Build OK! process delete or create
+            val newPCState =
+              PC.events(
+                events = events,
+                pcState = currentPCState
+              )
 
-        // Build OK! process delete or create
-        val newPCState =
-          PC.events(
-            events = events,
-            pcState = currentPCState
-          )
+            // Set the updated workspace
+            val diagnostics =
+              putPCStateAndBuildDiagnostics(
+                currentPCState = currentPCState,
+                newPCState = newPCState
+              )
 
-        // Set the updated workspace
-        val diagnostics =
-          setPCStateAndBuildDiagnostics(
-            currentPCState = currentPCState,
-            newPCState = newPCState
-          )
+            getClient() publish diagnostics
+          }
 
-        getClient() publish diagnostics
+        case (None, events) =>
+          // Occurs when no workspace is found for an event's `fileURI`.
+          // This can happen when modifying dependency files located under the home directory at `.ralph-lsp/dependencies/code.ral`.
+          logger.trace(s"Cannot execute events (count = ${events.size}) because source file is not within an active workspace: '${events.map(_.uri).distinct.mkString(", ")}'")
       }
-
     }
 
   override def completion(params: CompletionParams): CompletableFuture[messages.Either[util.List[CompletionItem], CompletionList]] =
@@ -438,44 +465,54 @@ class RalphLangServer private (
 
           cancelChecker.checkCanceled()
 
-          getPCState().workspace match {
-            case sourceAware: WorkspaceState.IsSourceAware =>
-              val completionResult =
-                CodeProvider.search[SourceCodeState.Parsed, Unit, Suggestion](
-                  line = line,
-                  character = character,
-                  fileURI = fileURI,
-                  workspace = sourceAware,
-                  searchSettings = ()
-                )
+          // Completion should always be executed within the scope of a valid workspace.
+          // Run only if a workspace is found, otherwise, ignore the request (e.g. for an external dependency).
+          // No need to report errors for code completion.
+          getPCStateOrNone(fileURI) match {
+            case Some(currentPCState) =>
+              currentPCState.workspace match {
+                case sourceAware: WorkspaceState.IsSourceAware =>
+                  val completionResult =
+                    CodeProvider.search[SourceCodeState.Parsed, Unit, Suggestion](
+                      line = line,
+                      character = character,
+                      fileURI = fileURI,
+                      workspace = sourceAware,
+                      searchSettings = ()
+                    )
 
-              val suggestions =
-                completionResult match {
-                  case Some(Right(suggestions)) =>
-                    // completion successful
-                    suggestions
+                  val suggestions =
+                    completionResult match {
+                      case Some(Right(suggestions)) =>
+                        // completion successful
+                        suggestions
 
-                  case Some(Left(error)) =>
-                    // Completion failed: Log the error message
-                    logger.info("Code completion unsuccessful: " + error.message)
-                    Iterator.empty[Suggestion]
+                      case Some(Left(error)) =>
+                        // Completion failed: Log the error message
+                        logger.info("Code completion unsuccessful: " + error.message)
+                        Iterator.empty[Suggestion]
 
-                  case None =>
-                    // Not a ralph file or it does not belong to the workspace's contract-uri directory.
-                    Iterator.empty[Suggestion]
-                }
+                      case None =>
+                        // Not a ralph file or it does not belong to the workspace's contract-uri directory.
+                        Iterator.empty[Suggestion]
+                    }
 
-              val completionList =
-                CompletionConverter.toCompletionList(suggestions)
+                  val completionList =
+                    CompletionConverter.toCompletionList(suggestions)
 
-              cancelChecker.checkCanceled()
+                  cancelChecker.checkCanceled()
 
-              messages.Either.forRight(completionList)
+                  messages.Either.forRight(completionList)
 
-            case _: WorkspaceState.Created =>
-              // Workspace must be compiled at least once to enable code completion.
-              // The server must've invoked the initial compilation in the boot-up initialize function.
-              logger.info("Code completion unsuccessful: Workspace is not compiled")
+                case _: WorkspaceState.Created =>
+                  // Workspace must be compiled at least once to enable code completion.
+                  // The server must've invoked the initial compilation in the boot-up initialize function.
+                  logger.info("Code completion unsuccessful: Workspace is not compiled")
+                  messages.Either.forLeft(util.Arrays.asList())
+              }
+
+            case None =>
+              logger.trace(s"Code completion unsuccessful: Source not within an active workspace. fileURI: $fileURI")
               messages.Either.forLeft(util.Arrays.asList())
           }
         }
@@ -499,28 +536,34 @@ class RalphLangServer private (
           if (enableSoftParser)
             CompletableFuture.supplyAsync {
               () =>
-                goTo[SourceCodeState.IsParsed, (SoftAST.type, GoToDefSetting), SourceLocation.GoToDefSoft](
-                  fileURI = fileURI,
-                  line = line,
-                  character = character,
-                  searchSettings = (SoftAST, settings),
-                  cancelChecker = cancelChecker,
-                  currentState = getPCState()
-                )
+                getOneOrAllPCStates(fileURI) flatMap {
+                  currentState =>
+                    goTo[SourceCodeState.IsParsed, (SoftAST.type, GoToDefSetting), SourceLocation.GoToDefSoft](
+                      fileURI = fileURI,
+                      line = line,
+                      character = character,
+                      searchSettings = (SoftAST, settings),
+                      cancelChecker = cancelChecker,
+                      currentState = currentState
+                    )
+                }
             }
           else
             CompletableFuture.completedFuture(Iterator.empty)
 
         // Compute strict AST locations within the current thread
         val strictASTLocations =
-          goTo[SourceCodeState.Parsed, GoToDefSetting, SourceLocation.GoToDefStrict](
-            fileURI = fileURI,
-            line = line,
-            character = character,
-            searchSettings = settings,
-            cancelChecker = cancelChecker,
-            currentState = getPCState()
-          )
+          getOneOrAllPCStates(fileURI) flatMap {
+            currentState =>
+              goTo[SourceCodeState.Parsed, GoToDefSetting, SourceLocation.GoToDefStrict](
+                fileURI = fileURI,
+                line = line,
+                character = character,
+                searchSettings = settings,
+                cancelChecker = cancelChecker,
+                currentState = currentState
+              )
+          }
 
         // Combine the results asynchronously
         softASTLocationsFuture.thenApply {
@@ -558,17 +601,20 @@ class RalphLangServer private (
           )
 
         val locations =
-          goTo[SourceCodeState.Parsed, GoToRefSetting, SourceLocation.GoToRefStrict](
-            fileURI = fileURI,
-            line = line,
-            character = character,
-            searchSettings = settings,
-            cancelChecker = cancelChecker,
-            currentState = getPCState()
-          )
+          getOneOrAllPCStates(fileURI) flatMap {
+            currentState =>
+              goTo[SourceCodeState.Parsed, GoToRefSetting, SourceLocation.GoToRefStrict](
+                fileURI = fileURI,
+                line = line,
+                character = character,
+                searchSettings = settings,
+                cancelChecker = cancelChecker,
+                currentState = currentState
+              )
+          }
 
         val javaLocations =
-          GoToConverter.toLocations(locations)
+          GoToConverter.toLocations(locations.iterator)
 
         CollectionUtil.toJavaList(javaLocations)
     }
@@ -587,7 +633,8 @@ class RalphLangServer private (
             character = character,
             searchSettings = (),
             cancelChecker = cancelChecker,
-            currentState = getPCState()
+            // Uses `OrFail` to ensure a notification is displayed when renaming a file not within an active workspace.
+            currentState = getPCStateOrFail(fileURI)
           )
 
         val javaLocations =
@@ -605,6 +652,14 @@ class RalphLangServer private (
         new WorkspaceEdit(javaLocations)
     }
 
+  override def didChangeWorkspaceFolders(params: DidChangeWorkspaceFoldersParams): Unit = {
+    val added   = params.getEvent.getAdded.asScala.map(_.getUri).map(URI.create)
+    val removed = params.getEvent.getRemoved.asScala.map(_.getUri).map(URI.create)
+
+    addWorkspaceFolders(added)
+    removeWorkspaceFolders(removed)
+  }
+
   override def didChangeConfiguration(params: DidChangeConfigurationParams): Unit =
     ()
 
@@ -613,6 +668,51 @@ class RalphLangServer private (
 
   override def getWorkspaceService: WorkspaceService =
     this
+
+  /**
+   * Inserts and builds the new workspace folders.
+   *
+   * @param uris Root workspace directory URIs to be added.
+   */
+  private def addWorkspaceFolders(uris: Iterable[URI]): Unit =
+    uris foreach {
+      newURI =>
+        // Initialise a new PCState
+        val pcState = PC.initialise(newURI)
+        // Insert the new initialised PCState
+        putPCState(pcState)
+        // Trigger initial build
+        triggerInitialBuild(pcState)
+    }
+
+  /**
+   * Removes the given workspace folder.
+   *
+   * @param uris Root workspace directory URIs to be removed.
+   */
+  private def removeWorkspaceFolders(uris: Iterable[URI]): Unit =
+    uris foreach {
+      removedURI =>
+        // remove workspace from state
+        removePCState(removedURI) match {
+          case Some(removedPCStates) =>
+            // publish an empty state to clear all existing diagnostics for the removed workspace.
+            removedPCStates foreach {
+              removed =>
+                val diagnostics =
+                  buildDiagnostics(
+                    currentPCState = removed,
+                    newPCState = PC.initialise(removedURI)
+                  )
+
+                // For quicker client updates, execute `publish` after each `build` instead of together.
+                getClient() publish diagnostics
+            }
+
+          case None =>
+            logger.error(s"Workspace-folder not found for URI $removedURI")
+        }
+    }
 
   /**
    * Apply code change and publish diagnostics.
@@ -644,41 +744,84 @@ class RalphLangServer private (
       fileURI: URI,
       code: Option[String]): Iterable[PublishDiagnosticsParams] =
     runSync {
-      val currentPCState =
-        getPCState()
+      getPCStateOrNone(fileURI) match {
+        case Some(currentPCState) =>
+          val newPCState =
+            PC.changed(
+              fileURI = fileURI,
+              code = code,
+              pcState = currentPCState
+            )
 
-      val newPCState =
-        PC.changed(
-          fileURI = fileURI,
-          code = code,
-          pcState = currentPCState
-        )
+          putPCStateAndBuildDiagnostics(
+            currentPCState = currentPCState,
+            newPCState = newPCState
+          )
 
-      setPCStateAndBuildDiagnostics(
-        currentPCState = currentPCState,
-        newPCState = newPCState
-      )
+        case None =>
+          logger.trace(s"Cannot execute change because the source file is not within an active workspace: '$fileURI'")
+          Iterable.empty
+      }
     }
 
-  private def getPCState(): PCState =
-    state.pcState getOrElse {
+  /**
+   * Get the [[PCState]] containing the given `fileURI`.
+   * If no matching [[PCState]] is found, returns all available [[PCState]]s.
+   *
+   * The purpose for retuning all [[PCState]]s is to handle cases
+   * the requested is executed outside the workspace directory,
+   * for example, within dependencies, then APIs like
+   * [[definition]] and [[references]] must be executed on all root-workspaces
+   * where the dependency code is used.
+   *
+   * @param fileURI The `fileURI` to search for in [[PCState]].
+   * @return The matching [[PCState]], or all [[PCState]]s if none is found.
+   */
+  private def getOneOrAllPCStates(fileURI: URI): ArraySeq[PCState] =
+    thisServer.state.findContains(fileURI) match {
+      case Some(pcState) =>
+        ArraySeq(pcState)
+
+      case None =>
+        getAllPCStates()
+    }
+
+  private def getPCStateOrFail(fileURI: URI): PCState =
+    getPCStateOrNone(fileURI) getOrElse {
+      // Workspace folder is not defined.
+      // This is not expected to occur since `initialized` is always invoked first.
+      notifyAndThrow(ResponseError.SourceNotInWorkspace(fileURI))
+    }
+
+  private def getPCStateOrNone(fileURI: URI): Option[PCState] =
+    thisServer.state.findContains(fileURI)
+
+  private def getAllPCStates(): ArraySeq[PCState] =
+    if (thisServer.state.pcState.isEmpty)
       // Workspace folder is not defined.
       // This is not expected to occur since `initialized` is always invoked first.
       notifyAndThrow(ResponseError.WorkspaceFolderNotSupplied)
+    else
+      state.pcState
+
+  private def removePCState(fileURI: URI): Option[ArraySeq[PCState]] =
+    thisServer.state.remove(fileURI) map {
+      case (newState, removedPCStates) =>
+        thisServer.state = newState
+        removedPCStates
     }
 
   private def getClient(): RalphLangClient =
-    state.client getOrElse {
+    thisServer.state.client getOrElse {
       val error     = ResponseError.ClientNotConfigured
       val exception = error.toResponseErrorException
       logger.error(error.getMessage, exception)
       throw exception
     }
 
-  private def setPCState(pcState: PCState): Unit =
+  private def putPCState(pcState: PCState): Unit =
     runSync {
-      thisServer.state = thisServer.state.copy(pcState = Some(pcState))
-      ()
+      thisServer.state = thisServer.state.put(pcState)
     }
 
   private def setClientAllowsWatchedFilesDynamicRegistration(allows: Boolean): Unit =
@@ -705,13 +848,13 @@ class RalphLangServer private (
    * @param newPCState Compilation result returned by presentation-compiler.
    * @return Diagnostics for current workspace.
    */
-  private def setPCStateAndBuildDiagnostics(
+  private def putPCStateAndBuildDiagnostics(
       currentPCState: PCState,
       newPCState: Either[ErrorUnknownFileType, Option[PCState]]): Iterable[PublishDiagnosticsParams] =
     runSync {
       newPCState match {
         case Right(Some(newPCState)) =>
-          setPCStateAndBuildDiagnostics(
+          putPCStateAndBuildDiagnostics(
             currentPCState = currentPCState,
             newPCState = newPCState
           )
@@ -733,15 +876,31 @@ class RalphLangServer private (
    *
    * @param currentPCState The [[PCState]] that got used to run this compilation.
    * @param newPCState     Compilation result returned by presentation-compiler.
-   *                       [[None]] indicates that the file-type does not belong to us.
    * @return Diagnostics for current workspace.
    */
-  private def setPCStateAndBuildDiagnostics(
+  private def putPCStateAndBuildDiagnostics(
       currentPCState: PCState,
       newPCState: PCState): Iterable[PublishDiagnosticsParams] =
     runSync {
-      setPCState(newPCState)
+      putPCState(newPCState)
 
+      buildDiagnostics(
+        currentPCState = currentPCState,
+        newPCState = newPCState
+      )
+    }
+
+  /**
+   * Returns diagnostics to publish for the current state.
+   *
+   * @param currentPCState The [[PCState]] that got used to run this compilation.
+   * @param newPCState     Compilation result returned by presentation-compiler.
+   * @return Diagnostics for current workspace.
+   */
+  private def buildDiagnostics(
+      currentPCState: PCState,
+      newPCState: PCState): Iterable[PublishDiagnosticsParams] =
+    runSync {
       // build diagnostics for this PCState change
       val pcDiagnostics =
         Diagnostics.toFileDiagnostics(

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
@@ -615,31 +615,6 @@ class RalphLangServer private (
     this
 
   /**
-   * Re-builds a fresh workspace from disk.
-   */
-  def reboot(): Unit =
-    runSync {
-      // initialise a new workspace
-      val currentPCState =
-        getPCState()
-
-      val newPCState =
-        PC.initialise(currentPCState.workspace.workspaceURI)
-
-      // clear all existing diagnostics
-      val diagnostics =
-        setPCStateAndBuildDiagnostics(
-          currentPCState = currentPCState,
-          newPCState = newPCState
-        )
-
-      getClient() publish diagnostics
-
-      // invoke initial build on new PCState
-      triggerInitialBuild()
-    }
-
-  /**
    * Apply code change and publish diagnostics.
    *
    * @param fileURI File that changed

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/ResponseError.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/ResponseError.scala
@@ -32,10 +32,10 @@ object ResponseError {
       message = "Root workspace folder not supplied"
     )
 
-  case object MultiRootWorkspaceFoldersNotSupported
+  case class SourceNotInWorkspace(fileURI: URI)
     extends ResponseError(
-      errorCode = ResponseErrorCode.InvalidParams,
-      message = "Multiple root workspace folders are not supported"
+      errorCode = ResponseErrorCode.InvalidRequest,
+      message = s"Source file not within an active workspace: '$fileURI'"
     )
 
   case class UnknownFileType(fileURI: URI)

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/state/ServerState.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/state/ServerState.scala
@@ -5,8 +5,12 @@ package org.alephium.ralph.lsp.server.state
 
 import org.alephium.ralph.lsp.pc.PCState
 import org.alephium.ralph.lsp.server.RalphLangClient
+import org.alephium.ralph.lsp.utils.CollectionUtil.CollectionUtilImplicits
+import org.alephium.ralph.lsp.utils.URIUtil.URIUtilImplicits
 
+import java.net.URI
 import java.util.concurrent.{Future => JFuture}
+import scala.collection.immutable.ArraySeq
 
 /**
  * Stores Ralph's LSP server state.
@@ -19,7 +23,46 @@ import java.util.concurrent.{Future => JFuture}
 case class ServerState(
     client: Option[RalphLangClient],
     listener: Option[JFuture[Void]],
-    pcState: Option[PCState],
+    pcState: ArraySeq[PCState],
     clientAllowsWatchedFilesDynamicRegistration: Boolean,
     trace: Trace,
-    shutdownReceived: Boolean)
+    shutdownReceived: Boolean) {
+
+  private implicit val order: Ordering[PCState] =
+    Ordering.by(_.workspace.workspaceURI)
+
+  /**
+   * Replaces an existing [[PCState]] with a matching workspace URI if it exists,
+   * otherwise, inserts the new [[PCState]].
+   */
+  def put(newState: PCState): ServerState =
+    this.copy(pcState = pcState put newState)
+
+  /**
+   * Removes all existing [[PCState]]s that matches the given `workspaceURI`.
+   *
+   * @return [[None]] if no [[PCState]]s are removed.
+   *         Otherwise, returns a tuple where:
+   *         - The first element is the updated [[ServerState]] after removal.
+   *         - The second element is the sequence of removed [[PCState]]s.
+   */
+  def remove(workspaceURI: URI): Option[(ServerState, ArraySeq[PCState])] = {
+    val removedStates =
+      pcState.filter(_.workspace.workspaceURI == workspaceURI)
+
+    if (removedStates.isEmpty) {
+      None
+    } else {
+      val newStates      = pcState.diff(removedStates)
+      val newServerState = this.copy(pcState = newStates)
+      Some((newServerState, removedStates))
+    }
+  }
+
+  /**
+   * Gets the [[PCState]] of a workspace that contains the given fileURI.
+   */
+  def findContains(fileURI: URI): Option[PCState] =
+    pcState.find(_.workspace.workspaceURI contains fileURI)
+
+}

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/state/Trace.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/state/Trace.scala
@@ -3,12 +3,18 @@
 
 package org.alephium.ralph.lsp.server.state
 
+import org.alephium.macros.EnumerationMacros
 import org.alephium.ralph.lsp.server.ResponseError.InvalidTraceSetting
 
 /**
  * @see [[org.eclipse.lsp4j.TraceValue]].
  */
-sealed trait Trace
+sealed trait Trace extends Ordered[Trace] with Product {
+
+  override def compare(that: Trace): Int =
+    this.productPrefix compare that.productPrefix
+
+}
 
 object Trace {
 
@@ -27,5 +33,10 @@ object Trace {
       Right(Trace.Verbose)
     else
       Left(InvalidTraceSetting(string))
+
+  def all: Array[Trace] =
+    EnumerationMacros
+      .sealedInstancesOf[Trace]
+      .toArray
 
 }

--- a/lsp-server/src/test/scala/org/alephium/ralph/lsp/server/RalphLangServerSpec.scala
+++ b/lsp-server/src/test/scala/org/alephium/ralph/lsp/server/RalphLangServerSpec.scala
@@ -6,17 +6,13 @@ package org.alephium.ralph.lsp.server
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.PCState
-import org.alephium.ralph.lsp.pc.client.TestClientLogger
-import org.alephium.ralph.lsp.utils.log.ClientLogger
-import org.alephium.ralph.lsp.pc.sourcecode.TestSourceCode
-import org.alephium.ralph.lsp.pc.workspace.{WorkspaceState, TestWorkspace}
-import org.alephium.ralph.lsp.server.state.{Trace, ServerState}
+import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
+import org.alephium.ralph.lsp.server.state.{ServerState, Trace}
 import org.eclipse.lsp4j._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.OptionValues._
 
 import java.nio.file.Paths
 import java.util.concurrent.{CompletableFuture, Future => JFuture}
@@ -212,89 +208,6 @@ class RalphLangServerSpec extends AnyWordSpec with Matchers with MockFactory wit
         .never()
 
       server.registerClientCapabilities() shouldBe ()
-    }
-  }
-
-  "reboot" should {
-    "start a new workspace compilation" in {
-      implicit val compiler: CompilerAccess = CompilerAccess.ralphc
-      implicit val file: FileAccess         = FileAccess.disk
-      implicit val logger: ClientLogger     = TestClientLogger
-
-      val client = mock[RalphLangClient]
-      // format: off
-      val listener = CompletableFuture.runAsync(() => ()) // format: on
-      val server   = RalphLangServer(client, listener)
-
-      // create unCompiled workspace
-      val workspace =
-        TestWorkspace
-          .genUnCompiled(
-            """
-              |Contract Test() {
-              |  fn main() -> () {}
-              |}
-              |""".stripMargin
-          )
-          .sample
-          .get
-
-      //  persist the workspace
-      TestWorkspace persist workspace
-
-      /**
-       * Start LSP server for that workspace
-       */
-      // this is the initial message received from the LSP client.
-      val initialise = new InitializeParams()
-      initialise.setRootUri(workspace.workspaceURI.toString)
-      initialise.setProcessId(ProcessHandle.current().pid().toInt)
-      // invoke server with the 'initialise' message
-      val initializeResult = server.initialize(initialise).get()
-      // expect server capabilities returned in response
-      initializeResult shouldBe new InitializeResult(RalphLangServer.serverCapabilities())
-
-      // Invoke initialized so an initial build occurs.
-      // After initialized, expect diagnostics to get published twice invoked by triggerInitialBuild():
-      //  1) First for the `alephium.config.ts` build,
-      //  2) Then for the `ralph.json` build.
-      (client.publish _).expects(*).twice()
-      server.initialized(new InitializedParams()) shouldBe ()
-
-      // The server has created a workspace in Compiled state
-      val newWorkspace = server.getState().pcState.value.workspace.asInstanceOf[WorkspaceState.Compiled]
-      newWorkspace.sourceCode.map(_.fileURI) should contain only workspace.sourceCode.head.fileURI
-
-      // Write a new file to the workspace
-      val newFile =
-        TestSourceCode
-          .genUnCompiled(
-            code = """
-              |Contract Test2() {
-              |  fn main() -> () {}
-              |}
-              |""".stripMargin,
-            fileURI = workspace.build.contractURI.resolve("newFile.ral")
-          )
-          .sample
-          .get
-
-      // persist the new file
-      TestSourceCode persist newFile
-
-      // Expect diagnostics to get published three times on reboot:
-      // 1) Publish diagnostics to clear all existing errors & warning.
-      // 2) Publish diagnostics for the new builds invoked by triggerInitialBuild():
-      //    2.1) First for the `alephium.config.ts` build,
-      //    2.2) Then for the `ralph.json` build.
-      (client.publish _).expects(*).repeat(3)
-
-      // invoke reboot, which should rebuild the workspace, but this time there will be 2 source files
-      server.reboot()
-
-      // Now the server has two source files instead of one.
-      val rebootedWorkspace = server.getState().pcState.value.workspace.asInstanceOf[WorkspaceState.Compiled]
-      rebootedWorkspace.sourceCode.map(_.fileURI) should contain only (workspace.sourceCode.head.fileURI, newFile.fileURI)
     }
   }
 

--- a/lsp-server/src/test/scala/org/alephium/ralph/lsp/server/ServerStateSpec.scala
+++ b/lsp-server/src/test/scala/org/alephium/ralph/lsp/server/ServerStateSpec.scala
@@ -1,0 +1,143 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.server
+
+import org.alephium.ralph.lsp.pc.PCState
+import org.alephium.ralph.lsp.server.state.ServerState
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.OptionValues._
+
+import java.nio.file.Paths
+import scala.collection.immutable.ArraySeq
+import scala.util.Random
+
+class ServerStateSpec extends AnyWordSpec with Matchers {
+
+  "findContains" should {
+    def testFind(
+        fileURI: String,
+        foldURI: String): Option[PCState] =
+      TestServerState
+        .genServerState(Iterable(Paths.get(foldURI).toUri))
+        .findContains(Paths.get(fileURI).toUri)
+
+    "return None" when {
+      "file does not belong a folder" in {
+        testFind(
+          foldURI = "/parent/child",
+          fileURI = "/blah" // `blah` has no workspace
+        ) shouldBe empty
+      }
+
+      "file is the parent directory (not contained within the folder)" in {
+        testFind(
+          foldURI = "/parent/child",
+          fileURI = "/parent" // `parent` is not contained within `/parent/child`
+        ) shouldBe empty
+      }
+    }
+
+    "return Some" when {
+      "fileURI matches exactly to the parentURI" in {
+        val pcState =
+          testFind(
+            foldURI = "/parent/child",
+            fileURI = "/parent/child"
+          ).value
+
+        pcState.workspace.workspaceURI.getPath shouldBe "/parent/child"
+      }
+
+      "fileURI is contained within the parentURI" in {
+        val pcState =
+          testFind(
+            foldURI = "/parent/child",
+            fileURI = "/parent/child/code.ral"
+          ).value
+
+        pcState.workspace.workspaceURI.getPath shouldBe "/parent/child"
+      }
+    }
+  }
+
+  "removeContains" should {
+    def testRemove(
+        foldURI: Iterable[String],
+        fileURI: String): Option[(ServerState, ArraySeq[PCState])] = {
+      val parent =
+        foldURI.map(Paths.get(_).toUri)
+
+      TestServerState
+        .genServerState(parent)
+        .remove(Paths.get(fileURI).toUri)
+    }
+
+    "return None" when {
+      "file does not belong a folder" in {
+        testRemove(
+          foldURI = Array("/parent/child"),
+          fileURI = "/blah" // `blah` has no workspace
+        ) shouldBe empty
+      }
+
+      "file is the parent directory (not contained within the folder)" in {
+        testRemove(
+          foldURI = Array("/parent/child"),
+          fileURI = "/parent" // `parent` is not contained within `/parent/child`
+        ) shouldBe empty
+      }
+
+      "fileURI is contained within the parentURI but is not an exact match" in {
+        testRemove(
+          foldURI = Array("/parent/child"),
+          fileURI = "/parent/child/code.ral"
+        ) shouldBe empty
+      }
+    }
+
+    "return Some" when {
+      "fileURI matches exactly to the parentURI" when {
+        "only on workspace exists" in {
+          val (serverState, removedStated) =
+            testRemove(
+              foldURI = Array("/parent/child"),
+              fileURI = "/parent/child"
+            ).value
+
+          // no PCStates left
+          serverState.pcState shouldBe empty
+
+          // assert removes
+          removedStated should have size 1
+          removedStated.head.workspace.workspaceURI.getPath shouldBe "/parent/child"
+        }
+
+        "multiple workspaces exist" in {
+          val (serverState, removedStated) =
+            testRemove(
+              foldURI = Random.shuffle(
+                List(
+                  "/parent/child",
+                  "/parent",
+                  "/up/down",
+                  "/this/that"
+                )
+              ),
+              fileURI = "/parent/child"
+            ).value
+
+          // other PCStates left
+          serverState.pcState.map(_.workspace.workspaceURI.getPath) should contain only ("/parent", "/up/down", "/this/that")
+
+          // assert removes
+          removedStated should have size 1
+          removedStated.head.workspace.workspaceURI.getPath shouldBe "/parent/child"
+
+        }
+      }
+    }
+  }
+
+}

--- a/lsp-server/src/test/scala/org/alephium/ralph/lsp/server/ServerStateSpec.scala
+++ b/lsp-server/src/test/scala/org/alephium/ralph/lsp/server/ServerStateSpec.scala
@@ -47,7 +47,7 @@ class ServerStateSpec extends AnyWordSpec with Matchers {
             fileURI = "/parent/child"
           ).value
 
-        pcState.workspace.workspaceURI.getPath shouldBe "/parent/child"
+        pcState.workspace.workspaceURI shouldBe Paths.get("/parent/child").toUri
       }
 
       "fileURI is contained within the parentURI" in {
@@ -57,7 +57,7 @@ class ServerStateSpec extends AnyWordSpec with Matchers {
             fileURI = "/parent/child/code.ral"
           ).value
 
-        pcState.workspace.workspaceURI.getPath shouldBe "/parent/child"
+        pcState.workspace.workspaceURI shouldBe Paths.get("/parent/child").toUri
       }
     }
   }
@@ -111,7 +111,7 @@ class ServerStateSpec extends AnyWordSpec with Matchers {
 
           // assert removes
           removedStated should have size 1
-          removedStated.head.workspace.workspaceURI.getPath shouldBe "/parent/child"
+          removedStated.head.workspace.workspaceURI shouldBe Paths.get("/parent/child").toUri
         }
 
         "multiple workspaces exist" in {
@@ -128,12 +128,19 @@ class ServerStateSpec extends AnyWordSpec with Matchers {
               fileURI = "/parent/child"
             ).value
 
+          val expected =
+            Seq("/parent", "/up/down", "/this/that") map {
+              path =>
+                Paths.get(path).toUri
+            }
+
           // other PCStates left
-          serverState.pcState.map(_.workspace.workspaceURI.getPath) should contain only ("/parent", "/up/down", "/this/that")
+          val actual = serverState.pcState.map(_.workspace.workspaceURI)
+          actual should contain theSameElementsAs expected
 
           // assert removes
           removedStated should have size 1
-          removedStated.head.workspace.workspaceURI.getPath shouldBe "/parent/child"
+          removedStated.head.workspace.workspaceURI shouldBe Paths.get("/parent/child").toUri
 
         }
       }

--- a/lsp-server/src/test/scala/org/alephium/ralph/lsp/server/TestServerState.scala
+++ b/lsp-server/src/test/scala/org/alephium/ralph/lsp/server/TestServerState.scala
@@ -1,0 +1,37 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.server
+
+import org.alephium.ralph.lsp.pc.PCState
+import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
+import org.alephium.ralph.lsp.server.state.{ServerState, Trace}
+
+import java.net.URI
+import scala.collection.immutable.ArraySeq
+import scala.util.Random
+
+object TestServerState {
+
+  def genServerState(uris: Iterable[URI]): ServerState = {
+    val pcStates =
+      uris map {
+        fileURI =>
+          PCState(
+            workspace = WorkspaceState.Created(fileURI),
+            buildErrors = None,
+            tsErrors = None
+          )
+      }
+
+    ServerState(
+      client = None,
+      listener = None,
+      pcState = pcStates.to(ArraySeq),
+      clientAllowsWatchedFilesDynamicRegistration = Random.nextBoolean(),
+      trace = Random.shuffle(Trace.all.toList).head,
+      shutdownReceived = Random.nextBoolean()
+    )
+  }
+
+}

--- a/plugin-vscode/README.md
+++ b/plugin-vscode/README.md
@@ -9,6 +9,7 @@ The Ralph LSP is an implementation of the [language server protocol](https://mic
 * [Find References](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_references)
 * [Completion](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion)
 * [Rename](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_rename)
+* [Workspace Folders](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_workspaceFolders)
 * More to come...
 
 ## Requirements

--- a/utils/src/main/scala/org/alephium/ralph/lsp/utils/URIUtil.scala
+++ b/utils/src/main/scala/org/alephium/ralph/lsp/utils/URIUtil.scala
@@ -9,6 +9,16 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
 
 object URIUtil {
 
+  implicit class URIUtilImplicits(val uri: URI) extends AnyVal {
+
+    def contains(child: URI): Boolean =
+      URIUtil.contains(
+        parent = uri,
+        child = child
+      )
+
+  }
+
   /**
    * Build URI and clean it from escaped characters. Happen on Windows
    */


### PR DESCRIPTION
- Resolves #417.
- Replaces deprecated `rootURI` with `getWorkspaceFolders`. 
  - To ensure [this](https://github.com/alephium/ralph-lsp/blob/239bd530a0d02a9d1d4f6d3751a12107c8814a59/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala#L88) comment is still behaving properly, testing on nvim might be needed.
- Deferred issue #419.

# Testing
- `RalphLangServerSpec` has minimal unit-tests. Any major change to the `RalphLangServer` file, such as in this PR, requires manual IDE testing instead of relying on unit tests which is time consuming. Although I have run IDE tests for this PR, unit tests still need to be written for all APIs (#421).
- IDE tested (#7) using drag-and-drop from [multi-root workspaces in VSCode](https://code.visualstudio.com/docs/editor/workspaces/multi-root-workspaces).
