### PR TITLE
Go-to type-definition: For tupled and anonymous variables

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gototypedef/GoToTypeDefCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gototypedef/GoToTypeDefCodeProvider.scala
@@ -9,8 +9,8 @@ import org.alephium.ralph.lsp.pc.search.CodeProvider
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
-import org.alephium.ralph.lsp.utils.Node
 import org.alephium.ralph.Ast
+import org.alephium.ralph.lsp.utils.Node
 
 case object GoToTypeDefCodeProvider extends CodeProvider[SourceCodeState.Parsed, Unit, SourceLocation.GoToTypeDef] with StrictImplicitLogging {
 
@@ -38,10 +38,20 @@ case object GoToTypeDefCodeProvider extends CodeProvider[SourceCodeState.Parsed,
           case tree: Tree.Source =>
             tree.rootNode.findLast(_.sourceIndex.exists(_ contains cursorIndex)) match {
               case Some(node @ Node(ident: Ast.Ident, _)) =>
-                GoToTypeDefIdent(
-                  node = node.upcast(ident),
-                  workspace = workspace
-                ).iterator
+                GoToTypeDefIdent
+                  .goToNamedVar(
+                    node = node.upcast(ident),
+                    workspace = workspace
+                  )
+                  .iterator
+
+              case Some(node @ Node(ident: Ast.AnonymousVar, _)) =>
+                GoToTypeDefIdent
+                  .goToAnonymousVar(
+                    anonVarNode = node.upcast(ident),
+                    workspace = workspace
+                  )
+                  .iterator
 
               case Some(Node(data, _)) =>
                 logger.error(s"GoToType not implemented for ${data.getClass.getName}. Index: $cursorIndex. FileURI: ${sourceCode.fileURI}")

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
@@ -252,6 +252,23 @@ object WorkspaceSearcher {
   }
 
   /**
+   * Collects source tree locations for the given types.
+   *
+   * @param types     The types to search.
+   * @param workspace The workspace to search for types.
+   * @return Type identifiers matching the searched types and their respective source trees.
+   */
+  def collectTypes(
+      types: Seq[Type],
+      workspace: WorkspaceState.IsSourceAware): ArraySeq[(Ast.TypeId, SourceLocation.CodeStrict)] = {
+    val workspaceTrees = collectAllTrees(workspace)
+    SourceCodeSearcher.collectTypes(
+      types = types,
+      workspaceSource = workspaceTrees
+    )
+  }
+
+  /**
    * Collects all global constants within the provided parsed workspace state.
    *
    * @param workspace The parsed workspace state from which to collect global constants.

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gototypedef/GoToTypeDefinitionSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gototypedef/GoToTypeDefinitionSpec.scala
@@ -5,6 +5,7 @@ package org.alephium.ralph.lsp.pc.search.gototypedef
 
 import org.alephium.ralph
 import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
+import org.alephium.ralph.Type
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -133,6 +134,123 @@ class GoToTypeDefinitionSpec extends AnyWordSpec with Matchers {
         "panic is searched" ignore {
           // TODO: Currently the type `Panic` is available in the built-in library.
           doTest(ralph.Type.Panic)
+        }
+      }
+    }
+
+    "anonymous single variable" in {
+      goToTypeDefBuiltIn(Some(s"Abstract Contract >>${Type.U256.productPrefix}<<"))(
+        """
+          |Contract Test() {
+          |  fn test() -> () {
+          |    let _@@ = 1
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
+
+    "tuple variables" when {
+      "first element is selected" in {
+        goToTypeDefBuiltIn(Some(s"Abstract Contract >>${Type.U256.productPrefix}<<"))(
+          """
+            |Contract Test() {
+            |  fn foo() -> (U256, Bool) {
+            |    return 1, false
+            |  }
+            |
+            |  fn test() -> () {
+            |    let (firs@@t, mut second) = foo()
+            |    second = true
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+
+      "second element is selected" in {
+        goToTypeDefBuiltIn(Some(s"Abstract Contract >>${Type.Bool.productPrefix}<<"))(
+          """
+            |Contract Test() {
+            |  fn foo() -> (U256, Bool) {
+            |    return 1, false
+            |  }
+            |
+            |  fn test() -> () {
+            |    let (first, mut seco@@nd) = foo()
+            |    second = true
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+
+      "anonymous var" when {
+        "the first element is anonymous" in {
+          goToTypeDefBuiltIn(Some(s"Abstract Contract >>${Type.U256.productPrefix}<<"))(
+            """
+              |Contract Test() {
+              |  fn tuple() -> (U256, Bool) {
+              |    return 1, true
+              |  }
+              |
+              |  fn test() -> () {
+              |    let (_@@, mut second) = tuple()
+              |    second = true
+              |  }
+              |}
+              |""".stripMargin
+          )
+        }
+
+        "the second element is anonymous" in {
+          goToTypeDefBuiltIn(Some(s"Abstract Contract >>${Type.Bool.productPrefix}<<"))(
+            """
+              |Contract Test() {
+              |  fn tuple() -> (U256, Bool) {
+              |    return 1, true
+              |  }
+              |
+              |  fn test() -> () {
+              |    let (first, _@@) = tuple()
+              |  }
+              |}
+              |""".stripMargin
+          )
+        }
+
+        "both elements are anonymous" when {
+          "first element is searched" in {
+            goToTypeDefBuiltIn(Some(s"Abstract Contract >>${Type.U256.productPrefix}<<"))(
+              """
+                |Contract Test() {
+                |  fn tuple() -> (U256, Bool) {
+                |    return 1, true
+                |  }
+                |
+                |  fn test() -> () {
+                |    let (_@@, _) = tuple()
+                |  }
+                |}
+                |""".stripMargin
+            )
+          }
+
+          "second element is searched" in {
+            goToTypeDefBuiltIn(Some(s"Abstract Contract >>${Type.Bool.productPrefix}<<"))(
+              """
+                |Contract Test() {
+                |  fn tuple() -> (U256, Bool) {
+                |    return 1, true
+                |  }
+                |
+                |  fn test() -> () {
+                |    let (_, _@@) = tuple()
+                |  }
+                |}
+                |""".stripMargin
+            )
+          }
         }
       }
     }


### PR DESCRIPTION
Handles the following cases:

```rust
let (a, b, _) = foo()
let _ = 1
```