### PR TITLE
Resolves FIXMEs: Implements copying a tree with a new `SourceIndex`

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -798,7 +798,7 @@ object SoftAST {
       copies.head
     }
 
-    /**
+    /*
      * Copies/Updates [[SourceIndex]] instances in the given `field` of the [[rootNode]] and appends the result to input buffer.
      *
      * @param field         A field within the root node to copy.

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftASTSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftASTSpec.scala
@@ -1,0 +1,56 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft.ast
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class SoftASTSpec extends AnyWordSpec with Matchers {
+
+  "deepCopy" should {
+
+    /**
+     * The function [[SoftAST.deepCopy]] is well tested in [[TestParser.runSoftParser]]
+     * by piggybacking on all existing parser test-cases.
+     *
+     * The following test is only to assert large trees.
+     */
+    "copy all instances of SourceIndex in a large SoftAST tree" in {
+      // Some random code.
+      val randomCode =
+        parseSoft(
+          """
+            |// Comment one
+            |// Comment two
+            |
+            |Contract MyContract() {
+            |  fn function() ->
+            |}
+            |
+            |let thereBeLight = 1
+            |const hello = 0
+            |
+            |Contract AnotherContract() {
+            |  fn function() -> {
+            |    while(true) {
+            |      // do something funky
+            |    }
+            |
+            |     {
+            |       for (a; b; c) {
+            |          let copy = object.variable.function().cache.function()
+            |       }
+            |     }
+            |  }
+            |}
+            |""".stripMargin
+        )
+
+      TestParser.testDeepCopy(randomCode)
+    }
+  }
+
+}

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToLocalVariableSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToLocalVariableSpec.scala
@@ -726,4 +726,54 @@ class GoToLocalVariableSpec extends AnyWordSpec with Matchers {
     }
   }
 
+  /**
+   * Asserts inheritance search where virtual nodes are created.
+   */
+  "Inheritance using virtual nodes" when {
+    "Parent is missing closing block and the last function contains the same identifier" in {
+      goToDefinitionSoft()(
+        """
+          |Contract Parent {
+          |
+          |  let >>one<< = 1
+          |
+          |  def function() {
+          |    // Even though the Parent is missing the closing block
+          |    // this `one` is still out of scope for the `Child` contract.
+          |    let one = 1
+          |  }
+          |""".stripMargin,
+        """
+          |Contract Child extends Parent {
+          |   let >>one<< = on@@e.two()
+          |}
+          |""".stripMargin
+      )
+    }
+
+    "Parent and the function both are missing closing blocks and the last function contains the same identifier" in {
+      pendingUntilFixed {
+        val _ =
+          goToDefinitionSoft()(
+            """
+              |Contract Parent {
+              |
+              |  let >>one<< = 1
+              |
+              |  def function() {
+              |    // This `one` escapes the scope of the function and is therefore
+              |    // accessible by the `Child`.
+              |    // This needs to be fixed. 
+              |    let one = 1
+              |""".stripMargin,
+            """
+              |Contract Child extends Parent {
+              |   let >>one<< = on@@e.two()
+              |}
+              |""".stripMargin
+          )
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Resolves the following FIXMEs. 

Removes the need for the assumption made here:

https://github.com/alephium/ralph-lsp/blob/fe8cff1001acc3990f5cfdb4d17f4beaa13a924d/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala#L579-L580

The function `updateSourceIndex` mentioned here is named `deepCopy`:

https://github.com/alephium/ralph-lsp/blob/fe8cff1001acc3990f5cfdb4d17f4beaa13a924d/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala#L526-L529

Note: The trees being copied are very small.

Towards #404.
