### PR TITLE
Improves `detectCallSyntax`

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -546,15 +546,10 @@ object SoftAST {
       index: SourceIndex,
       leftExpression: ExpressionAST,
       preDotSpace: Option[Space],
-      dotCalls: Seq[DotCall])
-    extends ExpressionAST
-
-  case class DotCall(
-      index: SourceIndex,
       dot: TokenDocumented[Token.Dot.type],
       postDotSpace: Option[Space],
       rightExpression: ExpressionAST)
-    extends SoftAST
+    extends ExpressionAST
 
   case class Emit(
       index: SourceIndex,

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentParserSpec.scala
@@ -110,8 +110,10 @@ class AssignmentParserSpec extends AnyWordSpec with Matchers {
         // left expression is a method call
         val methodCall = assignment.expressionLeft.asInstanceOf[SoftAST.MethodCall]
         methodCall.index shouldBe indexOf(">>obj.func(param).counter<< = 0")
-        val objectName = methodCall.leftExpression.asInstanceOf[SoftAST.Identifier]
-        objectName.code.text shouldBe "obj"
+        val leftMethodCall = methodCall.leftExpression.asInstanceOf[SoftAST.MethodCall]
+        leftMethodCall.toCode() shouldBe "obj.func(param)"
+        val rightIdent = methodCall.rightExpression.asInstanceOf[SoftAST.Identifier]
+        rightIdent.code.text shouldBe "counter"
 
         // right expression is a number
         val number = assignment.expressionRight.asInstanceOf[SoftAST.Number]
@@ -129,8 +131,6 @@ class AssignmentParserSpec extends AnyWordSpec with Matchers {
         // left expression is a method call
         val left = assignment.expressionLeft.asInstanceOf[SoftAST.MethodCall]
         left.index shouldBe indexOf(">>obj.func(param).counter<< = cache.getNumber()")
-        val objectName = left.leftExpression.asInstanceOf[SoftAST.Identifier]
-        objectName.code.text shouldBe "obj"
 
         // right expression is also a method call
         val right = assignment.expressionRight.asInstanceOf[SoftAST.MethodCall]
@@ -148,8 +148,6 @@ class AssignmentParserSpec extends AnyWordSpec with Matchers {
         // left expression is a method call
         val methodCall = assignment.expressionLeft.asInstanceOf[SoftAST.MethodCall]
         methodCall.index shouldBe indexOf(">>obj.func(param).counter<< = 0")
-        val objectName = methodCall.leftExpression.asInstanceOf[SoftAST.Identifier]
-        objectName.code.text shouldBe "obj"
 
         // right expression is a number
         assignment.expressionRight shouldBe

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/EmitParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/EmitParserSpec.scala
@@ -83,25 +83,20 @@ class EmitParserSpec extends AnyWordSpec with Matchers {
             index = indexOf("emit >>contract.createEvent()<<"),
             leftExpression = Identifier("emit >>contract<<.createEvent()"),
             preDotSpace = None,
-            dotCalls = Seq(
-              SoftAST.DotCall(
-                index = indexOf("emit contract>>.createEvent()<<"),
-                dot = Dot("emit contract>>.<<createEvent()"),
-                postDotSpace = None,
-                rightExpression = SoftAST.ReferenceCall(
-                  index = indexOf("emit contract.>>createEvent()<<"),
-                  reference = Identifier("emit contract.>>createEvent<<()"),
-                  preArgumentsSpace = None,
-                  arguments = SoftAST.Group(
-                    index = indexOf("emit contract.createEvent>>()<<"),
-                    openToken = Some(OpenParen("emit contract.createEvent>>(<<)")),
-                    preHeadExpressionSpace = None,
-                    headExpression = None,
-                    postHeadExpressionSpace = None,
-                    tailExpressions = Seq.empty,
-                    closeToken = Some(CloseParen("emit contract.createEvent(>>)<<"))
-                  )
-                )
+            dot = Dot("emit contract>>.<<createEvent()"),
+            postDotSpace = None,
+            rightExpression = SoftAST.ReferenceCall(
+              index = indexOf("emit contract.>>createEvent()<<"),
+              reference = Identifier("emit contract.>>createEvent<<()"),
+              preArgumentsSpace = None,
+              arguments = SoftAST.Group(
+                index = indexOf("emit contract.createEvent>>()<<"),
+                openToken = Some(OpenParen("emit contract.createEvent>>(<<)")),
+                preHeadExpressionSpace = None,
+                headExpression = None,
+                postHeadExpressionSpace = None,
+                tailExpressions = Seq.empty,
+                closeToken = Some(CloseParen("emit contract.createEvent(>>)<<"))
               )
             )
           )

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MethodCallParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MethodCallParserSpec.scala
@@ -39,80 +39,113 @@ class MethodCallParserSpec extends AnyWordSpec with Matchers {
   "pass" when {
     "dot is provided" when {
       "no expressions" in {
-        val dot = parseMethodCall(".")
+        val method = parseMethodCall(".")
 
-        dot shouldBe
+        method shouldBe
           SoftAST.MethodCall(
             index = indexOf(">>.<<"),
             leftExpression = ExpressionExpected(">><<."),
             preDotSpace = None,
-            dotCalls = Seq(
-              SoftAST.DotCall(
-                index = indexOf(">>.<<"),
-                dot = Dot(">>.<<"),
-                postDotSpace = None,
-                rightExpression = ExpressionExpected(".>><<")
-              )
-            )
+            dot = Dot(">>.<<"),
+            postDotSpace = None,
+            rightExpression = ExpressionExpected(".>><<")
           )
       }
 
       "no left expression" in {
-        val dot = parseMethodCall(".right")
+        val method = parseMethodCall(".right")
 
-        dot shouldBe
+        method shouldBe
           SoftAST.MethodCall(
             index = indexOf(">>.right<<"),
             leftExpression = ExpressionExpected(">><<.right"),
             preDotSpace = None,
-            dotCalls = Seq(
-              SoftAST.DotCall(
-                index = indexOf(">>.right<<"),
-                dot = Dot(">>.<<right"),
-                postDotSpace = None,
-                rightExpression = Identifier(".>>right<<")
-              )
-            )
+            dot = Dot(">>.<<right"),
+            postDotSpace = None,
+            rightExpression = Identifier(".>>right<<")
           )
       }
 
       "no right expression" in {
-        val dot = parseMethodCall("left.")
+        val method = parseMethodCall("left.")
 
-        dot shouldBe
+        method shouldBe
           SoftAST.MethodCall(
             index = indexOf(">>left.<<"),
             leftExpression = Identifier(">>left<<."),
             preDotSpace = None,
-            dotCalls = Seq(
-              SoftAST.DotCall(
-                index = indexOf("left>>.<<"),
-                dot = Dot("left>>.<<"),
-                postDotSpace = None,
-                rightExpression = ExpressionExpected("left.>><<")
-              )
-            )
+            dot = Dot("left>>.<<"),
+            postDotSpace = None,
+            rightExpression = ExpressionExpected("left.>><<")
           )
       }
 
       "with expressions" in {
-        val dot = parseMethodCall("left.right")
+        val method = parseMethodCall("left.right")
 
-        dot shouldBe
+        method shouldBe
           SoftAST.MethodCall(
             index = indexOf(">>left.right<<"),
             leftExpression = Identifier(">>left<<.right"),
             preDotSpace = None,
-            dotCalls = Seq(
-              SoftAST.DotCall(
-                index = indexOf("left>>.right<<"),
-                dot = Dot("left>>.<<right"),
-                postDotSpace = None,
-                rightExpression = Identifier("left.>>right<<")
-              )
-            )
+            dot = Dot("left>>.<<right"),
+            postDotSpace = None,
+            rightExpression = Identifier("left.>>right<<")
           )
       }
+    }
+
+    "three method calls" in {
+      val actual = parseMethodCall("a.b.c")
+
+      val expected =
+        SoftAST.MethodCall(
+          index = indexOf(">>a.b.c<<"),
+          leftExpression = SoftAST.MethodCall(
+            index = indexOf(">>a.b<<.c"),
+            leftExpression = Identifier(">>a<<.b.c"),
+            preDotSpace = None,
+            dot = Dot("a>>.<<b.c"),
+            postDotSpace = None,
+            rightExpression = Identifier("a.>>b<<.c")
+          ),
+          preDotSpace = None,
+          dot = Dot("a.b>>.<<c"),
+          postDotSpace = None,
+          rightExpression = Identifier("a.b.>>c<<")
+        )
+
+      actual shouldBe expected
+    }
+
+    "four method calls" in {
+      val actual = parseMethodCall("a.b.c.d")
+
+      val expected =
+        SoftAST.MethodCall(
+          index = indexOf(">>a.b.c.d<<"),
+          leftExpression = SoftAST.MethodCall(
+            index = indexOf(">>a.b.c<<.d"),
+            leftExpression = SoftAST.MethodCall(
+              index = indexOf(">>a.b<<.c.d"),
+              leftExpression = Identifier(">>a<<.b.c.d"),
+              preDotSpace = None,
+              dot = Dot("a>>.<<b.c.d"),
+              postDotSpace = None,
+              rightExpression = Identifier("a.>>b<<.c.d")
+            ),
+            preDotSpace = None,
+            dot = Dot("a.b>>.<<c.d"),
+            postDotSpace = None,
+            rightExpression = Identifier("a.b.>>c<<.d")
+          ),
+          preDotSpace = None,
+          dot = Dot("a.b.c>>.<<d"),
+          postDotSpace = None,
+          rightExpression = Identifier("a.b.c.>>d<<")
+        )
+
+      actual shouldBe expected
     }
   }
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/DetectCallSyntaxSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/DetectCallSyntaxSpec.scala
@@ -168,11 +168,11 @@ class DetectCallSyntaxSpec extends AnyWordSpec with Matchers {
     "call is a value call" in {
       goToDefinitionSoft() {
         """
-          |Contract >>variable<<() {}
+          |Contract variable() {}
           |event variable(a: Bool)
           |
           |Contract Test(>>variable<<: Var) {
-          |  Contract >>variable<<() {}
+          |  Contract variable() {}
           |  event variable(a: Bool)
           |
           |  fn variable() -> () {}
@@ -212,11 +212,11 @@ class DetectCallSyntaxSpec extends AnyWordSpec with Matchers {
     "call is method call" in {
       goToDefinitionSoft() {
         """
-          |Contract >>variable<<() {}
+          |Contract variable() {}
           |event variable(a: Bool)
           |
           |Contract Test(>>variable<<: Var) {
-          |  Contract >>variable<<() {}
+          |  Contract variable() {}
           |  event variable(a: Bool)
           |
           |  fn variable() -> () {}

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumTypeSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumTypeSpec.scala
@@ -220,6 +220,75 @@ class GoToEnumTypeSpec extends AnyWordSpec with Matchers {
           |""".stripMargin
       )
     }
+
+    "enum is within function parameter" in {
+      goToDefinitionSoft()(
+        """
+          |enum >>EnumType<< {
+          |  Field0 = 0
+          |  Field1 = 1
+          |}
+          |
+          |Abstract Contract Parent2() {
+          |
+          |  enum EnumTypeNotUsed {
+          |    Field0 = 0
+          |    Field1 = 1
+          |  }
+          |
+          |  enum >>EnumType<< {
+          |    Field0 = 0
+          |    Field1 = 1
+          |  }
+          |}
+          |
+          |enum >>EnumType<< {
+          |  Field0 = 0
+          |  Field1 = 1
+          |}
+          |
+          |Abstract Contract Parent1() extends Parent2() {
+          |
+          |  enum >>EnumType<< {
+          |    Field0 = 0
+          |    Field1 = 1
+          |  }
+          |
+          |  enum EnumTypeNotUsed {
+          |    Field0 = 0
+          |    Field1 = 1
+          |  }
+          |}
+          |
+          |enum >>EnumType<< {
+          |  Field0 = 0
+          |  Field1 = 1
+          |}
+          |
+          |Contract MyContract() extends Parent1() {
+          |
+          |  enum >>EnumType<< {
+          |    Field0 = 0
+          |    Field1 = 1
+          |  }
+          |
+          |  enum >>EnumType<< {
+          |    Field0 = 0
+          |    Field1 = 1
+          |  }
+          |
+          |  pub fn function() -> () {
+          |    let go_to_enum = object.function(param1, Enu@@mType.Field0, param2)
+          |  }
+          |}
+          |
+          |enum >>EnumType<< {
+          |  Field0 = 0
+          |  Field1 = 1
+          |}
+          |""".stripMargin
+      )
+    }
   }
 
   "duplicates identifier" when {
@@ -229,7 +298,7 @@ class GoToEnumTypeSpec extends AnyWordSpec with Matchers {
       //        This will be resolved by type-inference code-provider, which is not yet implemented.
       goToDefinitionSoft()(
         """
-          |Contract >>Enum<< {
+          |Contract Enum {
           |
           |  enum >>Enum<< {}
           |  const Enum = 1
@@ -249,7 +318,7 @@ class GoToEnumTypeSpec extends AnyWordSpec with Matchers {
           """
             |Contract Enum {
             |
-            |  enum >>Enum<< {}
+            |  enum Enum {}
             |  const >>Enum<< = 1
             |
             |  fn main() -> () {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumTypeSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumTypeSpec.scala
@@ -293,9 +293,6 @@ class GoToEnumTypeSpec extends AnyWordSpec with Matchers {
 
   "duplicates identifier" when {
     "enum is called" in {
-      // FIXME: Currently the `Contract` and the `enum` both are returned.
-      //        Only the `Enum` should be returned.
-      //        This will be resolved by type-inference code-provider, which is not yet implemented.
       goToDefinitionSoft()(
         """
           |Contract Enum {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEventSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEventSpec.scala
@@ -238,13 +238,13 @@ class GoToEventSpec extends AnyWordSpec with Matchers {
             |
             |  event TransferNotUsed(to: Address, amount: U256)
             |
-            |  event Transfer(to: Address, amount: U256)
+            |  event >>Transfer<<(to: Address, amount: U256)
             |
             |}
             |
             |Contract >>Transfer<<() extends Parent() {
             |
-            |  event Transfer(to: Address, amount: U256)
+            |  event >>Transfer<<(to: Address, amount: U256)
             |
             |  pub fn function() -> () {
             |    emit (Transfe@@r.function(), b, c)
@@ -328,11 +328,11 @@ class GoToEventSpec extends AnyWordSpec with Matchers {
             "event is defined locally" in {
               goToDefinitionSoft()(
                 """
-                  |Contract transfer() {
+                  |Contract >>transfer<<() {
                   |
                   |  event >>transfer<<(to: Address)
                   |
-                  |  pub fn transfer() -> () { }
+                  |  pub fn >>transfer<<() -> () { }
                   |
                   |  pub fn function() -> () {
                   |    emit transf@@er.transfer().transfer
@@ -350,9 +350,9 @@ class GoToEventSpec extends AnyWordSpec with Matchers {
                     | event >>transfer<<(to: Address)
                     |}
                     |
-                    |Contract transfer() extends parent {
+                    |Contract >>transfer<<() extends parent {
                     |
-                    |  pub fn transfer() -> () { }
+                    |  pub fn >>transfer<<() -> () { }
                     |
                     |  pub fn function() -> () {
                     |    emit transf@@er.transfer().transfer
@@ -369,9 +369,9 @@ class GoToEventSpec extends AnyWordSpec with Matchers {
                     | event >>transfer<<
                     |}
                     |
-                    |Contract transfer() extends parent {
+                    |Contract >>transfer<<() extends parent {
                     |
-                    |  pub fn transfer() -> () { }
+                    |  pub fn >>transfer<<() -> () { }
                     |
                     |  pub fn function() -> () {
                     |    emit transf@@er.transfer().transfer
@@ -387,9 +387,9 @@ class GoToEventSpec extends AnyWordSpec with Matchers {
                 """
                   |event >>transfer<<(to: Address)
                   |
-                  |Contract transfer() extends parent {
+                  |Contract >>transfer<<() extends parent {
                   |
-                  |  pub fn transfer() -> () { }
+                  |  pub fn >>transfer<<() -> () { }
                   |
                   |  pub fn function() -> () {
                   |    emit transf@@er.transfer().transfer

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToTemplateSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToTemplateSpec.scala
@@ -216,7 +216,7 @@ class GoToTemplateSpec extends AnyWordSpec with Matchers {
       "variable exists, but the call is a method call" in {
         goToDefinitionSoft() {
           """
-            |Contract >>variable<<() { }
+            |Contract variable() { }
             |
             |Contract Test(instance: variable) {
             |  let >>variable<< = instance


### PR DESCRIPTION
- Towards #481
- Towards #404
  - Removes the AST `DotCall` and instead stores `MethodCall` in order of their execution. For example, if there are a series of method calls like `a.b.c().d.e()`, they will be stored as a sequence of `MethodCall`s reflecting their order of execution `(((a.b).c()).d).e()`, where each grouped expression (in parens) is a simple `MethodCall`. This makes processing and searching each `MethodCall` easier than how they are currently stored. `DotCall` makes parsing easier, `MethodCall` makes searching easier.