### PR TITLE
Inlay hints for variable declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Language server for Ralph.
 - [Completion](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion)
 - [Rename](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_rename)
 - [Workspace Folders](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_workspaceFolders)
+- [Inlay Hints](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_inlayHint)
 - More to come...
 
 # Requirements

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtra.scala
@@ -169,6 +169,13 @@ object SourceIndexExtra {
     def toLineRange(code: String): LineRange =
       StringUtil.buildLineRange(code, sourceIndex.from, sourceIndex.to)
 
+    /** Checks if two [[SourceIndex]]s overlaps */
+    def overlaps(that: SourceIndex): Boolean =
+      sourceIndex.contains(that.from) ||
+        sourceIndex.contains(that.to) ||
+        that.contains(sourceIndex.from) ||
+        that.contains(sourceIndex.to)
+
   }
 
 }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtraSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/message/SourceIndexExtraSpec.scala
@@ -44,4 +44,43 @@ class SourceIndexExtraSpec extends AnyWordSpec with Matchers {
 
   }
 
+  "overlaps" when {
+    "child index is on the left" in {
+      //     5   -   10
+      // 4  -  6
+      range(5, 10) overlaps range(4, 4) shouldBe false
+      range(5, 10) overlaps range(4, 5) shouldBe true
+      range(5, 10) overlaps range(4, 6) shouldBe true
+    }
+
+    "child index is overlapping" in {
+      //     5   -   10
+      //     5   -   10
+      range(5, 10) overlaps range(5, 5) shouldBe true
+      range(5, 10) overlaps range(5, 6) shouldBe true
+      range(5, 10) overlaps range(7, 9) shouldBe true
+      range(5, 10) overlaps range(10, 10) shouldBe true
+      range(5, 10) overlaps range(5, 10) shouldBe true
+    }
+
+    "child index is on the right" in {
+      //     5   -   10
+      //           8  - 11
+      range(5, 10) overlaps range(8, 10) shouldBe true
+      range(5, 10) overlaps range(8, 11) shouldBe true
+      range(5, 10) overlaps range(10, 11) shouldBe true
+      range(5, 10) overlaps range(11, 11) shouldBe false
+    }
+
+    "child index is larger than parent" in {
+      //     5   -   10
+      //    4    -     11
+      range(5, 10) overlaps range(4, 11) shouldBe true
+      range(5, 10) overlaps range(5, 11) shouldBe true
+      range(5, 10) overlaps range(4, 10) shouldBe true
+      range(5, 10) overlaps range(6, 9) shouldBe true
+    }
+
+  }
+
 }

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/util/TestCodeUtil.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/util/TestCodeUtil.scala
@@ -184,6 +184,54 @@ object TestCodeUtil {
     }
   }
 
+  /**
+   * Given the following code string, extracts the text `": U256"` along with its range information.
+   *
+   * Example:
+   * {{{
+   *   @@
+   *   Contract Test() {
+   *     fn test() -> () {
+   *       let one>>: U256<< = 1
+   *     }
+   *   }
+   * }}}
+   *
+   * @param code The source code to analyse.
+   * @return The line range and the extracted text.
+   */
+  def extractLineRangeTextInfo(code: String): Array[(LineRange, String)] = {
+    // Remove `@@` markers
+    val codeWithoutAtMarker =
+      code.replace(TestCodeUtil.SEARCH_INDICATOR, "")
+
+    // Extract all line range information `>><<` markers
+    val (ranges, cleanCode, _, _) =
+      TestCodeUtil.lineRanges(codeWithoutAtMarker)
+
+    // Fetch the substring containing the line-ranges.
+    ranges map {
+      range =>
+        val fromIndex =
+          StringUtil.computeIndex(
+            code = cleanCode,
+            line = range.from.line,
+            character = range.from.character
+          )
+
+        val toIndex =
+          StringUtil.computeIndex(
+            code = cleanCode,
+            line = range.to.line,
+            character = range.to.character
+          )
+
+        val rangeText = cleanCode.substring(fromIndex, toIndex)
+
+        (range, rangeText)
+    }
+  }
+
   def clearTestMarkers(code: String): String =
     code.replaceAll(">>|<<|@@", "")
 

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/converter/CommonConverter.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/converter/CommonConverter.scala
@@ -15,7 +15,7 @@ object CommonConverter {
       toPosition(range.to)
     )
 
-  @inline private def toPosition(position: LinePosition): lsp4j.Position =
+  @inline def toPosition(position: LinePosition): lsp4j.Position =
     new lsp4j.Position(position.line, position.character)
 
 }

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/converter/GoToConverter.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/converter/GoToConverter.scala
@@ -5,14 +5,17 @@ package org.alephium.ralph.lsp.server.converter
 
 import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
 import org.alephium.ralph.lsp.utils.CollectionUtil
+import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
 import org.eclipse.lsp4j
-import org.eclipse.lsp4j.{Location, LocationLink}
+import org.eclipse.lsp4j.{InlayHint, Location, LocationLink}
 import org.eclipse.lsp4j.jsonrpc.messages
 
 import java.util
+import scala.collection.immutable.ArraySeq
+import scala.jdk.CollectionConverters.SeqHasAsJava
 
 /** Converts Go-to definition types to LSP4J types */
-object GoToConverter {
+object GoToConverter extends StrictImplicitLogging {
 
   /** Convert [[SourceLocation.GoTo]]s to LSP4J's either type [[lsp4j.Location]] */
   def toLocationEither(locations: Iterable[SourceLocation.GoTo]): messages.Either[util.List[_ <: Location], util.List[_ <: LocationLink]] =
@@ -24,6 +27,30 @@ object GoToConverter {
 
     CollectionUtil.toJavaList(javaLocations)
   }
+
+  def toInlayHint(types: ArraySeq[SourceLocation.InlayHint])(implicit logger: ClientLogger): util.List[InlayHint] =
+    types
+      .flatMap(toInlayHint)
+      .asJava
+
+  private def toInlayHint(hint: SourceLocation.InlayHint)(implicit logger: ClientLogger): Option[InlayHint] =
+    hint.inlayHintPosition() match {
+      case Some(displayPosition) =>
+        val javaHint =
+          new InlayHint(
+            CommonConverter.toPosition(displayPosition),
+            messages.Either.forLeft(hint.hint)
+          )
+
+        Some(javaHint)
+
+      case None =>
+        // None can occur when `SourceIndex` from node's AST is empty.
+        // format: off
+        logger.error(s"LineRange not found for hint '${hint.hint}'. SourceURI: ${hint.parsed.fileURI}. typeDef.TypeId: ${hint.typeDef.ast}, typeDef.fileURI: ${hint.typeDef.source.parsed.fileURI}")
+        // format: on
+        None
+    }
 
   /** Convert [[SourceLocation.GoTo]]s to LSP4J types [[lsp4j.Location]] */
   private def toLocations(goTos: Iterator[SourceLocation.GoTo]): Iterator[lsp4j.Location] =

--- a/plugin-vscode/README.md
+++ b/plugin-vscode/README.md
@@ -10,6 +10,7 @@ The Ralph LSP is an implementation of the [language server protocol](https://mic
 * [Completion](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion)
 * [Rename](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_rename)
 * [Workspace Folders](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_workspaceFolders)
+* [Inlay Hints](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_inlayHint)
 * More to come...
 
 ## Requirements

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/CodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/CodeProvider.scala
@@ -3,7 +3,7 @@
 
 package org.alephium.ralph.lsp.pc.search
 
-import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
+import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, LinePosition}
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
 import org.alephium.ralph.lsp.access.util.StringUtil
 import org.alephium.ralph.lsp.pc.search.completion.{CodeCompletionProvider, Suggestion}
@@ -12,6 +12,7 @@ import org.alephium.ralph.lsp.pc.search.gotodef.soft.GoToDefCodeProviderSoft
 import org.alephium.ralph.lsp.pc.search.gotoref.{GoToRefCodeProvider, GoToRefSetting}
 import org.alephium.ralph.lsp.pc.search.rename.GoToRenameCodeProvider
 import org.alephium.ralph.lsp.pc.search.gototypedef.GoToTypeDefCodeProvider
+import org.alephium.ralph.lsp.pc.search.inlayhints.InlayHintsCodeProvider
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
 import org.alephium.ralph.lsp.pc.workspace.{WorkspaceSearcher, WorkspaceState}
 import org.alephium.ralph.lsp.utils.log.ClientLogger
@@ -71,6 +72,10 @@ object CodeProvider {
   /** The go-to type implementation of [[CodeProvider]]. */
   implicit val goToTypeDef: CodeProvider[SourceCodeState.Parsed, Unit, SourceLocation.GoToTypeDef] =
     GoToTypeDefCodeProvider
+
+  /** The inlay-hint implementation of [[CodeProvider]]. */
+  implicit val inlayHints: CodeProvider[SourceCodeState.Parsed, LinePosition, SourceLocation.InlayHint] =
+    InlayHintsCodeProvider
 
   /**
    * Execute search at cursor position within the current workspace state.

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/MultiCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/MultiCodeProvider.scala
@@ -3,12 +3,13 @@
 
 package org.alephium.ralph.lsp.pc.search
 
-import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
+import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, LinePosition}
 import org.alephium.ralph.lsp.pc.PCStates
 import org.alephium.ralph.lsp.pc.search.completion.multi.CompletionMultiCodeProvider
 import org.alephium.ralph.lsp.pc.search.completion.Suggestion
 import org.alephium.ralph.lsp.pc.search.gotodef.multi.GoToDefMultiCodeProvider
 import org.alephium.ralph.lsp.pc.search.gotoref.multi.{GoToRefMultiCodeProvider, GoToRefMultiSetting}
+import org.alephium.ralph.lsp.pc.search.inlayhints.multi.InlayHintsMultiCodeProvider
 import org.alephium.ralph.lsp.pc.search.rename.multi.GoToRenameMultiCodeProvider
 import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
 import org.alephium.ralph.lsp.utils.IsCancelled
@@ -66,5 +67,8 @@ object MultiCodeProvider {
 
   implicit val completion: MultiCodeProvider[Unit, Suggestion] =
     CompletionMultiCodeProvider
+
+  implicit val inlayHints: MultiCodeProvider[LinePosition, SourceLocation.InlayHint] =
+    InlayHintsMultiCodeProvider
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsCodeProvider.scala
@@ -1,0 +1,186 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.pc.search.inlayhints
+
+import org.alephium.ralph.{Ast, SourceIndex}
+import org.alephium.ralph.lsp.access.compiler.ast.Tree
+import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, LinePosition}
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra._
+import org.alephium.ralph.lsp.access.util.StringUtil
+import org.alephium.ralph.lsp.pc.search.CodeProvider
+import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
+import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
+import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
+import org.alephium.ralph.lsp.utils.Node
+
+/**
+ * Implements [[CodeProvider]] that provides go-to definition results of type [[SourceLocation.InlayHint]].
+ *
+ * To execution this function invoke [[CodeProvider.search]] with [[SourceLocation.InlayHint]] as type parameter.
+ */
+private[search] case object InlayHintsCodeProvider extends CodeProvider[SourceCodeState.Parsed, LinePosition, SourceLocation.InlayHint] with StrictImplicitLogging {
+
+  /** @inheritdoc */
+  override def search(
+      rangeStart: Int,
+      sourceCode: SourceCodeState.Parsed,
+      workspace: WorkspaceState.IsSourceAware,
+      rangeEnd: LinePosition
+    )(implicit logger: ClientLogger): Iterator[SourceLocation.InlayHint] = {
+    val eligibleNodes =
+      collectHintEligibleNodesInRange(
+        rangeStart = rangeStart,
+        rangeEnd = rangeEnd,
+        sourceCode = sourceCode
+      )
+
+    eligibleNodes
+      .flatMap {
+        node =>
+          searchTypeDefinitions(
+            node = node,
+            sourceCode = sourceCode,
+            workspace = workspace
+          )
+      }
+      .flatMap {
+        /**
+         * Convert type-definitions to inlay-hints.
+         */
+        case (_, Some(Left(error))) =>
+          logger.error(s"${InlayHintsCodeProvider.productPrefix}: ${error.message}")
+          Iterable.empty
+
+        case (sourceIndex, Some(Right(types))) =>
+          // convert the types to TypeHint responses.
+          types map {
+            typeDef =>
+              val inlayHint =
+                s": ${typeDef.ast.name}"
+
+              val position =
+                SourceIndex(
+                  index = sourceIndex.endIndex,
+                  width = 0,
+                  fileURI = None
+                )
+
+              SourceLocation.InlayHint(
+                position = position,
+                parsed = sourceCode,
+                hint = inlayHint,
+                typeDef = typeDef
+              )
+          }
+
+        case (_, None) =>
+          Iterable.empty
+      }
+
+  }
+
+  /**
+   * Searches type-definitions for the given variable declaration.
+   *
+   * @param node       The variable node to search the type for.
+   * @param sourceCode The source code from which nodes are to be collected.
+   * @param workspace  The workspace state where the source-code is located.
+   * @return The [[SourceIndex]] of the variable and it's corresponding type-definitions.
+   */
+  private def searchTypeDefinitions(
+      node: Node[Ast.VarDeclaration, Ast.Positioned],
+      sourceCode: SourceCodeState.Parsed,
+      workspace: WorkspaceState.IsSourceAware
+    )(implicit logger: ClientLogger): Iterator[(SourceIndex, Option[Either[CompilerMessage.Error, Iterator[SourceLocation.GoToTypeDef]]])] =
+    // Collect all identifiers in the assignment.
+    node
+      .walkDown
+      .collect {
+        case Node(ident: Ast.Ident, _) =>
+          ident.sourceIndex
+
+        case Node(anonymousVar: Ast.AnonymousVar, _) =>
+          anonymousVar.sourceIndex
+      }
+      .flatten
+      .map {
+        varSourceIndex =>
+          // convert the SourceIndex to LineRange.
+          val varRange =
+            varSourceIndex.toLineRange(sourceCode.code)
+
+          // Find all type definitions at the range.
+          val typeDefinitions =
+            CodeProvider
+              .search[SourceCodeState.Parsed, Unit, SourceLocation.GoToTypeDef](
+                line = varRange.from.line,
+                character = varRange.from.character,
+                fileURI = sourceCode.fileURI,
+                workspace = workspace,
+                searchSettings = ()
+              )
+
+          (varSourceIndex, typeDefinitions)
+      }
+
+  /**
+   * Collects AST nodes within a specified range that can provide type hints for the inlay-hints.
+   *
+   * @param rangeStart The starting index of the target range in the source code.
+   * @param rangeEnd   The ending index of the target range in the source code.
+   * @param sourceCode The source code from which nodes are to be collected.
+   * @return All nodes within the range eligible for displaying type hints.
+   */
+  private def collectHintEligibleNodesInRange(
+      rangeStart: Int,
+      rangeEnd: LinePosition,
+      sourceCode: SourceCodeState.Parsed
+    )(implicit logger: ClientLogger): Iterator[Node[Ast.VarDeclaration, Ast.Positioned]] = {
+    val statementsInRange =
+      sourceCode
+        .astStrict
+        .statements
+        .find {
+          statement =>
+            statement.index.contains(rangeStart) || statement.index.isAhead(rangeStart)
+        }
+
+    statementsInRange match {
+      case Some(statement) =>
+        statement match {
+          case _: Tree.Import =>
+            // request is for import go-to definition
+            Iterator.empty
+
+          case tree: Tree.Source =>
+            val endIndex =
+              StringUtil.computeIndex(
+                code = sourceCode.code,
+                line = rangeEnd.line,
+                character = rangeEnd.character
+              )
+
+            val searchRange =
+              SourceIndex(
+                index = rangeStart,
+                width = endIndex - rangeStart,
+                fileURI = None
+              )
+
+            tree
+              .rootNode
+              .filterDown(_.data.sourceIndex.exists(_ overlaps searchRange))
+              .collect {
+                case node @ Node(varDef: Ast.VarDeclaration, _) =>
+                  node.upcast(varDef)
+              }
+        }
+
+      case None =>
+        logger.trace(s"${InlayHintsCodeProvider.productPrefix}: Statement not found for rangeStart: $rangeStart. File: ${sourceCode.fileURI}")
+        Iterator.empty
+    }
+  }
+
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsCodeProvider.scala
@@ -46,7 +46,7 @@ private[search] case object InlayHintsCodeProvider extends CodeProvider[SourceCo
           )
       }
       .flatMap {
-        /**
+        /*
          * Convert type-definitions to inlay-hints.
          */
         case (_, Some(Left(error))) =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/inlayhints/multi/InlayHintsMultiCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/inlayhints/multi/InlayHintsMultiCodeProvider.scala
@@ -1,0 +1,49 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.pc.search.inlayhints.multi
+
+import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, LinePosition}
+import org.alephium.ralph.lsp.pc.PCStates
+import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
+import org.alephium.ralph.lsp.pc.PCSearcher.goTo
+import org.alephium.ralph.lsp.pc.search.MultiCodeProvider
+import org.alephium.ralph.lsp.utils.IsCancelled
+import org.alephium.ralph.lsp.utils.log.ClientLogger
+
+import java.net.URI
+import scala.collection.immutable.ArraySeq
+import scala.concurrent.{ExecutionContext, Future}
+
+private[search] case object InlayHintsMultiCodeProvider extends MultiCodeProvider[LinePosition, SourceLocation.InlayHint] {
+
+  /** @inheritdoc */
+  override def search(
+      fileURI: URI,
+      line: Int,
+      character: Int,
+      enableSoftParser: Boolean,
+      isCancelled: IsCancelled,
+      pcStates: PCStates,
+      settings: LinePosition
+    )(implicit logger: ClientLogger,
+      ec: ExecutionContext): Future[Either[CompilerMessage.Error, ArraySeq[SourceLocation.InlayHint]]] =
+    pcStates.get(fileURI) match {
+      case Left(error) =>
+        Future.successful(Left(error))
+
+      case Right(pcState) =>
+        val result =
+          goTo[SourceCodeState.Parsed, LinePosition, SourceLocation.InlayHint](
+            fileURI = fileURI,
+            line = line,
+            character = character,
+            searchSettings = settings,
+            isCancelled = isCancelled,
+            state = pcState
+          ).to(ArraySeq)
+
+        Future(Right(result))
+    }
+
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/inlayhints/multi/InlayHintsMultiCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/inlayhints/multi/InlayHintsMultiCodeProvider.scala
@@ -43,7 +43,7 @@ private[search] case object InlayHintsMultiCodeProvider extends MultiCodeProvide
             state = pcState
           ).to(ArraySeq)
 
-        Future(Right(result))
+        Future.successful(Right(result))
     }
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceLocation.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceLocation.scala
@@ -5,7 +5,7 @@ package org.alephium.ralph.lsp.pc.sourcecode
 
 import org.alephium.ralph.{Ast, SourceIndex}
 import org.alephium.ralph.lsp.access.compiler.ast.Tree
-import org.alephium.ralph.lsp.access.compiler.message.LineRange
+import org.alephium.ralph.lsp.access.compiler.message.{LinePosition, LineRange}
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.SourceIndexExtension
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
 import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
@@ -179,6 +179,33 @@ object SourceLocation extends StrictImplicitLogging {
 
     override def parsed: SourceCodeState.Parsed =
       source.parsed
+
+  }
+
+  /**
+   * Represents information for inlay-hints.
+   *
+   * @param position  Position where the inlay-hint should be displayed.
+   * @param parsed    Source code where the inlay-hint is to be shown.
+   * @param hint The string content of the hint to be displayed inline (e.g. the inferred type name).
+   * @param typeDef   The type definition associated with the hint.
+   */
+  case class InlayHint(
+      position: SourceIndex,
+      parsed: SourceCodeState.Parsed,
+      hint: String,
+      typeDef: GoToTypeDef)
+    extends GoTo {
+
+    override def index: Option[SourceIndex] =
+      Some(position)
+
+    def toLineRange(): Option[LineRange] =
+      index.map(_.toLineRange(parsed.code))
+
+    /** The position of the hint to be displayed inline */
+    def inlayHintPosition(): Option[LinePosition] =
+      toLineRange().map(_.from)
 
   }
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/TestCommon.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/TestCommon.scala
@@ -158,7 +158,15 @@ object TestCommon {
       code: Iterable[SourceLocation.GoTo]): Iterable[String] =
     code map {
       result =>
-        val index          = result.index.value
+        val index = {
+          val index = result.index.value
+          // If the width is `0`, ensure it is at least `1` so that the marker `^` is displayed in the error message.
+          if (index.width <= 0)
+            index.addToWidth(1)
+          else
+            index
+        }
+
         val error          = CompilerError(message, Some(index))
         val formattedError = error.toFormatter(result.parsed.code).format(Some(Console.RED))
         s"Index: $index\n$formattedError"

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
@@ -128,7 +128,7 @@ object TestCodeProvider {
     )
 
   def inlayHints(code: String): List[SourceLocation.InlayHint] = {
-    // Replace all `>>inlay: Hints<<` with `>><<` because `goTo` dos not process code that is not real,
+    // Replace all `>>inlay: Hints<<` with `>><<` because `goTo` does not process code that is not real,
     // and hints are not real code.
     val emptyRangeMarkers =
       code.replaceAll(""">>.+?<<""", ">><<")

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
@@ -5,7 +5,7 @@ package org.alephium.ralph.lsp.pc.search
 
 import org.alephium.ralph.lsp.TestCommon
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
-import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, LineRange}
+import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.access.util.{StringUtil, TestCodeUtil}
@@ -66,14 +66,14 @@ object TestCodeProvider {
    *
    * @param code The containing `@@` and `>>...<<` symbols.
    */
-  def goToDefinitionStrict(settings: GoToDefSetting = testGoToDefSetting)(code: String*): List[(URI, LineRange)] =
+  def goToDefinitionStrict(settings: GoToDefSetting = testGoToDefSetting)(code: String*): List[SourceLocation.GoToDefStrict] =
     goTo[SourceCodeState.Parsed, GoToDefSetting, SourceLocation.GoToDefStrict](
       code = code.to(ArraySeq),
       searchSettings = settings,
       dependencyDownloaders = ArraySeq.empty
     )
 
-  def goToDefinitionSoft(settings: GoToDefSetting = testGoToDefSetting)(code: String*): List[(URI, LineRange)] =
+  def goToDefinitionSoft(settings: GoToDefSetting = testGoToDefSetting)(code: String*): List[SourceLocation.GoToDefSoft] =
     goTo[SourceCodeState.IsParsed, (SoftAST.type, GoToDefSetting), SourceLocation.GoToDefSoft](
       code = code.to(ArraySeq),
       searchSettings = (SoftAST, settings),
@@ -81,12 +81,12 @@ object TestCodeProvider {
     )
 
   /** Executes go-to-definition providers for both StrictAST and [[SoftAST]] */
-  def goToDefinition(settings: GoToDefSetting = testGoToDefSetting)(code: String*): List[(URI, LineRange)] = {
+  def goToDefinition(settings: GoToDefSetting = testGoToDefSetting)(code: String*): List[SourceLocation.GoToDefSoft] = {
     val resultStrict       = goToDefinitionStrict(settings)(code: _*)
-    val resultStrictRanges = resultStrict.map(_._2)
+    val resultStrictRanges = resultStrict.map(_.toLineRange().value)
 
     val resultSoft       = goToDefinitionSoft(settings)(code: _*)
-    val resultSoftRanges = resultSoft.map(_._2)
+    val resultSoftRanges = resultSoft.map(_.toLineRange().value)
 
     // Assert that both go-to-def services (Strict & Soft) return the same result.
     resultSoftRanges should contain theSameElementsAs resultStrictRanges
@@ -106,21 +106,21 @@ object TestCodeProvider {
       code = code
     )
 
-  def goToReferences(settings: GoToRefSetting = testGoToRefSetting)(code: String*): List[(URI, LineRange)] =
+  def goToReferences(settings: GoToRefSetting = testGoToRefSetting)(code: String*): List[SourceLocation.GoToRefStrict] =
     goTo[SourceCodeState.Parsed, GoToRefSetting, SourceLocation.GoToRefStrict](
       code = code.to(ArraySeq),
       searchSettings = settings,
       dependencyDownloaders = ArraySeq.empty
     )
 
-  def goToRename(code: String*): List[(URI, LineRange)] =
+  def goToRename(code: String*): List[SourceLocation.GoToRenameStrict] =
     goTo[SourceCodeState.Parsed, Unit, SourceLocation.GoToRenameStrict](
       code = code.to(ArraySeq),
       searchSettings = (),
       dependencyDownloaders = ArraySeq.empty
     )
 
-  def goToTypeDef(code: String*): List[(URI, LineRange)] =
+  def goToTypeDef(code: String*): List[SourceLocation.GoToTypeDef] =
     goTo[SourceCodeState.Parsed, Unit, SourceLocation.GoToTypeDef](
       code = code.to(ArraySeq),
       searchSettings = (),
@@ -175,7 +175,7 @@ object TestCodeProvider {
         code = ArraySeq(code),
         searchSettings = settings,
         dependencyDownloaders = ArraySeq.empty
-      ).map(_._2)
+      ).map(_.toLineRange().value)
 
     // remove the select indicator @@ from the code.
     val codeWithoutSelectSymbol =
@@ -221,7 +221,7 @@ object TestCodeProvider {
               code = ArraySeq(newCode),
               searchSettings = settings,
               dependencyDownloaders = ArraySeq.empty
-            ).map(_._2)
+            ).map(_.toLineRange().value)
           }
 
         // also check that the result is the same as the first ranges returned on declaration.
@@ -244,7 +244,7 @@ object TestCodeProvider {
       code: ArraySeq[String],
       searchSettings: I,
       dependencyDownloaders: ArraySeq[DependencyDownloader.Native]
-    )(implicit codeProvider: CodeProvider[S, I, O]): List[(URI, LineRange)] = {
+    )(implicit codeProvider: CodeProvider[S, I, O]): List[O] = {
     val expectedLineRanges =
       TestCodeUtil.extractLineRangeInfo(code)
 
@@ -295,7 +295,7 @@ object TestCodeProvider {
       actual should contain theSameElementsAs expectedGoToLocations
     }
 
-    actual
+    searchResultList
   }
 
   /**

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsSingleVariableSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsSingleVariableSpec.scala
@@ -68,7 +68,7 @@ class InlayHintsSingleVariableSpec extends AnyWordSpec with Matchers {
       }
     }
 
-    "return non-empty" when {
+    "return non-empty for immutable" when {
       "the range position is at the root" in {
         inlayHints(
           """
@@ -114,6 +114,59 @@ class InlayHintsSingleVariableSpec extends AnyWordSpec with Matchers {
             |Contract Test() {
             |  fn test() -> () {
             |    let @@ one>>: U256<< = 1
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+    }
+
+    "return non-empty mutable" when {
+      "the range position is at the root" in {
+        inlayHints(
+          """
+            |@@
+            |Contract Test() {
+            |  fn test() -> () {
+            |    let mut one>>: U256<< = 1
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+
+      "range position is within the contract" in {
+        inlayHints(
+          """
+            |Contract Test() {
+            |  @@
+            |  fn test() -> () {
+            |    let mut one>>: U256<< = 1
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+
+      "range position is within the function" in {
+        inlayHints(
+          """
+            |Contract Test() {
+            |  fn test() -> () {
+            |    @@
+            |    let mut one>>: U256<< = 1
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+
+      "range position is within the variable" in {
+        inlayHints(
+          """
+            |Contract Test() {
+            |  fn test() -> () {
+            |    let mut @@ one>>: U256<< = 1
             |  }
             |}
             |""".stripMargin

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsSingleVariableSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsSingleVariableSpec.scala
@@ -1,0 +1,238 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.pc.search.inlayhints
+
+import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class InlayHintsSingleVariableSpec extends AnyWordSpec with Matchers {
+
+  /**
+   * **********************************
+   * Test cases: Named single variable.
+   * **********************************
+   */
+  "named variable" should {
+    "return empty" when {
+      "the range position is at the end" in {
+        inlayHints(
+          """
+            |Contract Test() {
+            |  fn test() -> () {
+            |    let one = 1
+            |  }
+            |}
+            |@@
+            |""".stripMargin
+        )
+      }
+
+      "range position is within the contract" in {
+        inlayHints(
+          """
+            |Contract Test() {
+            |  fn test() -> () {
+            |    let one = 1
+            |  }
+            |  @@
+            |}
+            |""".stripMargin
+        )
+      }
+
+      "range position is within the function" in {
+        inlayHints(
+          """
+            |Contract Test() {
+            |  fn test() -> () {
+            |    let one = 1
+            |    @@
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+
+      "range position is within the variable" in {
+        inlayHints(
+          """
+            |Contract Test() {
+            |  fn test() -> () {
+            |    let one = 1  @@
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+    }
+
+    "return non-empty" when {
+      "the range position is at the root" in {
+        inlayHints(
+          """
+            |@@
+            |Contract Test() {
+            |  fn test() -> () {
+            |    let one>>: U256<< = 1
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+
+      "range position is within the contract" in {
+        inlayHints(
+          """
+            |Contract Test() {
+            |  @@
+            |  fn test() -> () {
+            |    let one>>: U256<< = 1
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+
+      "range position is within the function" in {
+        inlayHints(
+          """
+            |Contract Test() {
+            |  fn test() -> () {
+            |    @@
+            |    let one>>: U256<< = 1
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+
+      "range position is within the variable" in {
+        inlayHints(
+          """
+            |Contract Test() {
+            |  fn test() -> () {
+            |    let @@ one>>: U256<< = 1
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+    }
+  }
+
+  /**
+   * ************************************
+   * Test cases: Unnamed single variable.
+   * ************************************
+   */
+  "anonymous variable" should {
+    "return empty" when {
+      "the range position is at the end" in {
+        inlayHints(
+          """
+            |Contract Test() {
+            |  fn test() -> () {
+            |    let _ = 1
+            |  }
+            |}
+            |@@
+            |""".stripMargin
+        )
+      }
+
+      "range position is within the contract" in {
+        inlayHints(
+          """
+            |Contract Test() {
+            |  fn test() -> () {
+            |    let _ = 1
+            |  }
+            |  @@
+            |}
+            |""".stripMargin
+        )
+      }
+
+      "range position is within the function" in {
+        inlayHints(
+          """
+            |Contract Test() {
+            |  fn test() -> () {
+            |    let _ = 1
+            |    @@
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+
+      "range position is within the variable" in {
+        inlayHints(
+          """
+            |Contract Test() {
+            |  fn test() -> () {
+            |    let _ = 1  @@
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+    }
+
+    "return non-empty" when {
+      "the range position is at the root" in {
+        inlayHints(
+          """
+            |@@
+            |Contract Test() {
+            |  fn test() -> () {
+            |    let _>>: U256<< = 1
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+
+      "range position is within the contract" in {
+        inlayHints(
+          """
+            |Contract Test() {
+            |  @@
+            |  fn test() -> () {
+            |    let _>>: U256<< = 1
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+
+      "range position is within the function" in {
+        inlayHints(
+          """
+            |Contract Test() {
+            |  fn test() -> () {
+            |    @@
+            |    let _>>: U256<< = 1
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+
+      "range position is within the variable" in {
+        inlayHints(
+          """
+            |Contract Test() {
+            |  fn test() -> () {
+            |    let @@ _>>: U256<< = 1
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+    }
+  }
+
+}

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsTupledVariableSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsTupledVariableSpec.scala
@@ -40,7 +40,7 @@ class InlayHintsTupledVariableSpec extends AnyWordSpec with Matchers {
           |  @@
           |  fn test() -> () {
           |    let (one>>: U256<<,
-          |         bool>>: Bool<<) = tuple()
+          |         mut bool>>: Bool<<) = tuple()
           |  }
           |
           |  fn tuple() -> (U256, Bool) {
@@ -58,7 +58,7 @@ class InlayHintsTupledVariableSpec extends AnyWordSpec with Matchers {
           |
           |  fn test() -> () {
           |    @@
-          |    let (one>>: U256<<,
+          |    let (mut one>>: U256<<,
           |         bool>>: Bool<<) = tuple()
           |  }
           |

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsTupledVariableSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsTupledVariableSpec.scala
@@ -1,0 +1,326 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.pc.search.inlayhints
+
+import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class InlayHintsTupledVariableSpec extends AnyWordSpec with Matchers {
+
+  /**
+   * **********************************
+   * Test cases: Named tupled variable.
+   * **********************************
+   */
+  "return non-empty named variables" when {
+    "range is at the root" in {
+      inlayHints(
+        """
+          |@@
+          |Contract Test() {
+          |  fn test() -> () {
+          |    let (one>>: U256<<,
+          |         bool>>: Bool<<) = tuple()
+          |  }
+          |
+          |  fn tuple() -> (U256, Bool) {
+          |    return (1, true)
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
+
+    "range is in the contract" in {
+      inlayHints(
+        """
+          |Contract Test() {
+          |  @@
+          |  fn test() -> () {
+          |    let (one>>: U256<<,
+          |         bool>>: Bool<<) = tuple()
+          |  }
+          |
+          |  fn tuple() -> (U256, Bool) {
+          |    return (1, true)
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
+
+    "range is in the function" in {
+      inlayHints(
+        """
+          |Contract Test() {
+          |
+          |  fn test() -> () {
+          |    @@
+          |    let (one>>: U256<<,
+          |         bool>>: Bool<<) = tuple()
+          |  }
+          |
+          |  fn tuple() -> (U256, Bool) {
+          |    return (1, true)
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
+
+    "range is in the variable" in {
+      inlayHints(
+        """
+          |Contract Test() {
+          |
+          |  fn test() -> () {
+          |    let (@@ one>>: U256<<,
+          |         bool>>: Bool<<) = tuple()
+          |  }
+          |
+          |  fn tuple() -> (U256, Bool) {
+          |    return (1, true)
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
+
+    "range is at after the first variable" in {
+      inlayHints(
+        """
+          |Contract Test() {
+          |
+          |  fn test() -> () {
+          |    // Note: One will receive no hint 
+          |    let (one,
+          |         @@
+          |         bool>>: Bool<<) = tuple()
+          |  }
+          |
+          |  fn tuple() -> (U256, Bool) {
+          |    return (1, true)
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
+  }
+
+  "return empty named variables" when {
+    "range is at the end" in {
+      inlayHints(
+        """
+          |Contract Test() {
+          |  fn test() -> () {
+          |    let (one, bool) = tuple()
+          |  }
+          |
+          |  fn tuple() -> (U256, Bool) {
+          |    return (1, true)
+          |  }
+          |}
+          |@@
+          |""".stripMargin
+      )
+    }
+
+    "range is in the contract" in {
+      inlayHints(
+        """
+          |Contract Test() {
+          |  fn test() -> () {
+          |    let (one, bool) = tuple()
+          |  }
+          |
+          |  @@
+          |  
+          |  fn tuple() -> (U256, Bool) {
+          |    return (1, true)
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
+
+    "range is in the function" in {
+      inlayHints(
+        """
+          |Contract Test() {
+          |
+          |  fn test() -> () {
+          |    let (one, bool) = tuple()
+          |    @@
+          |  }
+          |  
+          |
+          |  fn tuple() -> (U256, Bool) {
+          |    return (1, true)
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
+  }
+
+  /**
+   * ************************************
+   * Test cases: Unnamed tupled variable.
+   * ************************************
+   */
+  "return non-empty unnamed variables" when {
+    "range is at the root" in {
+      inlayHints(
+        """
+          |@@
+          |Contract Test() {
+          |  fn test() -> () {
+          |    let (_>>: U256<<,
+          |         _>>: Bool<<) = tuple()
+          |  }
+          |
+          |  fn tuple() -> (U256, Bool) {
+          |    return (1, true)
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
+
+    "range is in the contract" in {
+      inlayHints(
+        """
+          |Contract Test() {
+          |  @@
+          |  fn test() -> () {
+          |    let (_>>: U256<<,
+          |         _>>: Bool<<) = tuple()
+          |  }
+          |
+          |  fn tuple() -> (U256, Bool) {
+          |    return (1, true)
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
+
+    "range is in the function" in {
+      inlayHints(
+        """
+          |Contract Test() {
+          |
+          |  fn test() -> () {
+          |    @@
+          |    let (_>>: U256<<,
+          |         _>>: Bool<<) = tuple()
+          |  }
+          |
+          |  fn tuple() -> (U256, Bool) {
+          |    return (1, true)
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
+
+    "range is in the variable" in {
+      inlayHints(
+        """
+          |Contract Test() {
+          |
+          |  fn test() -> () {
+          |    let (@@ _>>: U256<<,
+          |         _>>: Bool<<) = tuple()
+          |  }
+          |
+          |  fn tuple() -> (U256, Bool) {
+          |    return (1, true)
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
+
+    "range is at after the first variable" in {
+      inlayHints(
+        """
+          |Contract Test() {
+          |
+          |  fn test() -> () {
+          |    // Note: _ will receive no hint
+          |    let (_,
+          |         @@
+          |         _>>: Bool<<) = tuple()
+          |  }
+          |
+          |  fn tuple() -> (U256, Bool) {
+          |    return (1, true)
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
+  }
+
+  "return empty unnamed variables" when {
+    "range is at the end" in {
+      inlayHints(
+        """
+          |Contract Test() {
+          |  fn test() -> () {
+          |    let (_,
+          |         _) = tuple()
+          |  }
+          |
+          |  fn tuple() -> (U256, Bool) {
+          |    return (1, true)
+          |  }
+          |}
+          |@@
+          |""".stripMargin
+      )
+    }
+
+    "range is in the contract" in {
+      inlayHints(
+        """
+          |Contract Test() {
+          |  fn test() -> () {
+          |    let (_,
+          |         _) = tuple()
+          |  }
+          |
+          |  @@
+          |
+          |  fn tuple() -> (U256, Bool) {
+          |    return (1, true)
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
+
+    "range is in the function" in {
+      inlayHints(
+        """
+          |Contract Test() {
+          |
+          |  fn test() -> () {
+          |    let (_, _) = tuple()
+          |    @@
+          |  }
+          |
+          |
+          |  fn tuple() -> (U256, Bool) {
+          |    return (1, true)
+          |  }
+          |}
+          |""".stripMargin
+      )
+    }
+  }
+
+}

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsTupledVariableSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsTupledVariableSpec.scala
@@ -271,8 +271,7 @@ class InlayHintsTupledVariableSpec extends AnyWordSpec with Matchers {
         """
           |Contract Test() {
           |  fn test() -> () {
-          |    let (_,
-          |         _) = tuple()
+          |    let (_, _) = tuple()
           |  }
           |
           |  fn tuple() -> (U256, Bool) {
@@ -289,8 +288,7 @@ class InlayHintsTupledVariableSpec extends AnyWordSpec with Matchers {
         """
           |Contract Test() {
           |  fn test() -> () {
-          |    let (_,
-          |         _) = tuple()
+          |    let (_, _) = tuple()
           |  }
           |
           |  @@


### PR DESCRIPTION
- Towards #256
- Performance note: Inlay hints are computed only for the nodes within the range (screen range) provided by the client. VSCode seems to set this range to the visible screen area.
