### PR TITLE
Release as draft: Overwrite "Some solid code" notification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           tag_name: v${{ env.VERSION }}
           release_name: v${{ env.VERSION }}
           body: Some solid code
-          draft: false
+          draft: true
           prerelease: ${{ env.IS_RC }}
 
       - name: Upload Release Asset (Jar)


### PR DESCRIPTION
Currently, release emails and other notifications go out with the message `"Some solid code"` which is not a useful information.

This will create the draft release first. The draft can be published after the release notes include:
- Node version
- Breaking changes
- Change log

We already update the release notes manually after publishing anyway, this just moves the "update the release notes" step before the notifications.

TODO: Configure [automatically-generated-release-notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) to also include node-version etc.