### PR TITLE
Implement String-Interpolation Parser

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,49 +16,56 @@ val inliningOptions =
      */
   )
 
+val testOptions =
+  Seq(
+    "-deprecation",
+    "-encoding",
+    "utf-8",
+    "-explaintypes",
+    "-feature",
+    "-unchecked",
+    "-Xfatal-warnings",
+    "-Xlint:adapted-args",
+    "-Xlint:constant",
+    "-Xlint:delayedinit-select",
+    "-Xlint:doc-detached",
+    "-Xlint:inaccessible",
+    "-Xlint:infer-any",
+    "-Xlint:nullary-unit",
+    "-Xlint:option-implicit",
+    "-Xlint:package-object-classes",
+    "-Xlint:poly-implicit-overload",
+    "-Xlint:private-shadow",
+    "-Xlint:stars-align",
+    "-Xlint:type-parameter-shadow",
+    "-Xlint:nonlocal-return",
+    "-Ywarn-dead-code",
+    "-Ywarn-extra-implicit",
+    "-Ywarn-numeric-widen",
+    "-Ywarn-unused:implicits",
+    "-Ywarn-unused:imports",
+    "-Ywarn-unused:locals",
+    "-Ywarn-unused:params",
+    "-Ywarn-unused:patvars",
+    "-Ywarn-unused:privates",
+    "-Ywarn-value-discard"
+  ) ++ inliningOptions
+
+/**
+ * "-Xlint:missing-interpolator" is excluded from test to allow testing of Ralphc's string-interpolation feature.
+ */
+val mainOptions =
+  testOptions :+ "-Xlint:missing-interpolator"
+
 val commonSettings =
   Seq(
     organization := "org.alephium",
     scalaVersion := Version.scala213,
-    scalacOptions ++=
-      Seq(
-        "-deprecation",
-        "-encoding",
-        "utf-8",
-        "-explaintypes",
-        "-feature",
-        "-unchecked",
-        // "-Xsource:3.1",
-        "-Xfatal-warnings",
-        "-Xlint:adapted-args",
-        "-Xlint:constant",
-        "-Xlint:delayedinit-select",
-        "-Xlint:doc-detached",
-        "-Xlint:inaccessible",
-        "-Xlint:infer-any",
-        // "-Xlint:missing-interpolator",
-        "-Xlint:nullary-unit",
-        "-Xlint:option-implicit",
-        "-Xlint:package-object-classes",
-        "-Xlint:poly-implicit-overload",
-        "-Xlint:private-shadow",
-        "-Xlint:stars-align",
-        "-Xlint:type-parameter-shadow",
-        "-Xlint:nonlocal-return",
-        "-Ywarn-dead-code",
-        "-Ywarn-extra-implicit",
-        "-Ywarn-numeric-widen",
-        "-Ywarn-unused:implicits",
-        "-Ywarn-unused:imports",
-        "-Ywarn-unused:locals",
-        "-Ywarn-unused:params",
-        "-Ywarn-unused:patvars",
-        "-Ywarn-unused:privates",
-        "-Ywarn-value-discard"
-      ) ++ inliningOptions,
     Compile / doc / scalacOptions ++= Seq(
       "-no-link-warnings"
-    )
+    ),
+    Compile / scalacOptions := mainOptions,
+    Test / scalacOptions    := testOptions
   )
 
 lazy val utils =

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ val commonSettings =
         "-Xlint:doc-detached",
         "-Xlint:inaccessible",
         "-Xlint:infer-any",
-        "-Xlint:missing-interpolator",
+        // "-Xlint:missing-interpolator",
         "-Xlint:nullary-unit",
         "-Xlint:option-implicit",
         "-Xlint:package-object-classes",

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentParser.scala
@@ -66,6 +66,7 @@ private object AssignmentParser {
         )
     }
 
+  /** TODO: Review this function - Most of these parsers can be removed. */
   private def leftExpression[Unknown: P]: P[SoftAST.ExpressionAST] =
     P {
       MethodCallParser.parseOrFail |
@@ -74,6 +75,7 @@ private object AssignmentParser {
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |
         BStringParser.parseOrFail |
+        StringInterpolationParser.parseOrFail |
         StringLiteralParser.parseOrFail |
         IdentifierParser.parseOrFail
     }
@@ -92,6 +94,7 @@ private object AssignmentParser {
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |
         BStringParser.parseOrFail |
+        StringInterpolationParser.parseOrFail |
         StringLiteralParser.parseOrFail |
         IdentifierParser.parseOrFail
     }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/BlockParser.scala
@@ -5,10 +5,22 @@ package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
-import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra._
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object BlockParser {
+
+  /**
+   * Parses a mandatory block.
+   */
+  def parse[Unknown: P]: P[SoftAST.BlockExpectedAST] =
+    P(Index ~ parseOrFail.?) map {
+      case (_, Some(block)) =>
+        block
+
+      case (from, None) =>
+        SoftAST.BlockExpected(point(from))
+    }
 
   /**
    * Parses a block's body such a parent block is already defined.

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CodeParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/CodeParser.scala
@@ -5,10 +5,26 @@ package org.alephium.ralph.lsp.access.compiler.parser.soft
 
 import fastparse._
 import fastparse.NoWhitespace.noWhitespaceImplicit
-import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra._
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
 
 private object CodeParser {
+
+  /**
+   * Parses a mandatory token.
+   *
+   * @param token The expected token.
+   * @return The parsed token if matched.
+   *         Else fails with [[SoftAST.TokenExpected]] error.
+   */
+  def parse[Unknown: P, T <: Token](token: T): P[SoftAST.CodeTokenAST[T]] =
+    P(Index ~ parseOrFail(token).?) map {
+      case (_, Some(token)) =>
+        token
+
+      case (from, None) =>
+        SoftAST.TokenExpected(point(from), token)
+    }
 
   def parseOrFail[Unknown: P, T <: Token](token: T): P[SoftAST.CodeToken[T]] =
     P {

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ExpressionParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ExpressionParser.scala
@@ -50,6 +50,7 @@ private object ExpressionParser {
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |
         BStringParser.parseOrFail |
+        StringInterpolationParser.parseOrFail |
         StringLiteralParser.parseOrFail |
         IdentifierParser.parseOrFail
     }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ForParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ForParser.scala
@@ -90,6 +90,7 @@ private object ForParser {
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |
         BStringParser.parseOrFail |
+        StringInterpolationParser.parseOrFail |
         StringLiteralParser.parseOrFail |
         IdentifierParser.parseOrFail
     }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/GroupParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/GroupParser.scala
@@ -180,6 +180,7 @@ private object GroupParser {
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |
         BStringParser.parseOrFail |
+        StringInterpolationParser.parseOrFail |
         IdentifierParser.parseOrFail
     }
 

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/InfixCallParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/InfixCallParser.scala
@@ -41,6 +41,7 @@ private object InfixCallParser {
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |
         BStringParser.parseOrFail |
+        StringInterpolationParser.parseOrFail |
         StringLiteralParser.parseOrFail |
         IdentifierParser.parseOrFail
     }
@@ -58,6 +59,7 @@ private object InfixCallParser {
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |
         BStringParser.parseOrFail |
+        StringInterpolationParser.parseOrFail |
         StringLiteralParser.parseOrFail |
         IdentifierParser.parseOrFail
     }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MethodCallParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MethodCallParser.scala
@@ -82,6 +82,7 @@ private object MethodCallParser {
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |
         BStringParser.parseOrFail |
+        StringInterpolationParser.parseOrFail |
         IdentifierParser.parseOrFail
     }
 

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReturnParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReturnParser.scala
@@ -40,6 +40,7 @@ private object ReturnParser {
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |
         BStringParser.parseOrFail |
+        StringInterpolationParser.parseOrFail |
         StringLiteralParser.parseOrFail |
         IdentifierParser.parseOrFail
     }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringInterpolationParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringInterpolationParser.scala
@@ -47,7 +47,7 @@ private object StringInterpolationParser {
         // Parse escaped interpolation
         CodeParser
           .parseOrFail(Token.Dollar)
-          .rep(min = 2, max = 2)
+          .rep(exactly = 2)
     }
 
   /** Parse interpolated text */

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringInterpolationParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringInterpolationParser.scala
@@ -1,0 +1,72 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse._
+import fastparse.NoWhitespace.noWhitespaceImplicit
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
+import org.alephium.ralph.lsp.utils.CollectionUtil
+
+private object StringInterpolationParser {
+
+  /** Parses an interpolated string. */
+  def parseOrFail[Unknown: P]: P[SoftAST.StringInterpolation] =
+    P {
+      Index ~
+        TokenParser.parseOrFail(Token.Tick) ~
+        interpolate.rep ~
+        CodeParser.parse(Token.Tick) ~
+        Index
+    } map {
+      case (from, startTick, interpolation, endTick, to) =>
+        SoftAST.StringInterpolation(
+          index = range(from, to),
+          startTick = startTick,
+          interpolation = CollectionUtil.mergeConsecutive(interpolation),
+          endTick = endTick
+        )
+    }
+
+  private def interpolate[Unknown: P]: P[Either[Seq[SoftAST.Code], Seq[SoftAST.InterpolatedBlock]]] =
+    P {
+      // or without interpolation
+      nonInterpolation.map(Left(_)) |
+        // with interpolation
+        interpolation.rep(1).map(Right(_))
+    }
+
+  /** Parse non-interpolated text */
+  private def nonInterpolation[Unknown: P] =
+    P {
+      // Parse text not containing the dollar
+      TextParser
+        .parseOrFail(Token.Dollar, Token.Tick)
+        .map(Seq(_)) |
+        // Parse escaped interpolation
+        TokenParser
+          .parseOrFailUndocumented(Token.Dollar)
+          .rep(min = 2, max = 2)
+          .map(_.map(_.code))
+    }
+
+  /** Parse interpolated text */
+  private def interpolation[Unknown: P]: P[SoftAST.InterpolatedBlock] =
+    P {
+      Index ~
+        // Ensure that it's not an escaped interpolation. These should've already been processed by `nonInterpolation`.
+        (CodeParser.parseOrFail(Token.Dollar) ~ !Token.Dollar.lexeme) ~
+        // Interpolation syntax is valid. A block is required.
+        BlockParser.parse ~
+        Index
+    } map {
+      case (from, dollar, block, to) =>
+        SoftAST.InterpolatedBlock(
+          index = range(from, to),
+          dollar = dollar,
+          block = block
+        )
+    }
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringInterpolationParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringInterpolationParser.scala
@@ -38,7 +38,7 @@ private object StringInterpolationParser {
     }
 
   /** Parse non-interpolated text */
-  private def nonInterpolation[Unknown: P] =
+  private def nonInterpolation[Unknown: P]: P[Seq[SoftAST.Code]] =
     P {
       // Parse text not containing the dollar
       TextParser

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringInterpolationParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringInterpolationParser.scala
@@ -45,10 +45,9 @@ private object StringInterpolationParser {
         .parseOrFail(Token.Dollar, Token.Tick)
         .map(Seq(_)) |
         // Parse escaped interpolation
-        TokenParser
-          .parseOrFailUndocumented(Token.Dollar)
+        CodeParser
+          .parseOrFail(Token.Dollar)
           .rep(min = 2, max = 2)
-          .map(_.map(_.code))
     }
 
   /** Parse interpolated text */

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/WhileParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/WhileParser.scala
@@ -51,6 +51,7 @@ private object WhileParser {
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |
         BStringParser.parseOrFail |
+        StringInterpolationParser.parseOrFail |
         StringLiteralParser.parseOrFail |
         IdentifierParser.parseOrFail
     }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/Token.scala
@@ -109,6 +109,7 @@ object Token {
   case object Tick                                              extends Punctuator("`") with Reserved
   case object Quote                                             extends Punctuator("\"") with Reserved
   case object B                                                 extends Punctuator("b") with Token
+  case object Dollar                                            extends Punctuator("$") with Reserved
 
   sealed abstract class Data(override val lexeme: String) extends Token
   case object Const                                       extends Data("const") with Reserved

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringInterpolationParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/StringInterpolationParserSpec.scala
@@ -1,0 +1,283 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.TestParser._
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.TestSoftAST._
+import org.alephium.ralph.lsp.access.util.TestCodeUtil._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class StringInterpolationParserSpec extends AnyWordSpec with Matchers {
+
+  "single tick (no closing tick)" in {
+    val ast = parseStringInterpolation("`")
+
+    val expected =
+      SoftAST.StringInterpolation(
+        index = indexOf(">>`<<"),
+        startTick = Tick(">>`<<"),
+        interpolation = Seq.empty,
+        endTick = TokenExpected("`>><<", Token.Tick)
+      )
+
+    ast shouldBe expected
+  }
+
+  "empty string" in {
+    val ast = parseStringInterpolation("``")
+
+    val expected =
+      SoftAST.StringInterpolation(
+        index = indexOf(">>``<<"),
+        startTick = Tick(">>`<<`"),
+        interpolation = Seq.empty,
+        endTick = Tick("`>>`<<").code
+      )
+
+    ast shouldBe expected
+  }
+
+  "escaped interpolated string" when {
+    "$$" in {
+      val ast = parseStringInterpolation("`$${a + b}`")
+
+      val expected =
+        SoftAST.StringInterpolation(
+          index = indexOf(">>`$${a + b}`<<"),
+          startTick = Tick(">>`<<$${a + b}`"),
+          interpolation = Seq(
+            Left(
+              Seq(
+                Dollar("`>>$<<${a + b}`").code,
+                Dollar("`$>>$<<{a + b}`").code,
+                CodeString("`$$>>{a + b}<<`")
+              )
+            )
+          ),
+          endTick = Tick("`$${a + b}>>`<<").code
+        )
+
+      ast shouldBe expected
+    }
+
+    "$$$$" in {
+      val ast = parseStringInterpolation("`$$$${a + b}`")
+
+      val expected =
+        SoftAST.StringInterpolation(
+          index = indexOf(">>`$$$${a + b}`<<"),
+          startTick = Tick(">>`<<$$$${a + b}`"),
+          interpolation = Seq(
+            Left(
+              Seq(
+                Dollar("`>>$<<$$${a + b}`").code,
+                Dollar("`$>>$<<$${a + b}`").code,
+                Dollar("`$$>>$<<${a + b}`").code,
+                Dollar("`$$$>>$<<{a + b}`").code,
+                CodeString("`$$$$>>{a + b}<<`")
+              )
+            )
+          ),
+          endTick = Tick("`$$$${a + b}>>`<<").code
+        )
+
+      ast shouldBe expected
+    }
+  }
+
+  "missing block" when {
+    "block is missing" in {
+      val ast = parseStringInterpolation("`$`")
+
+      val expected =
+        SoftAST.StringInterpolation(
+          index = indexOf(">>`$`<<"),
+          startTick = Tick(">>`<<$`"),
+          interpolation = Seq(
+            Right(
+              Seq(
+                SoftAST.InterpolatedBlock(
+                  index = indexOf("`>>$<<`"),
+                  dollar = Dollar("`>>$<<`").code,
+                  block = SoftAST.BlockExpected(indexOf("`$>><<`"))
+                )
+              )
+            )
+          ),
+          endTick = Tick("`$>>`<<").code
+        )
+
+      ast shouldBe expected
+    }
+
+    "tail block is missing" in {
+      val ast = parseStringInterpolation("`${a}$`")
+
+      val expected =
+        SoftAST.StringInterpolation(
+          index = indexOf(">>`${a}$`<<"),
+          startTick = Tick(">>`<<${a}$`"),
+          interpolation = Seq(
+            Right(
+              Seq(
+                SoftAST.InterpolatedBlock(
+                  index = indexOf("`>>${a}<<$`"),
+                  dollar = Dollar("`>>$<<{a}$`").code,
+                  block = SoftAST.Block(
+                    index = indexOf("`$>>{a}<<$`"),
+                    openCurly = OpenCurly("`$>>{<<a}$`"),
+                    parts = Seq(Identifier("`${>>a<<}$`")),
+                    closeCurly = CloseCurly("`${a>>}<<$`")
+                  )
+                ),
+                SoftAST.InterpolatedBlock(
+                  index = indexOf("`${a}>>$<<`"),
+                  dollar = Dollar("`${a}>>$<<`").code,
+                  block = SoftAST.BlockExpected(indexOf("`${a}$>><<`"))
+                )
+              )
+            )
+          ),
+          endTick = Tick("`${a}$>>`<<").code
+        )
+
+      ast shouldBe expected
+    }
+  }
+
+  "interpolated string" when {
+    "$" in {
+      val ast = parseStringInterpolation("`${a}`")
+
+      val expected =
+        SoftAST.StringInterpolation(
+          index = indexOf(">>`${a}`<<"),
+          startTick = Tick(">>`<<${a}`"),
+          interpolation = Seq(
+            Right(
+              Seq(
+                SoftAST.InterpolatedBlock(
+                  index = indexOf("`>>${a}<<`"),
+                  dollar = Dollar("`>>$<<{a}`").code,
+                  block = SoftAST.Block(
+                    index = indexOf("`$>>{a}<<`"),
+                    openCurly = OpenCurly("`$>>{<<a}`"),
+                    parts = Seq(Identifier("`${>>a<<}`")),
+                    closeCurly = CloseCurly("`${a>>}<<`")
+                  )
+                )
+              )
+            )
+          ),
+          endTick = Tick("`${a}>>`<<").code
+        )
+
+      ast shouldBe expected
+    }
+
+    "$$$ (partially escaped)" in {
+      val ast = parseStringInterpolation("`$$${a}`")
+
+      val expected =
+        SoftAST.StringInterpolation(
+          index = indexOf(">>`$$${a}`<<"),
+          startTick = Tick(">>`<<$$${a}`"),
+          interpolation = Seq(
+            Left(
+              Seq(
+                Dollar("`>>$<<$$${a}`").code,
+                Dollar("`$>>$<<$${a}`").code
+              )
+            ),
+            Right(
+              Seq(
+                SoftAST.InterpolatedBlock(
+                  index = indexOf("`$$>>${a}<<`"),
+                  dollar = Dollar("`$$>>$<<{a}`").code,
+                  block = SoftAST.Block(
+                    index = indexOf("`$$$>>{a}<<`"),
+                    openCurly = OpenCurly("`$$$>>{<<a}`"),
+                    parts = Seq(Identifier("`$$${>>a<<}`")),
+                    closeCurly = CloseCurly("`$$${a>>}<<`")
+                  )
+                )
+              )
+            )
+          ),
+          endTick = Tick("`$$${a}>>`<<").code
+        )
+
+      ast shouldBe expected
+    }
+
+    "text & interpolation" in {
+      val ast = parseStringInterpolation("`a ${b} $${c} d ${e}${f}`")
+
+      val expected =
+        SoftAST.StringInterpolation(
+          index = indexOf(">>`a ${b} $${c} d ${e}${f}`<<"),
+          startTick = Tick(">>`<<a ${b} $${c} d ${e}${f}`"),
+          interpolation = Seq(
+            Left(
+              Seq(
+                CodeString("`>>a <<${b} $${c} d ${e}${f}`")
+              )
+            ),
+            Right(
+              Seq(
+                SoftAST.InterpolatedBlock(
+                  index = indexOf("`a >>${b}<< $${c} d ${e}${f}`"),
+                  dollar = Dollar("`a >>$<<{b} $${c} d ${e}${f}`").code,
+                  block = SoftAST.Block(
+                    index = indexOf("`a $>>{b}<< $${c} d ${e}${f}`"),
+                    openCurly = OpenCurly("`a $>>{<<b} $${c} d ${e}${f}`"),
+                    parts = Seq(Identifier("`a ${>>b<<} $${c} d ${e}${f}`")),
+                    closeCurly = CloseCurly("`a ${b>>}<< $${c} d ${e}${f}`")
+                  )
+                )
+              )
+            ),
+            Left(
+              Seq(
+                CodeString("`a ${b}>> <<$${c} d ${e}${f}`"),
+                Dollar("`a ${b} >>$<<${c} d ${e}${f}`").code,
+                Dollar("`a ${b} $>>$<<{c} d ${e}${f}`").code,
+                CodeString("`a ${b} $$>>{c} d <<${e}${f}`")
+              )
+            ),
+            Right(
+              Seq(
+                SoftAST.InterpolatedBlock(
+                  index = indexOf("`a ${b} $${c} d >>${e}<<${f}`"),
+                  dollar = Dollar("`a ${b} $${c} d >>$<<{e}${f}`").code,
+                  block = SoftAST.Block(
+                    index = indexOf("`a ${b} $${c} d $>>{e}<<${f}`"),
+                    openCurly = OpenCurly("`a ${b} $${c} d $>>{<<e}${f}`"),
+                    parts = Seq(Identifier("`a ${b} $${c} d ${>>e<<}${f}`")),
+                    closeCurly = CloseCurly("`a ${b} $${c} d ${e>>}<<${f}`")
+                  )
+                ),
+                SoftAST.InterpolatedBlock(
+                  index = indexOf("`a ${b} $${c} d ${e}>>${f}<<`"),
+                  dollar = Dollar("`a ${b} $${c} d ${e}>>$<<{f}`").code,
+                  block = SoftAST.Block(
+                    index = indexOf("`a ${b} $${c} d ${e}$>>{f}<<`"),
+                    openCurly = OpenCurly("`a ${b} $${c} d ${e}$>>{<<f}`"),
+                    parts = Seq(Identifier("`a ${b} $${c} d ${e}${>>f<<}`")),
+                    closeCurly = CloseCurly("`a ${b} $${c} d ${e}${f>>}<<`")
+                  )
+                )
+              )
+            )
+          ),
+          endTick = Tick("`a ${b} $${c} d ${e}${f}>>`<<").code
+        )
+
+      ast shouldBe expected
+    }
+  }
+
+}

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
@@ -75,6 +75,9 @@ object TestParser {
   def parseStringLiteral(code: String): SoftAST.StringLiteral =
     runSoftParser(StringLiteralParser.parseOrFail(_))(code)
 
+  def parseStringInterpolation(code: String): SoftAST.StringInterpolation =
+    runSoftParser(StringInterpolationParser.parseOrFail(_))(code)
+
   def parseImport(code: String): SoftAST.Import =
     runSoftParser(ImportParser.parseOrFail(_))(code)
 

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/TestSoftAST.scala
@@ -424,6 +424,15 @@ object TestSoftAST {
       token = Token.Tick
     )
 
+  def Dollar(code: String): SoftAST.TokenDocumented[Token.Dollar.type] =
+    Dollar(indexOf(code))
+
+  def Dollar(index: SourceIndex): SoftAST.TokenDocumented[Token.Dollar.type] =
+    TokenDocumented(
+      index = index,
+      token = Token.Dollar
+    )
+
   def Quote(code: String): SoftAST.TokenDocumented[Token.Quote.type] =
     Quote(indexOf(code))
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToStringInterpolationSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToStringInterpolationSpec.scala
@@ -1,0 +1,100 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.pc.search.gotodef
+
+import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class GoToStringInterpolationSpec extends AnyWordSpec with Matchers {
+
+  "return empty" when {
+    "Strict-AST" when {
+      "BString is string interpolated" in {
+        goToDefinition()(
+          """
+            |Contract Test() {
+            |
+            |  fn test() -> () {
+            |    let message = b`some debug message`
+            |    let log = b`Info: ${messag@@e}`
+            |  }
+            |
+            |}
+            |""".stripMargin
+        )
+      }
+    }
+
+    "SoftAST" when {
+      "BString is string interpolated" when {
+        "within a block" in {
+          goToDefinitionSoft()(
+            """
+              |{
+              |  let message = b`some debug message`
+              |  let log = b`Info: ${messag@@e}`
+              |}
+              |""".stripMargin
+          )
+        }
+
+        "without block" in {
+          goToDefinitionSoft()(
+            """
+              |let message = b`some debug message`
+              |let log = b`Info: ${messag@@e}`
+              |""".stripMargin
+          )
+        }
+      }
+    }
+  }
+
+  "return non-empty" when {
+    "Strict-AST" when {
+      "Debug event contains string interpolation" in {
+        goToDefinition()(
+          """
+            |Contract Test() {
+            |
+            |  fn test() -> () {
+            |    let >>message<< = b`some debug message`
+            |    emit Debug(`Info: ${messag@@e}`)
+            |  }
+            |
+            |}
+            |""".stripMargin
+        )
+      }
+    }
+
+    "SoftAST" when {
+      "nested interpolated strings" when {
+        "within a block" in {
+          goToDefinitionSoft()(
+            """
+              |{
+              |  let ERROR_ID = 404
+              |  let >>message<< = `Error: ${ERROR_ID}. Message: Some debug message`
+              |  let log = `Log: ${messag@@e}`
+              |}
+              |""".stripMargin
+          )
+        }
+
+        "without block" in {
+          goToDefinitionSoft()(
+            """
+              |let ERROR_ID = 404
+              |let >>message<< = `Error: ${ERROR_ID}. Message: Some debug message`
+              |let log = `Log: ${messag@@e}`
+              |""".stripMargin
+          )
+        }
+      }
+    }
+  }
+
+}

--- a/utils/src/main/scala/org/alephium/ralph/lsp/utils/CollectionUtil.scala
+++ b/utils/src/main/scala/org/alephium/ralph/lsp/utils/CollectionUtil.scala
@@ -59,4 +59,22 @@ object CollectionUtil {
 
   }
 
+  /**
+   * Merges consecutive [[Left]] or [[Right]] elements in a sequence of `Either[Seq[Code], Seq[InterpolatedBlock]]`.
+   */
+  def mergeConsecutive[L, R](seq: Seq[Either[Seq[L], Seq[R]]]): Seq[Either[Seq[L], Seq[R]]] =
+    seq.foldLeft(Seq.empty[Either[Seq[L], Seq[R]]]) {
+      case (result, current) =>
+        (result.lastOption, current) match {
+          case (Some(Left(previous)), Left(current)) =>
+            result.init :+ Left(previous ++ current)
+
+          case (Some(Right(previous)), Right(current)) =>
+            result.init :+ Right(previous ++ current)
+
+          case _ =>
+            result :+ current
+        }
+    }
+
 }


### PR DESCRIPTION
- Towards #403 
- Towards #404 

## Example

```rust
let error_code = 404
let log = `Error: ${error_code}. Message: ${error.getMessage()}`
```
## Escaped Interpolation

Similar to ralphc, `$$` escapes interpolation. For example, following will not apply string-interpolation:

```rust
let log = `Error: $${error_code} - $${message}`
```

## Soft: Go-to-definition

Enabled with the implemented parser. No direct changes required. 
