### PR TITLE
`findLast` depth-first search

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefCodeProviderSoft.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefCodeProviderSoft.scala
@@ -68,7 +68,7 @@ case object GoToDefCodeProviderSoft extends CodeProvider[SourceCodeState.IsParse
       workspace: WorkspaceState.IsSourceAware,
       settings: GoToDefSetting
     )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToDefSoft] =
-    blockPart.toNode.findLast(_.index contains cursorIndex) match {
+    blockPart.toNode.findLastChild(_.data.index contains cursorIndex) match {
       case Some(Node(_: SoftAST.CodeToken[_], _)) =>
         // Tokens (fn, Contract etc.) do not require go-to-definitions
         Iterator.empty

--- a/utils/src/main/scala/org/alephium/ralph/lsp/utils/Node.scala
+++ b/utils/src/main/scala/org/alephium/ralph/lsp/utils/Node.scala
@@ -144,6 +144,8 @@ case class Node[+A, B] private (
    * Find the last node for which this predicate is true.
    *
    * This function is useful for find the closest node that contains a source-index.
+   *
+   * Use [[findLastChild]] for depth-first search.
    */
   def findLast(f: B => Boolean): Option[Node[B, B]] =
     self
@@ -155,6 +157,28 @@ case class Node[+A, B] private (
           else
             closest
       }
+
+  /**
+   * Depth-first search.
+   *
+   * Finds the last node for which the predicate is true, skipping the node
+   * and its children if the predicate fails for the parent node.
+   */
+  def findLastChild(f: Node[B, B] => Boolean): Option[Node[B, B]] = {
+    val selfCasted =
+      self.asInstanceOf[Node[B, B]]
+
+    if (f(selfCasted))
+      children
+        .iterator
+        .flatMap(_.findLastChild(f))
+        .foldLeft(Some(selfCasted)) {
+          case (_, next) =>
+            Some(next)
+        }
+    else
+      None
+  }
 
   /**
    * Upcasts this node's data type [[A]] to a narrower type.


### PR DESCRIPTION
- Resolves issue #178 for `SoftAST` search only.
- Not used in providers searching Strict-AST because `TxScript`'s compiler generated `main` function does not have a `SourceIndex`. And a few other test-cases fail (possibly due to similar `SourceIndex` issue).