### PR TITLE
Soft: Go-to-def for `enum`

### DIFF
--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumTypeSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumTypeSpec.scala
@@ -74,7 +74,7 @@ class GoToEnumTypeSpec extends AnyWordSpec with Matchers {
 
   "return non-empty" when {
     "user selects the enum type of the first field" in {
-      goToDefinitionStrict()(
+      goToDefinition()(
         """
           |enum >>EnumType<< {
           |  Field0 = 0
@@ -116,7 +116,7 @@ class GoToEnumTypeSpec extends AnyWordSpec with Matchers {
     }
 
     "user selects the enum type of the second field" in {
-      goToDefinitionStrict()(
+      goToDefinition()(
         """
           |enum >>EnumType<< {
           |  Field0 = 0
@@ -153,7 +153,7 @@ class GoToEnumTypeSpec extends AnyWordSpec with Matchers {
     }
 
     "there are multiple enum types with duplicate names" in {
-      goToDefinitionStrict()(
+      goToDefinition()(
         """
           |enum >>EnumType<< {
           |  Field0 = 0
@@ -219,6 +219,64 @@ class GoToEnumTypeSpec extends AnyWordSpec with Matchers {
           |}
           |""".stripMargin
       )
+    }
+  }
+
+  "duplicates identifier" when {
+    "enum is called" in {
+      // FIXME: Currently the `Contract` and the `enum` both are returned.
+      //        Only the `Enum` should be returned.
+      //        This will be resolved by type-inference code-provider, which is not yet implemented.
+      goToDefinitionSoft()(
+        """
+          |Contract >>Enum<< {
+          |
+          |  enum >>Enum<< {}
+          |  const Enum = 1
+          |
+          |  fn main() -> () {
+          |     Enu@@m.One
+          |  }
+          |
+          |}
+          |""".stripMargin
+      )
+    }
+
+    "identifier is called" when {
+      "cont and enum exists" in {
+        goToDefinitionSoft()(
+          """
+            |Contract Enum {
+            |
+            |  enum >>Enum<< {}
+            |  const >>Enum<< = 1
+            |
+            |  fn main() -> () {
+            |     Enu@@m
+            |  }
+            |
+            |}
+            |""".stripMargin
+        )
+      }
+
+      "cont and enum do not exist" in {
+        goToDefinitionSoft()(
+          """
+            |Contract >>Enum<< {
+            |
+            |  // enum Enum {}
+            |  // const Enum = 1
+            |
+            |  fn main() -> () {
+            |     Enu@@m
+            |  }
+            |
+            |}
+            |""".stripMargin
+        )
+      }
     }
   }
 


### PR DESCRIPTION
- Initial support for `enum`.
  - See [FIXME](https://github.com/alephium/ralph-lsp/compare/soft_go_to_enum?expand=1#diff-38a5fd052df7f2722f9f05ff6430c9229b62d51e2b959d9386deca2143b0e9c3R227). This will be resolved in the following PRs.
- Towards #404

## Status

Go-to def for `SoftAST` is `71%` complete.

There are a total of 14 go-to-def test files, of which 10 run on both strict and `SoftAST`, it is therefore `71%` complete with many additional test-cases added for `SoftAST` testing go-to-def for error-tolerance.

SoftAST go-to-def remains for only four types:
- Array.
- Enum fields.
- External function call.
- Mapping.