### PR TITLE
Multi root nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ lazy_plugin_config = {
 
 The plugin adds file type detection, syntax highlighting and start the LSP server, make sure you have `ralph-lsp` available in your `PATH`
 
+For more info check the [plugin-nvim](plugin-nvim) directory.
+
 # Build the JAR
 
 ```shell
@@ -121,7 +123,7 @@ Refer to the [documentation](https://docs.alephium.org/sdk/cli/#configuration) f
 ## `ralph.json`
 
 Once your IDE has booted up, a config file named `ralph.json` will be generated in your project's root
-directory under the folder `.ralph-lsp/ralph.json`. 
+directory under the folder `.ralph-lsp/ralph.json`.
 This file reflects the `sourceDir` and `compilerOptions` settings defined in `alephium.config.ts`.
 If `alephium.config.ts` is not present or if the settings are missing, default settings will be used.
 

--- a/plugin-nvim/README.md
+++ b/plugin-nvim/README.md
@@ -1,3 +1,17 @@
+# Ralph Nvim pluggin
+
 Nvim plugin for [Alephium](https://alephium.org/) smart contract programming language: [Ralph](https://wiki.alephium.org/ralph/getting-started/)
 
 This plugin use [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) to provide LSP client
+
+## Workspace folders
+
+Ralph.nvim supports multiple workspace projects. You can use the [Workspace Folders Request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_workspaceFolders) to manage multiple ralph projects within the same Neovim session.
+
+To add a workspace folder, run the following command in Neovim:
+
+```vim
+:lua vim.lsp.buf.add_workspace_folder()
+```
+
+This allows you to register additional project folders, and `ralph-lsp` will handle each project separately.

--- a/plugin-nvim/plugin/ralph.lua
+++ b/plugin-nvim/plugin/ralph.lua
@@ -4,17 +4,20 @@ local function ralph_init()
 
   capabilities.workspace.didChangeWatchedFiles.dynamicRegistration = true
 
-  local root_dir = vim.fs.dirname(vim.fs.find({'build.ralph', 'contracts', 'artifacts'}, { upward = true })[1])
+  local function find_project_root(fname)
+    return vim.fs.dirname(vim.fs.find({'alephium.config.ts', '.ralph-lsp', 'contracts', 'artifacts', '.git'}, { upward = true, path = fname })[1])
+      or vim.fn.getcwd()
+  end
 
-  if root_dir == nil then root_dir = vim.fn.getcwd() end
+  local buf = vim.api.nvim_get_current_buf()
+  local root_dir = find_project_root(vim.api.nvim_buf_get_name(buf))
 
-   vim.lsp.start({
-     name = 'ralph-lsp',
-     cmd = {'ralph-lsp'},
-     root_dir = root_dir,
-     capabilities = capabilities
-   })
-
+  vim.lsp.start({
+    name = 'ralph-lsp',
+    cmd = {'ralph-lsp'},
+    root_dir = root_dir,
+    capabilities = capabilities
+  })
 end
 
 vim.api.nvim_create_autocmd('FileType', {


### PR DESCRIPTION
Multi workspaces works great in nvim, I just noticed that the plugin was not looking for `alephium.config.ts` first to define root_dir.

I also added the command to run in the README