### PR TITLE
Enable multi-file testing within a workspace

### DIFF
--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/util/StringUtilSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/util/StringUtilSpec.scala
@@ -12,7 +12,7 @@ import org.alephium.ralph.lsp.access.util.StringUtil._
 class StringUtilSpec extends AnyWordSpec with Matchers {
 
   def computeIndex(code: String): Assertion = {
-    val (linePosition, index, codeWithoutSymbol) = TestCodeUtil.indicatorPosition(code)
+    val (linePosition, index, codeWithoutSymbol) = TestCodeUtil.indicatorPositionOrFail(code)
     StringUtil.computeIndex(codeWithoutSymbol, linePosition.line, linePosition.character) shouldBe index
   }
 

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/util/TestCodeUtil.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/util/TestCodeUtil.scala
@@ -24,6 +24,12 @@ object TestCodeUtil {
     range.head
   }
 
+  def lineRangesOnly(code: String): Array[LineRange] =
+    lineRanges(code)._1
+
+  def removeRangeSymbols(code: String): String =
+    lineRanges(code)._2
+
   /**
    * Extracts line ranges from the code provided between the symbols `>>...<<`.
    *
@@ -64,29 +70,30 @@ object TestCodeUtil {
   /**
    *  Extracts the 'LinePosition', as well as the index from the code provided where `@@` is located.
    */
-  def indicatorPosition(code: String): (LinePosition, Int, String) = {
-    val lines = codeLines(code)
-
+  def indicatorPositionOrFail(code: String): (LinePosition, Int, String) =
     // find the line where @@ is located
-    lines.zipWithIndex.find(_._1.contains(SEARCH_INDICATOR)) match {
-      case Some((line, lineIndex)) =>
-        val index = code.indexOf(SEARCH_INDICATOR)
-        // find the character where @@ is located
-        val character =
-          line.indexOf(SEARCH_INDICATOR)
+    indicatorPosition(code) getOrElse fail(s"Location indicator '$SEARCH_INDICATOR' not provided")
 
-        // remove @@
-        val codeWithoutAtSymbol =
-          code.replaceFirst(SEARCH_INDICATOR, "")
+  // find the line where @@ is located
+  def indicatorPosition(code: String): Option[(LinePosition, Int, String)] =
+    codeLines(code)
+      .zipWithIndex
+      .find(_._1.contains(SEARCH_INDICATOR))
+      .map {
+        case (line, lineIndex) =>
+          val index = code.indexOf(SEARCH_INDICATOR)
+          // find the character where @@ is located
+          val character =
+            line.indexOf(SEARCH_INDICATOR)
 
-        val linePosition = LinePosition(lineIndex, character)
+          // remove @@
+          val codeWithoutAtSymbol =
+            code.replaceFirst(SEARCH_INDICATOR, "")
 
-        (linePosition, index, codeWithoutAtSymbol)
+          val linePosition = LinePosition(lineIndex, character)
 
-      case None =>
-        fail(s"Location indicator '$SEARCH_INDICATOR' not provided")
-    }
-  }
+          (linePosition, index, codeWithoutAtSymbol)
+      }
 
   /**
    * Extracts the [[SourceIndex]] from the given input.

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
@@ -51,9 +51,9 @@ object TestCodeProvider {
    * @param code The code to run code completion on.
    * @return A list of code completion suggestions.
    */
-  def suggest(code: String): List[Suggestion] =
+  def suggest(code: String*): List[Suggestion] =
     TestCodeProvider[SourceCodeState.Parsed, Unit, Suggestion](
-      code = code,
+      code = code.to(ArraySeq),
       searchSettings = (),
       dependencyDownloaders = DependencyDownloader.natives()
     )._1.toList
@@ -67,24 +67,24 @@ object TestCodeProvider {
    *
    * @param code The containing `@@` and `>>...<<` symbols.
    */
-  def goToDefinitionStrict(settings: GoToDefSetting = testGoToDefSetting)(code: String): List[(URI, LineRange)] =
+  def goToDefinitionStrict(settings: GoToDefSetting = testGoToDefSetting)(code: String*): List[(URI, LineRange)] =
     goTo[SourceCodeState.Parsed, GoToDefSetting, SourceLocation.GoToDefStrict](
-      code = code,
+      code = code.to(ArraySeq),
       searchSettings = settings
     )
 
-  def goToDefinitionSoft(settings: GoToDefSetting = testGoToDefSetting)(code: String): List[(URI, LineRange)] =
+  def goToDefinitionSoft(settings: GoToDefSetting = testGoToDefSetting)(code: String*): List[(URI, LineRange)] =
     goTo[SourceCodeState.IsParsed, (SoftAST.type, GoToDefSetting), SourceLocation.GoToDefSoft](
-      code = code,
+      code = code.to(ArraySeq),
       searchSettings = (SoftAST, settings)
     )
 
   /** Executes go-to-definition providers for both StrictAST and [[SoftAST]] */
-  def goToDefinition(settings: GoToDefSetting = testGoToDefSetting)(code: String): List[(URI, LineRange)] = {
-    val resultStrict       = goToDefinitionStrict(settings)(code)
+  def goToDefinition(settings: GoToDefSetting = testGoToDefSetting)(code: String*): List[(URI, LineRange)] = {
+    val resultStrict       = goToDefinitionStrict(settings)(code: _*)
     val resultStrictRanges = resultStrict.map(_._2)
 
-    val resultSoft       = goToDefinitionSoft(settings)(code)
+    val resultSoft       = goToDefinitionSoft(settings)(code: _*)
     val resultSoftRanges = resultSoft.map(_._2)
 
     // Assert that both go-to-def services (Strict & Soft) return the same result.
@@ -105,15 +105,15 @@ object TestCodeProvider {
       code = code
     )
 
-  def goToReferences(settings: GoToRefSetting = testGoToRefSetting)(code: String): List[(URI, LineRange)] =
+  def goToReferences(settings: GoToRefSetting = testGoToRefSetting)(code: String*): List[(URI, LineRange)] =
     goTo[SourceCodeState.Parsed, GoToRefSetting, SourceLocation.GoToRefStrict](
-      code = code,
+      code = code.to(ArraySeq),
       searchSettings = settings
     )
 
-  def goToRename(code: String): List[(URI, LineRange)] =
+  def goToRename(code: String*): List[(URI, LineRange)] =
     goTo[SourceCodeState.Parsed, Unit, SourceLocation.GoToRenameStrict](
-      code = code,
+      code = code.to(ArraySeq),
       searchSettings = ()
     )
 
@@ -162,7 +162,7 @@ object TestCodeProvider {
     // This should be most expressed on the declaration.
     val firstResult =
       goTo(
-        code = code,
+        code = ArraySeq(code),
         searchSettings = settings
       ).map(_._2)
 
@@ -207,7 +207,7 @@ object TestCodeProvider {
         val newRanges =
           reportCodeOnFailure {
             goTo(
-              code = newCode,
+              code = ArraySeq(newCode),
               searchSettings = settings
             ).map(_._2)
           }
@@ -228,20 +228,23 @@ object TestCodeProvider {
    *
    * @param code The containing `@@` and `>>...<<` symbols.
    */
-  def goTo[S, I, O <: SourceLocation.GoTo](
-      code: String,
+  private def goTo[S, I, O <: SourceLocation.GoTo](
+      code: ArraySeq[String],
       searchSettings: I
     )(implicit codeProvider: CodeProvider[S, I, O]): List[(URI, LineRange)] = {
     // To find line ranges remove the select indicator @@
     val codeWithoutSelectSymbol =
-      code.replace(TestCodeUtil.SEARCH_INDICATOR, "")
+      code.map(_.replace(TestCodeUtil.SEARCH_INDICATOR, ""))
 
-    val (expectedLineRanges, _, _, _) =
-      TestCodeUtil.lineRanges(codeWithoutSelectSymbol)
+    val expectedLineRanges =
+      (codeWithoutSelectSymbol map TestCodeUtil.lineRanges).map {
+        case (ranges, code, _, _) =>
+          (ranges, code)
+      }
 
     // Remove all line-range indicators and keep the select indicator @@
     val codeWithoutLineRangeSymbols =
-      code.replaceAll(">>|<<", "")
+      code.map(_.replaceAll(">>|<<", ""))
 
     // Execute go-to definition.
     val (searchResultIterator, sourceCode, _) =
@@ -253,9 +256,15 @@ object TestCodeProvider {
 
     // Expect GoToLocations to also contain the fileURI
     val expectedGoToLocations =
-      expectedLineRanges map {
-        lineRange =>
-          (sourceCode.fileURI, lineRange)
+      expectedLineRanges flatMap {
+        case (ranges, code) =>
+          val targetCode =
+            sourceCode.find(_.code == code).value
+
+          ranges map {
+            range =>
+              (targetCode.fileURI, range)
+          }
       }
 
     // Convert to List for debugging
@@ -298,7 +307,7 @@ object TestCodeProvider {
       code: String,
       expected: Option[String]): Assertion =
     goToDependencyStrict(
-      code = code,
+      code = ArraySeq(code),
       expected = expected.map {
         string =>
           (string, string)
@@ -318,9 +327,9 @@ object TestCodeProvider {
    *                 and the second is the highlighted token in that line.
    * @param code     The code with the search indicator '@@'.
    */
-  def goToStd(expected: Option[(String, String)])(code: String): Assertion =
+  def goToStd(expected: Option[(String, String)])(code: String*): Assertion =
     goToDependency(
-      code = code,
+      code = code.to(ArraySeq),
       expected = expected,
       downloader = StdInterfaceDownloader
     )
@@ -385,9 +394,9 @@ object TestCodeProvider {
 
     val (indicatorPosition, _, codeWithoutIndicatorMarker) =
       if (isIndicatorInDependency)
-        TestCodeUtil.indicatorPosition(dependency) // maybe the indicator in dependency code
+        TestCodeUtil.indicatorPositionOrFail(dependency) // maybe the indicator in dependency code
       else
-        TestCodeUtil.indicatorPosition(workspace) // otherwise, the indicator must be in dependency code
+        TestCodeUtil.indicatorPositionOrFail(workspace) // otherwise, the indicator must be in dependency code
 
     val (dependencyLineRange, dependencyCodeWithoutRangeMarkers, _, _) =
       if (isIndicatorInDependency)
@@ -428,7 +437,7 @@ object TestCodeProvider {
               )
         }
         .sample
-        .get
+        .value
 
     // the one dependency is written with custom code.
     build.dependencies should have size 1
@@ -444,7 +453,7 @@ object TestCodeProvider {
           code = workspaceCodeWithoutRangeMarkers
         )
         .sample
-        .get
+        .value
 
     // use the selected fileURI to be the one with @@ indicator.
     val selectedFileURI =
@@ -461,7 +470,7 @@ object TestCodeProvider {
         selectedFileURI = selectedFileURI,
         searchSettings = searchSettings,
         build = build,
-        workspaceSourceCode = sourceCode
+        workspaceSourceCode = ArraySeq(sourceCode)
       )
 
     testWorkspace.sourceCode should have size 1
@@ -487,7 +496,7 @@ object TestCodeProvider {
    *                   We don't want generated libraries being written to `~/ralph-lsp`.
    */
   private def goToDependency(
-      code: String,
+      code: ArraySeq[String],
       expected: Option[(String, String)],
       downloader: DependencyDownloader.Native): Assertion = {
     goToDependencyStrict(
@@ -516,11 +525,11 @@ object TestCodeProvider {
    *                   We don't want generated libraries being written to `~/ralph-lsp`.
    */
   private def goToDependencyStrict(
-      code: String,
+      code: ArraySeq[String],
       expected: Option[(String, String)],
       downloader: DependencyDownloader.Native): Assertion = {
-    val (_, codeWithoutGoToSymbols, _, _) =
-      TestCodeUtil.lineRanges(code)
+    val codeWithoutGoToSymbols =
+      code map TestCodeUtil.removeRangeSymbols
 
     // Execute go-to definition on strict-AST.
     val (searchResult, _, workspace) =
@@ -551,11 +560,11 @@ object TestCodeProvider {
    *                   We don't want generated libraries being written to `~/ralph-lsp`.
    */
   private def goToDependencySoft(
-      code: String,
+      code: ArraySeq[String],
       expected: Option[(String, String)],
       downloader: DependencyDownloader.Native): Assertion = {
-    val (_, codeWithoutGoToSymbols, _, _) =
-      TestCodeUtil.lineRanges(code)
+    val codeWithoutGoToSymbols =
+      code map TestCodeUtil.removeRangeSymbols
 
     // Execute go-to definition on SoftAST.
     val (searchResult, _, workspace) =
@@ -613,8 +622,7 @@ object TestCodeProvider {
 
                 // compute the line range
                 TestCodeUtil
-                  .lineRanges(codeWithRangeSymbols)
-                  ._1
+                  .lineRangesOnly(codeWithRangeSymbols)
                   .map {
                     lineRange =>
                       (builtInFile.fileURI, lineRange)
@@ -650,52 +658,84 @@ object TestCodeProvider {
    *                              We don't want generated libraries being written to `~/ralph-lsp`.
    */
   private def apply[S, I, O](
-      code: String,
       searchSettings: I,
-      dependencyDownloaders: ArraySeq[DependencyDownloader.Native]
-    )(implicit provider: CodeProvider[S, I, O]): (Iterator[O], SourceCodeState.IsCodeAware, WorkspaceState.IsParsedAndCompiled) = {
+      dependencyDownloaders: ArraySeq[DependencyDownloader.Native],
+      code: ArraySeq[String]
+    )(implicit provider: CodeProvider[S, I, O]): (Iterator[O], ArraySeq[SourceCodeState.IsCodeAware], WorkspaceState.IsParsedAndCompiled) = {
     implicit val clientLogger: ClientLogger = TestClientLogger
     implicit val file: FileAccess           = FileAccess.disk
     implicit val compiler: CompilerAccess   = CompilerAccess.ralphc
 
-    val (linePosition, _, codeWithoutAtSymbol) =
-      TestCodeUtil.indicatorPosition(code)
+    val (withoutAt, withAt) =
+      code partitionMap {
+        code =>
+          // - Right = Code with the `@` symbol (expected only 1)
+          // - Left  = Code without the `@` symbol
+          TestCodeUtil.indicatorPosition(code) match {
+            case Some((location, _, code)) =>
+              Right((location, code))
+
+            case None =>
+              Left(code)
+          }
+      }
+
+    // there should only be 1 source-code with the `@` symbol
+    withAt should have size 1
+    val (atPosition, codeWithAt) = withAt.head
 
     // create a build file
     val build =
       TestBuild
         .genCompiledOK(dependencyDownloaders = dependencyDownloaders)
         .sample
-        .get
+        .value
 
-    // generate source-code for the code
-    val sourceCode =
+    val sourceCodeWithAt =
       TestSourceCode
         .genOnDiskAndPersist(
           build = build,
-          code = codeWithoutAtSymbol
+          code = codeWithAt
         )
         .sample
-        .get
+        .value
+
+    val sourceCodeWithoutAt =
+      withoutAt map {
+        code =>
+          TestSourceCode
+            .genOnDiskAndPersist(
+              build = build,
+              code = code
+            )
+            .sample
+            .value
+      }
+
+    val workspaceSourceCode =
+      sourceCodeWithoutAt :+ sourceCodeWithAt
 
     // run completion at that line and character
     val (searchResult, workspace) =
       TestCodeProvider(
-        line = linePosition.line,
-        character = linePosition.character,
-        selectedFileURI = sourceCode.fileURI,
+        line = atPosition.line,
+        character = atPosition.character,
+        selectedFileURI = sourceCodeWithAt.fileURI,
         searchSettings = searchSettings,
         build = build,
-        workspaceSourceCode = sourceCode
+        workspaceSourceCode = workspaceSourceCode
       )
 
-    workspace.sourceCode should have size 1
+    workspace.sourceCode should have size code.size.toLong
 
     // delete the workspace
     TestWorkspace delete workspace
 
-    (searchResult.value, workspace.sourceCode.head.asInstanceOf[SourceCodeState.IsCodeAware], workspace)
+    // The workspace must contain `CodeAware` source files, meaning - it is read from disk.
+    val codeAwareSource =
+      workspace.sourceCode.asInstanceOf[ArraySeq[SourceCodeState.IsCodeAware]]
 
+    (searchResult.value, codeAwareSource, workspace)
   }
 
   /**
@@ -713,7 +753,7 @@ object TestCodeProvider {
       selectedFileURI: URI,
       searchSettings: I,
       build: BuildState.Compiled,
-      workspaceSourceCode: SourceCodeState.OnDisk
+      workspaceSourceCode: ArraySeq[SourceCodeState.OnDisk]
     )(implicit provider: CodeProvider[S, I, O],
       client: ClientLogger,
       file: FileAccess,
@@ -723,7 +763,7 @@ object TestCodeProvider {
     val workspace =
       WorkspaceState.UnCompiled(
         build = build,
-        sourceCode = ArraySeq(workspaceSourceCode)
+        sourceCode = workspaceSourceCode
       )
 
     // parse and compile workspace
@@ -754,8 +794,8 @@ object TestCodeProvider {
    *             without the test markers `>><<` and `@@`.
    */
   private def tryOrPrintIndexer[T](
-      codeBeingTested: String,
-      code: List[SourceLocation.GoTo],
+      codeBeingTested: Iterable[String],
+      code: Iterable[SourceLocation.GoTo],
       message: String = "Actual"
     )(f: => T): T =
     try
@@ -763,7 +803,7 @@ object TestCodeProvider {
     catch {
       case throwable: Throwable =>
         // print the code was tested
-        println(codeBeingTested)
+        codeBeingTested foreach println
 
         // print the actual result
         printAsError(
@@ -783,7 +823,7 @@ object TestCodeProvider {
    */
   private def printAsError(
       message: String,
-      code: List[SourceLocation.GoTo]): Unit =
+      code: Iterable[SourceLocation.GoTo]): Unit =
     toErrorMessage(
       message = message,
       code = code
@@ -798,7 +838,7 @@ object TestCodeProvider {
    */
   private def toErrorMessage(
       message: String,
-      code: List[SourceLocation.GoTo]): Iterable[String] =
+      code: Iterable[SourceLocation.GoTo]): Iterable[String] =
     code map {
       result =>
         val index          = result.index.value

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArgumentSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArgumentSpec.scala
@@ -541,29 +541,59 @@ class GoToArgumentSpec extends AnyWordSpec with Matchers {
       }
     }
 
-    "there are duplicate arguments within inheritance" in {
-      goToDefinition() {
-        """
-          |Abstract Contract Parent3(>>param<<: MyParam,
-          |                          >>param<<: MyParam) { }
-          |
-          |
-          |Abstract Contract Parent2(>>param<<: MyParam,
-          |                          >>param<<: MyParam) extends Parent3() { }
-          |
-          |Abstract Contract Parent1(>>param<<: MyParam) extends Parent2() {
-          |
-          |  // this function also has `interface` as parameter, but it is not in scope.
-          |  pub fn local_function(param: MyParam) -> () { }
-          |}
-          |
-          |Contract GoToField(>>param<<: MyParam) extends Parent1() {
-          |
-          |  pub fn local_function(>>param<<: MyParam) -> () {
-          |    let result = para@@m.function()
-          |  }
-          |}
-          |""".stripMargin
+    "there are duplicate arguments within inheritance" when {
+      "single source-file" in {
+        goToDefinition() {
+          """
+            |Abstract Contract Parent3(>>param<<: MyParam,
+            |                          >>param<<: MyParam) { }
+            |
+            |
+            |Abstract Contract Parent2(>>param<<: MyParam,
+            |                          >>param<<: MyParam) extends Parent3() { }
+            |
+            |Abstract Contract Parent1(>>param<<: MyParam) extends Parent2() {
+            |
+            |  // this function also has `interface` as parameter, but it is not in scope.
+            |  pub fn local_function(param: MyParam) -> () { }
+            |}
+            |
+            |Contract GoToField(>>param<<: MyParam) extends Parent1() {
+            |
+            |  pub fn local_function(>>param<<: MyParam) -> () {
+            |    let result = para@@m.function()
+            |  }
+            |}
+            |""".stripMargin
+        }
+      }
+
+      "multiple source-files" in {
+        goToDefinition()(
+          """
+            |Abstract Contract Parent3(>>param<<: MyParam,
+            |                          >>param<<: MyParam) { }
+            |""".stripMargin,
+          """
+            |Abstract Contract Parent2(>>param<<: MyParam,
+            |                          >>param<<: MyParam) extends Parent3() { }
+            |""".stripMargin,
+          """
+            |Abstract Contract Parent1(>>param<<: MyParam) extends Parent2() {
+            |
+            |  // this function also has `interface` as parameter, but it is not in scope.
+            |  pub fn local_function(param: MyParam) -> () { }
+            |}
+            |""".stripMargin,
+          """
+            |Contract GoToField(>>param<<: MyParam) extends Parent1() {
+            |
+            |  pub fn local_function(>>param<<: MyParam) -> () {
+            |    let result = para@@m.function()
+            |  }
+            |}
+            |""".stripMargin
+        )
       }
     }
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArraySpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArraySpec.scala
@@ -49,22 +49,43 @@ class GoToArraySpec extends AnyWordSpec with Matchers {
         )
       }
 
-      "within inheritance" in {
-        goToDefinitionStrict()(
-          """
-            |Contract Parent(>>array<<: [U256; 2])  {
-            |  fn main(array: [U256; 2]) -> () {
-            |    let head = array[0]
-            |  }
-            |}
-            |
-            |Contract Test(>>array<<: [U256; 2]) extends Parent(array) {
-            |  fn main(>>array<<: [U256; 2]) -> () {
-            |    let head = arra@@y[0]
-            |  }
-            |}
-            |""".stripMargin
-        )
+      "within inheritance" when {
+        "single source-file" in {
+          goToDefinitionStrict()(
+            """
+              |Contract Parent(>>array<<: [U256; 2])  {
+              |  fn main(array: [U256; 2]) -> () {
+              |    let head = array[0]
+              |  }
+              |}
+              |
+              |Contract Test(>>array<<: [U256; 2]) extends Parent(array) {
+              |  fn main(>>array<<: [U256; 2]) -> () {
+              |    let head = arra@@y[0]
+              |  }
+              |}
+              |""".stripMargin
+          )
+        }
+
+        "multiple source-files" in {
+          goToDefinitionStrict()(
+            """
+              |Contract Parent(>>array<<: [U256; 2])  {
+              |  fn main(array: [U256; 2]) -> () {
+              |    let head = array[0]
+              |  }
+              |}
+              |""".stripMargin,
+            """
+              |Contract Test(>>array<<: [U256; 2]) extends Parent(array) {
+              |  fn main(>>array<<: [U256; 2]) -> () {
+              |    let head = arra@@y[0]
+              |  }
+              |}
+              |""".stripMargin
+          )
+        }
       }
     }
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToAssignmentsInContractSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToAssignmentsInContractSpec.scala
@@ -384,43 +384,87 @@ class GoToAssignmentsInContractSpec extends AnyWordSpec with Matchers {
           }
         }
 
-        "soft-parseable" in {
-          goToDefinitionSoft() {
-            """
-              |Contract Parent2(>>counter<< { }
-              |
-              |// This is not an Abstract, but Go-To definition should still work as expected.
-              |Contract Parent1(mut >>counter<<: U256,
-              |                     >>counter<<) extends Parent2(counter) {
-              |
-              |  // the counter parameter here is not in scope, so it should get added to search result.
-              |  fn function(mut counter: U256) -> () {}
-              |
-              |}
-              |
-              |Contract GoToAssignment(mut >>counter<<) extends Parent1(counter, counter) {
-              |
-              |  let >>counter<<
-              |  let anotherCounter = 1
-              |
-              |  {
-              |    // within a block, so it is out of scope.
-              |    let mut counter = 0
-              |  }
-              |
-              |  fn function(mut >>counter<<: U256) -> {
-              |    let mut >>counter<<
-              |    counter = count@@er
-              |    for (let mut counter = 0; counter <= 4; counter = counter + 1) {
-              |      counter = counter + 1
-              |    }
-              |
-              |    let counter = 0
-              |  }
-              |
-              |  let counter = 0
-              |}
-              |""".stripMargin
+        "soft-parseable" when {
+          "single source-file" in {
+            goToDefinitionSoft() {
+              """
+                |Contract Parent2(>>counter<< { }
+                |
+                |// This is not an Abstract, but Go-To definition should still work as expected.
+                |Contract Parent1(mut >>counter<<: U256,
+                |                     >>counter<<) extends Parent2(counter) {
+                |
+                |  // the counter parameter here is not in scope, so it should get added to search result.
+                |  fn function(mut counter: U256) -> () {}
+                |
+                |}
+                |
+                |Contract GoToAssignment(mut >>counter<<) extends Parent1(counter, counter) {
+                |
+                |  let >>counter<<
+                |  let anotherCounter = 1
+                |
+                |  {
+                |    // within a block, so it is out of scope.
+                |    let mut counter = 0
+                |  }
+                |
+                |  fn function(mut >>counter<<: U256) -> {
+                |    let mut >>counter<<
+                |    counter = count@@er
+                |    for (let mut counter = 0; counter <= 4; counter = counter + 1) {
+                |      counter = counter + 1
+                |    }
+                |
+                |    let counter = 0
+                |  }
+                |
+                |  let counter = 0
+                |}
+                |""".stripMargin
+            }
+          }
+
+          "multiple source-files" in {
+            goToDefinitionSoft()(
+              """
+                |Contract Parent2(>>counter<< { }
+                |""".stripMargin,
+              """
+                |// This is not an Abstract, but Go-To definition should still work as expected.
+                |Contract Parent1(mut >>counter<<: U256,
+                |                     >>counter<<) extends Parent2(counter) {
+                |
+                |  // the counter parameter here is not in scope, so it should get added to search result.
+                |  fn function(mut counter: U256) -> () {}
+                |
+                |}
+                |""".stripMargin,
+              """
+                |Contract GoToAssignment(mut >>counter<<) extends Parent1(counter, counter) {
+                |
+                |  let >>counter<<
+                |  let anotherCounter = 1
+                |
+                |  {
+                |    // within a block, so it is out of scope.
+                |    let mut counter = 0
+                |  }
+                |
+                |  fn function(mut >>counter<<: U256) -> {
+                |    let mut >>counter<<
+                |    counter = count@@er
+                |    for (let mut counter = 0; counter <= 4; counter = counter + 1) {
+                |      counter = counter + 1
+                |    }
+                |
+                |    let counter = 0
+                |  }
+                |
+                |  let counter = 0
+                |}
+                |""".stripMargin
+            )
           }
         }
       }


### PR DESCRIPTION
Currently, most test-cases can only test a single source file within a workspace. This extends it to allow test-cases to run across multiple source files in the same workspace.

Towards #421.