### PR TITLE
Split newline

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/BuiltInFunctionDownloader.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/BuiltInFunctionDownloader.scala
@@ -155,7 +155,7 @@ object BuiltInFunctionDownloader extends DependencyDownloader.Native {
             val doc =
               function
                 .doc
-                .split(Token.Newline.lexeme)
+                .split("\n") // `\n` for splitting because the `doc` string comes from the JVM and is not persisted.
                 .map {
                   docLine =>
                     s"  // $docLine"

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestBuild.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/workspace/build/TestBuild.scala
@@ -3,16 +3,16 @@
 
 package org.alephium.ralph.lsp.pc.workspace.build
 
+import org.alephium.ralph.lsp.{TestCode, TestCommon, TestFile}
 import org.alephium.ralph.lsp.GenExtension.GenExtensionsImplicits
 import org.alephium.ralph.lsp.TestFile.genFolderURI
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.file.FileAccess
-import org.alephium.ralph.lsp.utils.log.ClientLogger
-import org.alephium.ralph.lsp.pc.sourcecode.{TestSourceCode, SourceCodeState}
+import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, TestSourceCode}
 import org.alephium.ralph.lsp.pc.workspace.build.TestRalphc.genRalphcParsedConfig
-import org.alephium.ralph.lsp.pc.workspace.build.config.{RalphcConfigState, RalphcConfig}
+import org.alephium.ralph.lsp.pc.workspace.build.config.{RalphcConfig, RalphcConfigState}
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.downloader.DependencyDownloader
-import org.alephium.ralph.lsp.{TestCode, TestFile}
+import org.alephium.ralph.lsp.utils.log.ClientLogger
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers._
 
@@ -56,7 +56,7 @@ object TestBuild {
       workspaceURI = workspaceURI,
       config = config,
       dependencyDownloaders = dependencyDownloaders
-    ).map(_.asInstanceOf[BuildState.Compiled])
+    ).map(TestCommon.castOrPrintErrors[BuildState.Compiled])
 
   def genCompiled(
       workspaceURI: Gen[URI] = genFolderURI(),


### PR DESCRIPTION
- Resolves Windows build [issue](https://github.com/alephium/ralph-lsp/actions/runs/14876430454/job/41840418315).
- Better error messages for debugging similar cases (when dependencies contain syntax errors). The [same build](https://github.com/alephium/ralph-lsp/actions/runs/14876430454/job/41840418315) now emits [clearer errors](https://github.com/alephium/ralph-lsp/actions/runs/14897629291/job/41843105098).