### PR TITLE
Go-to references `MultiCodeProvider`

### DIFF
--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/converter/GoToConverter.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/converter/GoToConverter.scala
@@ -15,18 +15,18 @@ import java.util
 object GoToConverter {
 
   /** Convert [[SourceLocation.GoTo]]s to LSP4J's either type [[lsp4j.Location]] */
-  def toLocationEither(locations: Iterable[SourceLocation.GoTo]): messages.Either[util.List[_ <: Location], util.List[_ <: LocationLink]] = {
+  def toLocationEither(locations: Iterable[SourceLocation.GoTo]): messages.Either[util.List[_ <: Location], util.List[_ <: LocationLink]] =
+    messages.Either.forLeft[util.List[_ <: Location], util.List[_ <: LocationLink]](toLocations(locations))
+
+  def toLocations(locations: Iterable[SourceLocation.GoTo]): util.ArrayList[Location] = {
     val javaLocations =
       GoToConverter.toLocations(locations.iterator)
 
-    val javaList =
-      CollectionUtil.toJavaList(javaLocations)
-
-    messages.Either.forLeft[util.List[_ <: Location], util.List[_ <: LocationLink]](javaList)
+    CollectionUtil.toJavaList(javaLocations)
   }
 
   /** Convert [[SourceLocation.GoTo]]s to LSP4J types [[lsp4j.Location]] */
-  def toLocations(goTos: Iterator[SourceLocation.GoTo]): Iterator[lsp4j.Location] =
+  private def toLocations(goTos: Iterator[SourceLocation.GoTo]): Iterator[lsp4j.Location] =
     goTos flatMap toLocation
 
   /** Convert [[SourceLocation.GoTo]] to LSP4J type [[lsp4j.Location]] */

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/MultiCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/MultiCodeProvider.scala
@@ -6,6 +6,7 @@ package org.alephium.ralph.lsp.pc.search
 import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.pc.PCStates
 import org.alephium.ralph.lsp.pc.search.gotodef.multi.GoToDefMultiCodeProvider
+import org.alephium.ralph.lsp.pc.search.gotoref.multi.{GoToRefMultiCodeProvider, GoToRefMultiSetting}
 import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
 import org.alephium.ralph.lsp.utils.IsCancelled
 import org.alephium.ralph.lsp.utils.log.ClientLogger
@@ -53,6 +54,9 @@ object MultiCodeProvider {
 
   implicit val goToDef: MultiCodeProvider[Unit, SourceLocation.GoToDef] =
     GoToDefMultiCodeProvider
+
+  implicit val goToRef: MultiCodeProvider[GoToRefMultiSetting, SourceLocation.GoToRefStrict] =
+    GoToRefMultiCodeProvider
 
   /**
    * Executes the search.

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/multi/GoToRefMultiCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/multi/GoToRefMultiCodeProvider.scala
@@ -1,0 +1,141 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.pc.search.gotoref.multi
+
+import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.SourceIndexExtension
+import org.alephium.ralph.lsp.access.util.StringUtil
+import org.alephium.ralph.lsp.pc.{PCSearcher, PCStates}
+import org.alephium.ralph.lsp.pc.search.gotodef.GoToDefSetting
+import org.alephium.ralph.lsp.pc.search.gotoref.GoToRefSetting
+import org.alephium.ralph.lsp.pc.search.MultiCodeProvider
+import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
+import org.alephium.ralph.lsp.utils.IsCancelled
+import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
+
+import java.net.URI
+import scala.collection.immutable.ArraySeq
+import scala.concurrent.{ExecutionContext, Future}
+
+private[search] case object GoToRefMultiCodeProvider extends MultiCodeProvider[GoToRefMultiSetting, SourceLocation.GoToRefStrict] with StrictImplicitLogging {
+
+  /**
+   * Searches the reference location(s) for a symbol at the given position in a file.
+   *
+   * This function is used by the LSP to resolve “Go to References” requests across multiple workspaces.
+   * For single-workspace search, use [[org.alephium.ralph.lsp.pc.search.gotoref.GoToRefCodeProvider]].
+   *
+   * @param fileURI          The URI of the file where this search is executed.
+   * @param line             The line number where the search begins.
+   * @param character        The character offset within the line.
+   * @param enableSoftParser Whether to use a soft parser.
+   * @param isCancelled      Check whether the search should be cancelled.
+   * @param pcStates         Current presentation-compiler states of each workspace.
+   * @param settings         Provider-specific settings.
+   * @return Either an error or search results.
+   */
+  override def search(
+      fileURI: URI,
+      line: Int,
+      character: Int,
+      enableSoftParser: Boolean,
+      isCancelled: IsCancelled,
+      pcStates: PCStates,
+      settings: GoToRefMultiSetting
+    )(implicit logger: ClientLogger,
+      ec: ExecutionContext): Future[Either[CompilerMessage.Error, ArraySeq[SourceLocation.GoToRefStrict]]] =
+    MultiCodeProvider
+      .goToDef
+      .search(
+        fileURI = fileURI,
+        line = line,
+        character = character,
+        enableSoftParser = false, // Reference search is currently not implemented for SoftAST.
+        isCancelled = isCancelled,
+        pcStates = pcStates,
+        settings = ()
+      )
+      .flatMap {
+        case Left(error) =>
+          Future.successful(Left(error))
+
+        case Right(definitions) =>
+          val refSettings =
+            GoToRefSetting(
+              includeDeclaration = settings.isIncludeDeclaration,
+              includeTemplateArgumentOverrides = false,
+              includeEventFieldReferences = true,
+              goToDefSetting = GoToDefSetting(
+                includeAbstractFuncDef = false,
+                includeInheritance = true
+              )
+            )
+
+          // Execute search in parallel for each definition across all workspaces.
+          Future
+            .traverse(definitions) {
+              definition =>
+                references(
+                  definition = definition,
+                  settings = refSettings,
+                  isCancelled = isCancelled,
+                  pcStates = pcStates
+                )
+            }
+            .map(_.flatten)
+            .map(SourceLocation.distinctByLocation)
+            .map(Right(_))
+      }
+
+  /**
+   * Finds all reference location(s) for a symbol at the given position in a file.
+   *
+   * This function is used by the LSP to resolve "Go to References" requests.
+   *
+   * @param definition  The definition to search for references.
+   * @param isCancelled A callback to check if the request has been cancelled.
+   * @param pcStates  The current state of the language server, holding all workspace states.
+   * @return Either an error or a sequence of reference locations.
+   */
+  private def references(
+      definition: SourceLocation.GoToDef,
+      settings: GoToRefSetting,
+      isCancelled: IsCancelled,
+      pcStates: PCStates
+    )(implicit logger: ClientLogger,
+      ec: ExecutionContext): Future[ArraySeq[SourceLocation.GoToRefStrict]] =
+    definition.index match {
+      case Some(index) =>
+        val lineRange =
+          StringUtil.buildLineRange(
+            code = definition.parsed.code,
+            from = index.from,
+            to = index.to
+          )
+
+        // Execute search in parallel across all workspaces
+        Future
+          .traverse(pcStates.states) {
+            state =>
+              Future {
+                PCSearcher.goTo[SourceCodeState.Parsed, GoToRefSetting, SourceLocation.GoToRefStrict](
+                  fileURI = definition.parsed.fileURI,
+                  line = lineRange.from.line,
+                  character = lineRange.from.character,
+                  searchSettings = settings,
+                  isCancelled = isCancelled,
+                  state = state
+                )
+              }
+          }
+          .map(_.flatten)
+
+      case None =>
+        // This occurs because `Ast.Positioned` contains optional `SourceIndex`.
+        // This can be removed when the migration to `SoftAST` is complete.
+        logger.error(s"GoToDef contains empty SourceIndex. File: ${definition.parsed.fileURI}")
+        Future.successful(ArraySeq.empty[SourceLocation.GoToRefStrict])
+    }
+
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/multi/GoToRefMultiSetting.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/multi/GoToRefMultiSetting.scala
@@ -1,0 +1,6 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.pc.search.gotoref.multi
+
+case class GoToRefMultiSetting(isIncludeDeclaration: Boolean) extends AnyVal

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestMultiCodeProvider.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestMultiCodeProvider.scala
@@ -9,6 +9,7 @@ import org.alephium.ralph.lsp.access.compiler.message.LineRange
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.access.util.TestCodeUtil
 import org.alephium.ralph.lsp.pc.{PCState, PCStates}
+import org.alephium.ralph.lsp.pc.search.gotoref.multi.GoToRefMultiSetting
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceLocation, TestSourceCode}
 import org.alephium.ralph.lsp.pc.workspace.{TestWorkspace, Workspace, WorkspaceState}
 import org.alephium.ralph.lsp.pc.workspace.build.{TestBuild, TestRalphc}
@@ -72,6 +73,52 @@ object TestMultiCodeProvider extends ScalaFutures {
     goTo[Unit, SourceLocation.GoToDef](
       enableSoftParser = enableSoftParser,
       settings = (),
+      dependencyID = dependencyID,
+      dependency = dependency.to(ArraySeq),
+      workspaces = workspaces.to(ArraySeq)
+    )
+
+  /**
+   * Runs the [[org.alephium.ralph.lsp.pc.search.gotoref.multi.GoToRefMultiCodeProvider]] on the given workspaces,
+   * which contains the selection indicator `@@` and may also include the result indicator `>><<`.
+   *
+   * @param workspaces The source code for the workspaces.
+   * @return The line range pairs pointing to the resolved locations.
+   */
+  def goToRefMulti(
+      settings: GoToRefMultiSetting = GoToRefMultiSetting(false)
+    )(workspaces: ArraySeq[String]*
+    )(implicit logger: ClientLogger,
+      file: FileAccess,
+      compiler: CompilerAccess,
+      ec: ExecutionContext): ArraySeq[(URI, LineRange)] =
+    goToRefMultiWithDependency(settings = settings)(
+      dependencyID = DependencyID.Std,
+      dependency = ArraySeq.empty,
+      workspaces = workspaces: _*
+    )
+
+  /**
+   * Runs the [[org.alephium.ralph.lsp.pc.search.gotodef.multi.GoToDefMultiCodeProvider]] on the given workspaces and dependency,
+   * which contains the selection indicator `@@` and may also include the result indicator `>><<`.
+   *
+   * @param dependencyID     The ID to assign to the created dependency.
+   * @param dependency       The source code for the dependency.
+   * @param workspaces       The source code for the workspaces.
+   * @return The line range pairs pointing to the resolved locations.
+   */
+  def goToRefMultiWithDependency(
+      settings: GoToRefMultiSetting = GoToRefMultiSetting(false)
+    )(dependencyID: DependencyID,
+      dependency: ArraySeq[String],
+      workspaces: ArraySeq[String]*
+    )(implicit logger: ClientLogger,
+      file: FileAccess,
+      compiler: CompilerAccess,
+      ec: ExecutionContext): ArraySeq[(URI, LineRange)] =
+    goTo[GoToRefMultiSetting, SourceLocation.GoToRefStrict](
+      enableSoftParser = false,
+      settings = settings,
       dependencyID = dependencyID,
       dependency = dependency.to(ArraySeq),
       workspaces = workspaces.to(ArraySeq)

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotoref/multi/GoToReferencesMultiSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotoref/multi/GoToReferencesMultiSpec.scala
@@ -1,0 +1,224 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.pc.search.gotoref.multi
+
+import org.alephium.ralph.lsp.access.compiler.CompilerAccess
+import org.alephium.ralph.lsp.access.file.FileAccess
+import org.alephium.ralph.lsp.pc.client.TestClientLogger
+import org.alephium.ralph.lsp.pc.search.TestMultiCodeProvider._
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
+import org.alephium.ralph.lsp.utils.log.ClientLogger
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.collection.immutable.ArraySeq
+import scala.concurrent.ExecutionContext
+
+class GoToReferencesMultiSpec extends AnyWordSpec with Matchers with ScalaFutures {
+
+  implicit val compiler: CompilerAccess = CompilerAccess.ralphc
+  implicit val fileAccess: FileAccess   = FileAccess.disk
+  implicit val logger: ClientLogger     = TestClientLogger
+  implicit val ec: ExecutionContext     = ExecutionContext.Implicits.global
+
+  "search local to the workspace" when {
+    "the workspace is duplicate" in {
+      goToRefMulti()(
+        workspaces =
+          /**
+           * Workspace 1: Has the same code as Workspace 2, but it's not the one being searched.
+           */
+          ArraySeq(
+            """
+              |Abstract Contract Parent() { }
+              |""".stripMargin,
+            """
+              |Contract Child() extends Parent() {
+              |  fn function() -> () {}
+              |}
+              |""".stripMargin
+          ),
+
+        /**
+         * Workspace 2: THe workspace being search.
+         */
+        ArraySeq(
+          """
+            |Abstract Contract Pare@@nt() { }
+            |""".stripMargin,
+          """
+            |Contract Child() extends >>Parent<<() {
+            |  fn function() -> () {}
+            |}
+            |""".stripMargin
+        )
+      )
+    }
+  }
+
+  "search dependency" when {
+    "workspaces are empty" in {
+      goToRefMultiWithDependency()(
+        dependencyID = DependencyID.Std,
+        dependency = ArraySeq(
+          // Dependency file 1
+          """
+            |Abstract Contract Pare@@nt() {}
+            |
+            |Abstract Contract Dependency1() extends >>Parent<<() {}
+            |""".stripMargin,
+          // Dependency file 2
+          """
+            |Abstract Contract Dependency2() extends >>Parent<<() {}
+            |""".stripMargin
+        ),
+        workspaces = ArraySeq.empty
+      )
+    }
+
+    "references exist only within the dependency" in {
+      goToRefMultiWithDependency()(
+        dependencyID = DependencyID.Std,
+        dependency = ArraySeq(
+          // Dependency file 1
+          """
+            |Abstract Contract Pare@@nt() {}
+            |
+            |Abstract Contract Dependency1() extends >>Parent<<() {}
+            |""".stripMargin,
+          // Dependency file 2
+          """
+            |Abstract Contract Dependency2() extends >>Parent<<() {}
+            |""".stripMargin
+        ),
+        workspaces =
+          /**
+           * Workspace 1
+           */
+          ArraySeq(
+            """
+              |Contract One() extends ParentLocal() {
+              |  fn function() -> () {
+              |    let call = function()
+              |  }
+              |}
+              |""".stripMargin
+          ),
+
+        /**
+         * Workspace 2
+         */
+        ArraySeq(
+          """
+            |Contract Two() extends ParentLocal() {
+            |  fn function() -> () {
+            |    let call = function()
+            |  }
+            |}
+            |""".stripMargin
+        )
+      )
+    }
+
+    "references exist within and outside the dependency" when {
+      "declaration are included" in {
+        goToRefMultiWithDependency(settings = GoToRefMultiSetting(isIncludeDeclaration = true))(
+          dependencyID = DependencyID.Std,
+
+          /**
+           * Dependencies also contain references to `Parent` which must be included in the search result.
+           */
+          dependency = ArraySeq(
+            // Dependency file 1
+            """
+              |Abstract Contract >>Pare@@nt<<() {}
+              |
+              |Abstract Contract Dependency1() extends >>Parent<<() {}
+              |""".stripMargin,
+            // Dependency file 2
+            """
+              |Abstract Contract Dependency2() extends >>Parent<<() {}
+              |""".stripMargin
+          ),
+          workspaces =
+            /**
+             * Workspace 1
+             */
+            ArraySeq(
+              """
+                |Contract One() extends >>Parent<<() {
+                |  fn function() -> () {
+                |    let call = function()
+                |  }
+                |}
+                |""".stripMargin
+            ),
+
+          /**
+           * Workspace 2
+           */
+          ArraySeq(
+            """
+              |Contract Two() extends >>Parent<<() {
+              |  fn function() -> () {
+              |    let call = function()
+              |  }
+              |}
+              |""".stripMargin
+          )
+        )
+      }
+
+      "declaration are excluded" in {
+        goToRefMultiWithDependency()(
+          dependencyID = DependencyID.Std,
+
+          /**
+           * Dependencies also contain references to `Parent` which must be included in the search result.
+           */
+          dependency = ArraySeq(
+            // Dependency file 1
+            """
+              |Abstract Contract Pare@@nt() {}
+              |
+              |Abstract Contract Dependency1() extends >>Parent<<() {}
+              |""".stripMargin,
+            // Dependency file 2
+            """
+              |Abstract Contract Dependency2() extends >>Parent<<() {}
+              |""".stripMargin
+          ),
+          workspaces =
+            /**
+             * Workspace 1
+             */
+            ArraySeq(
+              """
+                |Contract One() extends >>Parent<<() {
+                |  fn function() -> () {
+                |    let call = function()
+                |  }
+                |}
+                |""".stripMargin
+            ),
+
+          /**
+           * Workspace 2
+           */
+          ArraySeq(
+            """
+              |Contract Two() extends >>Parent<<() {
+              |  fn function() -> () {
+              |    let call = function()
+              |  }
+              |}
+              |""".stripMargin
+          )
+        )
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
- Resolves #419
- Towards #421.
- Executes go-to-references search in parallel across all workspaces, and also for each definition.
- #7 is pending to prepare for RC1.
