### PR TITLE
Soft: Static call search

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -166,7 +166,17 @@ object SoftAST {
    */
   sealed trait BlockPartAST   extends SoftAST
   sealed trait DeclarationAST extends BlockPartAST
-  sealed trait ExpressionAST  extends BlockPartAST
+
+  /**
+   * Represents declarations that define new named type.
+   */
+  sealed trait TypeDefinitionAST extends DeclarationAST {
+
+    def identifier: IdentifierAST
+
+  }
+
+  sealed trait ExpressionAST extends BlockPartAST
 
   case class ExpressionExpected(
       index: SourceIndex)
@@ -265,7 +275,7 @@ object SoftAST {
       postParamSpace: Option[Space],
       inheritance: Seq[Inheritance],
       block: Option[Block])
-    extends DeclarationAST
+    extends TypeDefinitionAST
 
   case class Abstract(
       index: SourceIndex,
@@ -280,7 +290,7 @@ object SoftAST {
       identifier: IdentifierAST,
       preParamSpace: Option[Space],
       params: Group[Token.OpenParen.type, Token.CloseParen.type])
-    extends DeclarationAST
+    extends TypeDefinitionAST
 
   case class Struct(
       index: SourceIndex,
@@ -289,7 +299,7 @@ object SoftAST {
       identifier: IdentifierAST,
       preParamSpace: Option[Space],
       params: Group[Token.OpenCurly.type, Token.CloseCurly.type])
-    extends DeclarationAST
+    extends TypeDefinitionAST
 
   case class Enum(
       index: SourceIndex,
@@ -298,7 +308,7 @@ object SoftAST {
       identifier: IdentifierAST,
       preBlockSpace: Option[Space],
       block: Option[Block])
-    extends DeclarationAST
+    extends TypeDefinitionAST
 
   case class Const(
       index: SourceIndex,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
@@ -939,7 +939,7 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
 
       case _ =>
         // Otherwise, type information is needed.
-        searchTypeCall(
+        searchTypeCallStrict(
           typeProperty = identNode,
           theType = methodCallNode.data.leftExpression,
           sourceCode = sourceCode,
@@ -964,7 +964,7 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
    * @param cache        The workspace state and its cached trees.
    * @return An iterator matching properties found in the given type.
    */
-  private def searchTypeCall(
+  private def searchTypeCallStrict(
       theType: SoftAST.ExpressionAST,
       typeProperty: Node[SoftAST.Identifier, SoftAST],
       sourceCode: SourceLocation.CodeSoft,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
@@ -1090,7 +1090,8 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
   }
 
   /**
-   * A basic type-def search on [[SoftAST]]. Search only if the exact type-name/identifier is known.
+   * Performs a basic type-def search on [[SoftAST]].
+   * Use this search only if the exact type-name/identifier is known.
    *
    * {{{
    *   MyEnu@@m.Value               // Can handle this
@@ -1102,13 +1103,11 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
    *   }
    * }}}
    *
-   * @param typeIdentifier
-   * @param sourceCode
-   * @param cache
-   * @param settings
-   * @param detectCallSyntax
-   * @param logger
-   * @return
+   * @param typeIdentifier   The reference identifier being searched.
+   * @param sourceCode       The source code where this search was executed.
+   * @param cache            The workspace state and its cached trees.
+   * @param detectCallSyntax If `true`, detects the type of search based on the syntax.
+   * @return Type definitions matching the given type identifier.
    */
   private def searchTypeDefinitionSoft(
       typeIdentifier: Node[SoftAST.Identifier, SoftAST],
@@ -1133,8 +1132,9 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
           case Some(node) =>
             node
               .walkParents
+              .takeWhile(_.data contains definition.ast) // traverse only the up to the parent that contains the definition
               .collectFirst {
-                case Node(typeDef: SoftAST.TypeDefinitionAST, _) if typeDef.identifier contains definition.ast =>
+                case Node(typeDef: SoftAST.TypeDefinitionAST, _) =>
                   // Lift the type from `CodeString` to `TypeDefinitionAST`.
                   definition.copy(ast = typeDef)
               }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
@@ -955,7 +955,7 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
         )
 
       case (left: SoftAST.Identifier, right @ (_: SoftAST.Identifier | _: SoftAST.ReferenceCall)) if right contains identNode =>
-        /**
+        /*
          * This might be a static call.
          *
          * {{{

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumFieldSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumFieldSpec.scala
@@ -11,7 +11,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "enum type does not exist" in {
-      goToDefinitionStrict()(
+      goToDefinition()(
         """
           |Contract MyContract() {
           |  pub fn function() -> () {
@@ -25,7 +25,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
 
   "return self" when {
     "enum field definition is selected" in {
-      goToDefinitionStrict()(
+      goToDefinition()(
         """
           |// This parent is not inherited
           |Abstract Contract ParentNotUsed() {
@@ -47,7 +47,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
 
   "return non-empty" when {
     "user selects the first enum field" in {
-      goToDefinitionStrict()(
+      goToDefinition()(
         """
           |// This parent is not inherited
           |Abstract Contract ParentNotUsed() {
@@ -93,7 +93,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
     }
 
     "user selects the second enum field" in {
-      goToDefinitionStrict()(
+      goToDefinition()(
         """
           |enum EnumType {
           |  Field0 = 0
@@ -132,7 +132,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
 
     "there are duplicate enum types and fields" when {
       "user selects the first enum field" in {
-        goToDefinitionStrict()(
+        goToDefinition()(
           """
             |enum EnumType {
             |  >>Field0<< = 0
@@ -178,7 +178,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
       }
 
       "user selects the second enum field" in {
-        goToDefinitionStrict()(
+        goToDefinition()(
           """
             |enum EnumType {
             |  Field0 = 0
@@ -209,7 +209,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
 
     "there are duplicate enum types with distinct fields" when {
       "user selects the first enum field" in {
-        goToDefinitionStrict()(
+        goToDefinition()(
           """
             |enum EnumType {
             |  >>Field0<< = 0
@@ -240,7 +240,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
       }
 
       "user selects the third enum field" in {
-        goToDefinitionStrict()(
+        goToDefinition()(
           """
             |Contract MyContract() {
             |
@@ -266,7 +266,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
       }
 
       "an enum field is selected that's implemented within a parent" in {
-        goToDefinitionStrict()(
+        goToDefinition()(
           """
             |Abstract Contract Parent2() {
             |  enum EnumType {
@@ -290,7 +290,7 @@ class GoToEnumFieldSpec extends AnyWordSpec with Matchers {
             |  }
             |
             |  pub fn function() -> () {
-            |    let field0 = EnumType.Field0@@
+            |    let field0 = EnumType.Fiel@@d0
             |  }
             |}
             |""".stripMargin

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToStaticCall.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToStaticCall.scala
@@ -1,0 +1,54 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.pc.search.gotodef
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
+
+class GoToStaticCall extends AnyWordSpec with Matchers {
+
+  "access single static functions" in {
+    goToDefinitionSoft()(
+      """
+        |Contract Test {
+        |  fn >>encodeFields<<() -> ()
+        |}
+        |
+        |Test.encodeFiel@@ds
+        |""".stripMargin
+    )
+  }
+
+  "access duplicate static functions" in {
+    goToDefinitionSoft()(
+      """
+        |Contract Test {
+        |  fn >>encodeFields<<() -> ()
+        |  fn >>encodeFields<<(paramA: A) -> ()
+        |  fn >>encodeFields<<(paramA: A, paramB: A) -> ()
+        |}
+        |
+        |Test.encodeFiel@@ds
+        |""".stripMargin
+    )
+  }
+
+  "access within another contract" in {
+    goToDefinitionSoft()(
+      """
+        |Contract Test {
+        |  fn >>encodeFields<<() -> ()
+        |  fn >>encodeFields<<(paramA: A) -> ()
+        |  fn >>encodeFields<<(paramA: A, paramB: A) -> ()
+        |}
+        |
+        |Contract Main {
+        |  Test.encodeFiel@@ds
+        |}
+        |""".stripMargin
+    )
+  }
+
+}


### PR DESCRIPTION
Static calls like following do not require type information from strict-AST. They are searched directly on `SoftAST`.

```rust
MyEnum.Value
MyContract.encodeFields!(...)
```

TODO: Handle duplicates (#481).

Towards #404.