### PR TITLE
Suffix dependencies with version numbers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,6 +92,7 @@ lazy val `compiler-access` =
 
 lazy val `presentation-compiler` =
   project
+    .enablePlugins(BuildInfoPlugin)
     .settings(
       commonSettings,
       libraryDependencies ++=
@@ -102,7 +103,12 @@ lazy val `presentation-compiler` =
           Dependencies.scalaMock,
           Dependencies.logback,
           Dependencies.scalaLogging
-        )
+        ),
+      buildInfoKeys ++= Seq[BuildInfoKey](
+        "web3Version"   -> Version.web3,
+        "ralphcVersion" -> Version.ralphc
+      ),
+      buildInfoPackage := "org.alephium.ralph.lsp"
     )
     .dependsOn(
       `compiler-access` % "test->test;compile->compile",

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCodeState.scala
@@ -9,8 +9,9 @@ import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.access.compiler.message.error.FastParseError
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.pc.sourcecode.imports.Importer
 import org.alephium.ralph.lsp.pc.sourcecode.warning.StringWarning
-import org.alephium.ralph.lsp.utils.{LazyVal, URIUtil}
+import org.alephium.ralph.lsp.utils.LazyVal
 
 import java.net.URI
 
@@ -24,10 +25,10 @@ sealed trait SourceCodeState {
    * Can be concurrently accessed or not accessed at all.
    *
    * @return An AST representing this source file's import string literal.
-   * @see [[URIUtil.importIdentifier]]
+   * @see [[Importer.importIdentifier]]
    */
   lazy val importIdentifier: Option[Tree.Import] =
-    URIUtil
+    Importer
       .importIdentifier(fileURI)
       .flatMap(RalphParserExtension.lazyParseImportIdentifier(_, fileURI))
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/Importer.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/Importer.scala
@@ -6,7 +6,8 @@ package org.alephium.ralph.lsp.pc.sourcecode.imports
 import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.message.error.ImportError
 import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
-import org.alephium.ralph.lsp.utils.URIUtil.takeRight
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
+import org.alephium.ralph.lsp.utils.URIUtil
 
 import java.net.URI
 import scala.collection.immutable.ArraySeq
@@ -103,7 +104,7 @@ object Importer {
    *         is `import "std/my_code"`.
    */
   def importIdentifier(uri: URI): Option[String] =
-    takeRight(
+    URIUtil.takeRight(
       uri = uri,
       count = 2
     ) map {
@@ -114,7 +115,14 @@ object Importer {
             .asScala
             .mkString("/") // import statements use forward slash.
 
-        string.substring(0, string.lastIndexOf("."))
+        val identifierWithVersion =
+          string.substring(0, string.lastIndexOf("."))
+
+        // Import statements do not contain version numbers, remove them.
+        DependencyID.all().foldLeft(identifierWithVersion) {
+          case (ident, dependencyID) =>
+            ident.replace(dependencyID.dirName, dependencyID.importName)
+        }
     }
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/Importer.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/imports/Importer.scala
@@ -6,8 +6,11 @@ package org.alephium.ralph.lsp.pc.sourcecode.imports
 import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.message.error.ImportError
 import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
+import org.alephium.ralph.lsp.utils.URIUtil.takeRight
 
+import java.net.URI
 import scala.collection.immutable.ArraySeq
+import scala.jdk.CollectionConverters.IteratorHasAsScala
 
 object Importer {
 
@@ -92,5 +95,26 @@ object Importer {
       Right(importedCode)
     }
   }
+
+  /**
+   * String literal that defines an import statement for a source file.
+   *
+   * @return If the file is named `std/my_code.ral`, the import statement returned
+   *         is `import "std/my_code"`.
+   */
+  def importIdentifier(uri: URI): Option[String] =
+    takeRight(
+      uri = uri,
+      count = 2
+    ) map {
+      identifier =>
+        val string =
+          identifier
+            .iterator()
+            .asScala
+            .mkString("/") // import statements use forward slash.
+
+        string.substring(0, string.lastIndexOf("."))
+    }
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/DependencyID.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/DependencyID.scala
@@ -3,19 +3,24 @@
 
 package org.alephium.ralph.lsp.pc.workspace.build.dependency
 
+import org.alephium.ralph.lsp.BuildInfo
+
 import scala.collection.immutable.ArraySeq
 
-sealed trait DependencyID extends Product {
+sealed abstract class DependencyID(version: String) extends Product {
 
-  final def dirName: String =
+  final val importName: String =
     productPrefix.toLowerCase
+
+  final val dirName: String =
+    s"$importName-$version"
 
 }
 
 object DependencyID {
 
-  case object Std     extends DependencyID
-  case object BuiltIn extends DependencyID
+  case object Std     extends DependencyID(BuildInfo.web3Version)
+  case object BuiltIn extends DependencyID(BuildInfo.ralphcVersion)
 
   def all(): ArraySeq[DependencyID] =
     ArraySeq(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/StdInterfaceDownloader.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/StdInterfaceDownloader.scala
@@ -77,7 +77,7 @@ object StdInterfaceDownloader extends DependencyDownloader.Native with StrictImp
     )(implicit logger: ClientLogger): Either[ErrorDownloadingDependency, List[SourceCodeState.UnCompiled]] =
     Using.Manager {
       use =>
-        val stdURL = getClass.getResource(s"/${dependencyID.dirName}")
+        val stdURL = getClass.getResource(s"/${dependencyID.importName}")
 
         val stdPath = if (stdURL.getProtocol == "file") {
           Paths.get(stdURL.toURI)
@@ -105,7 +105,7 @@ object StdInterfaceDownloader extends DependencyDownloader.Native with StrictImp
       case Failure(throwable) =>
         val error =
           ErrorDownloadingDependency(
-            dependencyID = dependencyID.dirName,
+            dependencyID = dependencyID.importName,
             throwable = throwable,
             index = errorIndex
           )

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/sourcecode/TestSourceCode.scala
@@ -4,15 +4,15 @@
 package org.alephium.ralph.lsp.pc.sourcecode
 
 import org.alephium.ralph.CompilerOptions
-import org.alephium.ralph.lsp.{TestCode, TestFile}
+import org.alephium.ralph.lsp.{TestCode, TestCommon, TestFile}
 import org.alephium.ralph.lsp.TestFile._
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.compiler.message.error.TestError
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.workspace.build.{BuildState, TestBuild}
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.TestDependency
-import org.alephium.ralph.lsp.utils.log.ClientLogger
 import org.alephium.ralph.lsp.utils.{LazyVal, URIUtil}
+import org.alephium.ralph.lsp.utils.log.ClientLogger
 import org.scalacheck.Gen
 import org.scalatest.EitherValues._
 import org.scalatest.OptionValues._
@@ -192,7 +192,7 @@ object TestSourceCode {
     genParsed(
       code = code,
       fileURI = fileURI
-    ).map(_.asInstanceOf[SourceCodeState.Parsed])
+    ).map(TestCommon.castOrPrintErrors[SourceCodeState.Parsed])
 
   def genParsed(
       code: Gen[String] = TestCode.genGoodCode(),
@@ -223,7 +223,7 @@ object TestSourceCode {
     genCompiled(
       code = code,
       fileURI = fileURI
-    ).map(_.asInstanceOf[SourceCodeState.Compiled])
+    ).map(TestCommon.castOrPrintErrors[SourceCodeState.Compiled])
 
   def genCompiled(
       code: Gen[String] = TestCode.genGoodCode(),

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/StdInterfaceDownloaderSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/StdInterfaceDownloaderSpec.scala
@@ -7,6 +7,7 @@ import org.alephium.ralph.lsp.TestFile
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra
 import org.alephium.ralph.lsp.pc.client.TestClientLogger
 import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 import org.scalatest.EitherValues._
 import org.scalatest.OptionValues._
 import org.scalatest.matchers.should.Matchers
@@ -38,7 +39,7 @@ class StdInterfaceDownloaderSpec extends AnyWordSpec with Matchers {
     "respect `std/` structure" in {
       stdInterfaces foreach {
         source =>
-          source.fileURI.toString.contains("std/") shouldBe true
+          source.fileURI.toString.contains(s"${DependencyID.Std.dirName}/") shouldBe true
       }
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,6 +4,7 @@ object Version {
 
   val scala213 = "2.13.15"
   val web3     = "0.38.0"
+  val ralphc   = "3.12.6"
 
 }
 
@@ -15,7 +16,7 @@ object Dependencies {
   lazy val scalaMock  = "org.scalamock"     %% "scalamock"       % "7.3.0"    % Test
 
   /** Core */
-  lazy val ralphc = "org.alephium" %% "alephium-ralphc" % "3.12.6" excludeAll (
+  lazy val ralphc = "org.alephium" %% "alephium-ralphc" % Version.ralphc excludeAll (
     ExclusionRule(organization = "org.rocksdb"),
     ExclusionRule(organization = "io.prometheus"),
     ExclusionRule(organization = "org.alephium", name = "alephium-api_2.13"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("com.eed3si9n"   % "sbt-assembly"        % "2.3.1")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.1")
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"        % "2.5.4")
+addSbtPlugin("com.eed3si9n"   % "sbt-buildinfo"       % "0.13.1")

--- a/utils/src/main/scala/org/alephium/ralph/lsp/utils/URIUtil.scala
+++ b/utils/src/main/scala/org/alephium/ralph/lsp/utils/URIUtil.scala
@@ -152,25 +152,4 @@ object URIUtil {
     )
   }
 
-  /**
-   * String literal that defines an import statement for a source file.
-   *
-   * @return If the file is named `std/my_code.ral`, the import statement returned
-   *         is `import "std/my_code"`.
-   */
-  def importIdentifier(uri: URI): Option[String] =
-    takeRight(
-      uri = uri,
-      count = 2
-    ) map {
-      identifier =>
-        val string =
-          identifier
-            .iterator()
-            .asScala
-            .mkString("/") // import statements use forward slash.
-
-        string.substring(0, string.lastIndexOf("."))
-    }
-
 }


### PR DESCRIPTION
- Dependencies are now written with their version number as suffix (e.g. builtin-3.12.6, std-0.38.0), following the same format as Maven.
- Resolves #162
- Resolves #113
- Resolves #307 
- Executed #7