### PR TITLE
Minor refactoring

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
@@ -997,10 +997,12 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
             else
               // If no result, execute a typed-search which searches strict-AST for the node's type information.
               searchTypeCallStrict(
-                typeProperty = identNode,
                 theType = left,
+                typeProperty = identNode,
                 sourceCode = sourceCode,
-                cache = cache
+                cache = cache,
+                settings = settings,
+                detectCallSyntax = detectCallSyntax
               )
 
           case (leftNode, rightNode) =>
@@ -1009,20 +1011,24 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
               logger.error(s"Not found: Static-call Node info. left: ${leftNode.map(_.toCode())}. right: ${rightNode.map(_.toCode())}. FileURI: ${sourceCode.parsed.fileURI}")
 
             searchTypeCallStrict(
-              typeProperty = identNode,
               theType = left,
+              typeProperty = identNode,
               sourceCode = sourceCode,
-              cache = cache
+              cache = cache,
+              settings = settings,
+              detectCallSyntax = detectCallSyntax
             )
         }
 
       case _ =>
         // Otherwise, type information is needed.
         searchTypeCallStrict(
-          typeProperty = identNode,
           theType = methodCallNode.data.leftExpression,
+          typeProperty = identNode,
           sourceCode = sourceCode,
-          cache = cache
+          cache = cache,
+          settings = settings,
+          detectCallSyntax = detectCallSyntax
         )
     }
 
@@ -1167,7 +1173,9 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
       theType: SoftAST.ExpressionAST,
       typeProperty: Node[SoftAST.Identifier, SoftAST],
       sourceCode: SourceLocation.CodeSoft,
-      cache: SearchCache
+      cache: SearchCache,
+      settings: GoToDefSetting,
+      detectCallSyntax: Boolean
     )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeSoft[SoftAST.CodeString]] = {
     // Find all the type definitions.
     val typeDefs =
@@ -1182,13 +1190,6 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
 
     typeDefs match {
       case Some(Right(typeDefs)) =>
-        // For each type-definition, search for the property `typeProperty` within it.
-        val settings =
-          GoToDefSetting(
-            includeAbstractFuncDef = false,
-            includeInheritance = true
-          )
-
         // TODO: Execute in parallel
         typeDefs flatMap {
           typDef =>
@@ -1210,7 +1211,7 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
                       sourceCode = softTypeDef,
                       cache = cache,
                       settings = settings,
-                      detectCallSyntax = true
+                      detectCallSyntax = detectCallSyntax
                     )
 
                   case None =>


### PR DESCRIPTION
- Remove hardcoded `settings` and `detectCallSyntax` from function `searchTypeCallStrict`
- Reordered match.