### PR TITLE
Add `encodeFields!` to built-in library file `contract_functions.ral`

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/BuiltInFunctionInfo.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/build/dependency/downloader/BuiltInFunctionInfo.scala
@@ -49,6 +49,28 @@ object BuiltInFunctionInfo {
             returns = function.returns
           )
       }
+      .:+(buildEncodeFields())
+
+  /**
+   * [[BuiltIn.statefulFuncsSeq]] does not include the static function `encodeFields`.
+   * This manually builds it within the category [[Category.Contract]].
+   *
+   * Documentation borrowed from <a href="https://docs.alephium.org/ralph/built-in-functions/#encodefields">#encodefields</a>.
+   *
+   * @return Built-in function information for `encodeFields!`.
+   */
+  private def buildEncodeFields(): BuiltInFunctionInfo = {
+    val name = "encodeFields"
+
+    BuiltInFunctionInfo(
+      name = name,
+      category = Category.Contract,
+      signature = s"fn $name!(fields:Fields) -> (ByteVec, ByteVec)",
+      doc = "Encode the fields for creating a contract",
+      params = Seq("@param fields the fields of the to-be-created target contract"),
+      returns = "@returns two ByteVecs: the first one is the encoded immutable fields, and the second one is the encoded mutable fields"
+    )
+  }
 
 }
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToStaticCall.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToStaticCall.scala
@@ -13,10 +13,10 @@ class GoToStaticCall extends AnyWordSpec with Matchers {
     goToDefinitionSoft()(
       """
         |Contract Test {
-        |  fn >>encodeFields<<() -> ()
+        |  fn >>static_function<<() -> ()
         |}
         |
-        |Test.encodeFiel@@ds
+        |Test.static_functi@@on
         |""".stripMargin
     )
   }
@@ -25,12 +25,12 @@ class GoToStaticCall extends AnyWordSpec with Matchers {
     goToDefinitionSoft()(
       """
         |Contract Test {
-        |  fn >>encodeFields<<() -> ()
-        |  fn >>encodeFields<<(paramA: A) -> ()
-        |  fn >>encodeFields<<(paramA: A, paramB: A) -> ()
+        |  fn >>static_function<<() -> ()
+        |  fn >>static_function<<(paramA: A) -> ()
+        |  fn >>static_function<<(paramA: A, paramB: B) -> ()
         |}
         |
-        |Test.encodeFiel@@ds
+        |Test.static_functi@@on
         |""".stripMargin
     )
   }
@@ -39,16 +39,53 @@ class GoToStaticCall extends AnyWordSpec with Matchers {
     goToDefinitionSoft()(
       """
         |Contract Test {
-        |  fn >>encodeFields<<() -> ()
-        |  fn >>encodeFields<<(paramA: A) -> ()
-        |  fn >>encodeFields<<(paramA: A, paramB: A) -> ()
+        |  fn >>static_function<<() -> ()
+        |  fn >>static_function<<(paramA: A) -> ()
+        |  fn >>static_function<<(paramA: A, paramB: B) -> ()
         |}
         |
         |Contract Main {
-        |  Test.encodeFiel@@ds
+        |  Test.static_functi@@on
         |}
         |""".stripMargin
     )
+  }
+
+  "go-to static function encodeFields!" when {
+    "from global scope" in {
+      goToDefBuiltInSoft(
+        code = """
+            |Contract Test { }
+            |
+            |Test.encodeFiel@@ds!
+            |""".stripMargin,
+        expected = Some("fn >>encodeFields!<<(fields:Fields) -> (ByteVec, ByteVec)")
+      )
+    }
+
+    "from contract scope" in {
+      goToDefBuiltInSoft(
+        code = """
+            |Contract Test { }
+            |
+            |Contract Main {
+            |  Test.encodeFiel@@ds!
+            |}
+            |""".stripMargin,
+        expected = Some("fn >>encodeFields!<<(fields:Fields) -> (ByteVec, ByteVec)")
+      )
+    }
+
+    "from self scope" in {
+      goToDefBuiltInSoft(
+        code = """
+            |Contract Main {
+            |  Main.encodeFiel@@ds!
+            |}
+            |""".stripMargin,
+        expected = Some("fn >>encodeFields!<<(fields:Fields) -> (ByteVec, ByteVec)")
+      )
+    }
   }
 
 }


### PR DESCRIPTION
- Static function `encodeFields!` is not included in [`BuiltIn.statefulFuncsSeq`](https://github.com/alephium/alephium/blob/1411a4f8684fa7b968cf48c92f77651e93faffb6/ralph/src/main/scala/org/alephium/ralph/BuiltIn.scala#L2247). This manually inserts it to the `Contract` category.
- Towards #287 (supported only for `SoftAST`).
- Pending go-to references.