### PR TITLE
Towards disallow direct `CodeProvider` access that skips dependency search

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PCSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PCSearcher.scala
@@ -23,7 +23,7 @@ object PCSearcher extends StrictImplicitLogging {
    * @param searchSettings Settings defined for the input [[CodeProvider]].
    * @param isCancelled    Cancellation support instance.
    * @param state          Current presentation-compiler state.
-   * @param codeProvider   Target [[CodeProvider]] to use for responding to this request.
+   * @param provider       Target [[CodeProvider]] to use for responding to this request.
    * @param logger         Remote client and local logger.
    * @tparam I The type of input [[CodeProvider]] settings.
    * @tparam O The type of [[CodeProvider]] function output.
@@ -36,7 +36,7 @@ object PCSearcher extends StrictImplicitLogging {
       searchSettings: I,
       isCancelled: IsCancelled,
       state: PCState
-    )(implicit codeProvider: CodeProvider[S, I, O],
+    )(implicit provider: CodeProvider[S, I, O],
       logger: ClientLogger): Iterator[O] =
     if (!isFileScheme(fileURI) || isCancelled.check())
       Iterator.empty
@@ -44,7 +44,7 @@ object PCSearcher extends StrictImplicitLogging {
       state.workspace match {
         case sourceAware: WorkspaceState.IsSourceAware =>
           val goToResult =
-            CodeProvider.search[S, I, O](
+            provider.search(
               line = line,
               character = character,
               fileURI = fileURI,
@@ -62,7 +62,7 @@ object PCSearcher extends StrictImplicitLogging {
 
               case Some(Left(error)) =>
                 // Go-to definition failed: Log the error message
-                logger.info(s"${codeProvider.productPrefix} unsuccessful: " + error.message)
+                logger.info(s"${provider.productPrefix} unsuccessful: " + error.message)
                 Iterator.empty
 
               case None =>
@@ -73,7 +73,7 @@ object PCSearcher extends StrictImplicitLogging {
         case _: WorkspaceState.Created =>
           // Workspace must be compiled at least once to enable GoTo definition.
           // The server must've invoked the initial compilation in the boot-up initialize function.
-          logger.info(s"${codeProvider.productPrefix} unsuccessful: Workspace is not compiled")
+          logger.info(s"${provider.productPrefix} unsuccessful: Workspace is not compiled")
           Iterator.empty
       }
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/CodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/CodeProvider.scala
@@ -10,9 +10,9 @@ import org.alephium.ralph.lsp.pc.search.completion.{CodeCompletionProvider, Sugg
 import org.alephium.ralph.lsp.pc.search.gotodef.{GoToDefCodeProvider, GoToDefSetting}
 import org.alephium.ralph.lsp.pc.search.gotodef.soft.GoToDefCodeProviderSoft
 import org.alephium.ralph.lsp.pc.search.gotoref.{GoToRefCodeProvider, GoToRefSetting}
-import org.alephium.ralph.lsp.pc.search.rename.GoToRenameCodeProvider
 import org.alephium.ralph.lsp.pc.search.gototypedef.GoToTypeDefCodeProvider
 import org.alephium.ralph.lsp.pc.search.inlayhints.InlayHintsCodeProvider
+import org.alephium.ralph.lsp.pc.search.rename.GoToRenameCodeProvider
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
 import org.alephium.ralph.lsp.pc.workspace.{WorkspaceSearcher, WorkspaceState}
 import org.alephium.ralph.lsp.utils.log.ClientLogger
@@ -31,7 +31,7 @@ import java.net.URI
 trait CodeProvider[S, I, O] extends Product {
 
   /**
-   * Performs a search operation at the cursor index within the source-code of a workspace.
+   * Searches the source-code of a workspace at the given cursor index, excluding any workspace dependencies.
    *
    * @param cursorIndex    The index (character offset) in the source code representing the cursor position.
    * @param sourceCode     The source code state where the search is executed.
@@ -39,7 +39,7 @@ trait CodeProvider[S, I, O] extends Product {
    * @param searchSettings Provider-specific settings.
    * @return Search results.
    */
-  def search(
+  def searchLocal(
       cursorIndex: Int,
       sourceCode: S,
       workspace: WorkspaceState.IsSourceAware,
@@ -203,7 +203,7 @@ object CodeProvider {
               )
 
             // execute the search
-            provider.search(
+            provider.searchLocal(
               cursorIndex = cursorIndex,
               sourceCode = parsed.asInstanceOf[S],
               workspace = workspace,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/CodeCompletionProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/CodeCompletionProvider.scala
@@ -13,13 +13,11 @@ import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 
 /**
  * Implements [[CodeProvider]] that provides code completion results of type [[Suggestion]].
- *
- * To execution this function invoke [[CodeProvider.search]] with [[Suggestion]] as type parameter.
  */
 private[search] case object CodeCompletionProvider extends CodeProvider[SourceCodeState.Parsed, Unit, Suggestion] with StrictImplicitLogging {
 
   /** @inheritdoc */
-  override def search(
+  override def searchLocal(
       cursorIndex: Int,
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/multi/CompletionMultiCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/multi/CompletionMultiCodeProvider.scala
@@ -6,7 +6,6 @@ package org.alephium.ralph.lsp.pc.search.completion.multi
 import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.pc.search.{CodeProvider, MultiCodeProvider}
 import org.alephium.ralph.lsp.pc.search.completion.Suggestion
-import org.alephium.ralph.lsp.pc.sourcecode.SourceCodeState
 import org.alephium.ralph.lsp.pc.PCStates
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
@@ -76,13 +75,15 @@ private[search] case object CompletionMultiCodeProvider extends MultiCodeProvide
       workspace match {
         case sourceAware: WorkspaceState.IsSourceAware =>
           val completionResult =
-            CodeProvider.search[SourceCodeState.Parsed, Unit, Suggestion](
-              line = line,
-              character = character,
-              fileURI = fileURI,
-              workspace = sourceAware,
-              searchSettings = ()
-            )
+            CodeProvider
+              .codeCompleter
+              .search(
+                line = line,
+                character = character,
+                fileURI = fileURI,
+                workspace = sourceAware,
+                searchSettings = ()
+              )
 
           completionResult match {
             case Some(Right(suggestions)) =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefCodeProvider.scala
@@ -13,13 +13,11 @@ import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 
 /**
  * Implements [[CodeProvider]] that provides go-to definition results of type [[SourceLocation.GoToDefStrict]].
- *
- * To execution this function invoke [[CodeProvider.search]] with [[SourceLocation.GoToDefStrict]] as type parameter.
  */
 private[search] case object GoToDefCodeProvider extends CodeProvider[SourceCodeState.Parsed, GoToDefSetting, SourceLocation.GoToDefStrict] with StrictImplicitLogging {
 
   /** @inheritdoc */
-  override def search(
+  override def searchLocal(
       cursorIndex: Int,
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefCodeProviderSoft.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefCodeProviderSoft.scala
@@ -15,7 +15,7 @@ import org.alephium.ralph.lsp.utils.Node
 case object GoToDefCodeProviderSoft extends CodeProvider[SourceCodeState.IsParsed, (SoftAST.type, GoToDefSetting), SourceLocation.GoToDefSoft] with StrictImplicitLogging {
 
   /** @inheritdoc */
-  override def search(
+  override def searchLocal(
       cursorIndex: Int,
       sourceCode: SourceCodeState.IsParsed,
       workspace: WorkspaceState.IsSourceAware,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefCodeProvider.scala
@@ -12,13 +12,11 @@ import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 
 /**
  * Implements [[CodeProvider]] that provides go-to references results of type [[SourceLocation.GoToRefStrict]].
- *
- * To execution this function invoke [[CodeProvider.search]] with [[Boolean]] and [[SourceLocation.GoToRefStrict]] as type parameter.
  */
 private[search] case object GoToRefCodeProvider extends CodeProvider[SourceCodeState.Parsed, GoToRefSetting, SourceLocation.GoToRefStrict] with StrictImplicitLogging {
 
   /** @inheritdoc */
-  override def search(
+  override def searchLocal(
       cursorIndex: Int,
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefIdent.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefIdent.scala
@@ -601,7 +601,7 @@ private object GoToRefIdent extends StrictImplicitLogging {
       referenceSourceIndex =>
         CodeProvider
           .goToDef
-          .search(
+          .searchLocal(
             cursorIndex = referenceSourceIndex.index,
             sourceCode = sourceCode.parsed,
             workspace = workspace,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefSource.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefSource.scala
@@ -29,7 +29,7 @@ private object GoToRefSource extends StrictImplicitLogging {
     )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     CodeProvider
       .goToDef
-      .search( // find definitions for the token at the given cursorIndex.
+      .searchLocal( // find definitions for the token at the given cursorIndex.
         cursorIndex = cursorIndex,
         sourceCode = sourceCode,
         workspace = workspace,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gototypedef/GoToTypeDefCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gototypedef/GoToTypeDefCodeProvider.scala
@@ -23,7 +23,7 @@ case object GoToTypeDefCodeProvider extends CodeProvider[SourceCodeState.Parsed,
    * @param searchSettings Provider-specific settings.
    * @return Search results.
    */
-  override def search(
+  override def searchLocal(
       cursorIndex: Int,
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsCodeProvider.scala
@@ -113,7 +113,8 @@ private[search] case object InlayHintsCodeProvider extends CodeProvider[SourceCo
           // Find all type definitions at the range.
           val typeDefinitions =
             CodeProvider
-              .search[SourceCodeState.Parsed, Unit, SourceLocation.GoToTypeDef](
+              .goToTypeDef
+              .search(
                 line = varRange.from.line,
                 character = varRange.from.character,
                 fileURI = sourceCode.fileURI,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsCodeProvider.scala
@@ -17,12 +17,12 @@ import org.alephium.ralph.lsp.utils.Node
 /**
  * Implements [[CodeProvider]] that provides go-to definition results of type [[SourceLocation.InlayHint]].
  *
- * To execution this function invoke [[CodeProvider.search]] with [[SourceLocation.InlayHint]] as type parameter.
+ * To execution this function invoke [[CodeProvider.searchLocal]] with [[SourceLocation.InlayHint]] as type parameter.
  */
 private[search] case object InlayHintsCodeProvider extends CodeProvider[SourceCodeState.Parsed, LinePosition, SourceLocation.InlayHint] with StrictImplicitLogging {
 
   /** @inheritdoc */
-  override def search(
+  override def searchLocal(
       rangeStart: Int,
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/rename/GoToRenameAll.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/rename/GoToRenameAll.scala
@@ -96,7 +96,7 @@ private object GoToRenameAll extends StrictImplicitLogging {
         sourceCode: SourceCodeState.Parsed): Unit =
       CodeProvider
         .goToRef
-        .search(
+        .searchLocal(
           cursorIndex = cursorIndex,
           sourceCode = sourceCode,
           workspace = workspace,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/rename/GoToRenameCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/rename/GoToRenameCodeProvider.scala
@@ -14,7 +14,7 @@ import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 private[search] case object GoToRenameCodeProvider extends CodeProvider[SourceCodeState.Parsed, Unit, SourceLocation.GoToRenameStrict] {
 
   /** @inheritdoc */
-  override def search(
+  override def searchLocal(
       cursorIndex: Int,
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware,

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
@@ -208,7 +208,7 @@ object TestCodeProvider {
       replacer: String,
       settings: I,
       code: String
-    )(implicit codeProvider: CodeProvider[S, I, O]): Unit = {
+    )(implicit provider: CodeProvider[S, I, O]): Unit = {
     // Initially, execute the test defined.
     // This should be most expressed on the declaration.
     val firstResult =
@@ -285,7 +285,7 @@ object TestCodeProvider {
       code: ArraySeq[String],
       searchSettings: I,
       dependencyDownloaders: ArraySeq[DependencyDownloader.Native]
-    )(implicit codeProvider: CodeProvider[S, I, O]): List[O] = {
+    )(implicit provider: CodeProvider[S, I, O]): List[O] = {
     val expectedLineRanges =
       TestCodeUtil.extractLineRangeInfo(code)
 
@@ -474,7 +474,7 @@ object TestCodeProvider {
       dependency: String,
       workspace: String,
       searchSettings: I
-    )(implicit codeProvider: CodeProvider[S, I, O]): Unit = {
+    )(implicit provider: CodeProvider[S, I, O]): Unit = {
     implicit val clientLogger: ClientLogger = TestClientLogger
     implicit val file: FileAccess           = FileAccess.disk
     implicit val compiler: CompilerAccess   = CompilerAccess.ralphc
@@ -863,7 +863,7 @@ object TestCodeProvider {
 
     // execute code-provider.
     val result =
-      CodeProvider.search(
+      provider.search(
         line = line,
         character = character,
         fileURI = selectedFileURI,


### PR DESCRIPTION
- Used in #404.
- Towards #453
