### PR TITLE
Enable `ArrayParser` for Go-To-Definition (Soft)

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/AssignmentParser.scala
@@ -92,6 +92,7 @@ private object AssignmentParser {
         ReferenceCallParser.parseOrFail |
         AnnotationParser.parseOrFail |
         TupleParser.parseOrFail |
+        ArrayParser.parseOrFail |
         ByteVecParser.parseOrFail |
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ExpressionParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ExpressionParser.scala
@@ -50,6 +50,7 @@ private object ExpressionParser {
         ReferenceCallParser.parseOrFail |
         AnnotationParser.parseOrFail |
         TupleParser.parseOrFail |
+        ArrayParser.parseOrFail |
         ByteVecParser.parseOrFail |
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/FunctionParser.scala
@@ -109,6 +109,7 @@ private object FunctionParser {
       IfElseParser.parseOrFail |
         ElseParser.parseOrFail |
         TupleParser.parseOrFail |
+        ArrayParser.parseOrFail |
         ByteVecParser.parseOrFail |
         NumberParser.parseOrFail |
         IdentifierParser.parseOrFail

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/GroupParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/GroupParser.scala
@@ -173,6 +173,7 @@ private object GroupParser {
         ElseParser.parseOrFail |
         ReferenceCallParser.parseOrFail |
         TupleParser.parseOrFail |
+        ArrayParser.parseOrFail |
         ByteVecParser.parseOrFail |
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/InfixCallParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/InfixCallParser.scala
@@ -38,6 +38,7 @@ private object InfixCallParser {
         ElseParser.parseOrFail |
         ReferenceCallParser.parseOrFail |
         TupleParser.parseOrFail |
+        ArrayParser.parseOrFail |
         ByteVecParser.parseOrFail |
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |
@@ -57,6 +58,7 @@ private object InfixCallParser {
         ReferenceCallParser.parseOrFail |
         AnnotationParser.parseOrFail |
         TupleParser.parseOrFail |
+        ArrayParser.parseOrFail |
         ByteVecParser.parseOrFail |
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MethodCallParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/MethodCallParser.scala
@@ -79,6 +79,7 @@ private object MethodCallParser {
     P {
       ReferenceCallParser.parseOrFail |
         TupleParser.parseOrFail |
+        ArrayParser.parseOrFail |
         ByteVecParser.parseOrFail |
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReturnParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReturnParser.scala
@@ -37,6 +37,7 @@ private object ReturnParser {
         ElseParser.parseOrFail |
         AnnotationParser.parseOrFail |
         TupleParser.parseOrFail |
+        ArrayParser.parseOrFail |
         ByteVecParser.parseOrFail |
         NumberParser.parseOrFail |
         BooleanParser.parseOrFail |

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeAssignmentParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TypeAssignmentParser.scala
@@ -42,6 +42,7 @@ private object TypeAssignmentParser {
   private def rightExpression[Unknown: P] =
     P {
       TupleParser.parseOrFail |
+        ArrayParser.parseOrFail |
         IdentifierParser.parseOrFail
     }
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArraySpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArraySpec.scala
@@ -24,29 +24,70 @@ class GoToArraySpec extends AnyWordSpec with Matchers {
   }
 
   "return non-empty" when {
-    "there is a single array definition" in {
-      goToDefinition()(
-        """
-          |Contract Test(>>array<<: [U256; 2])  {
-          |  fn main() -> () {
-          |    let head = arra@@y[0]
-          |  }
-          |}
-          |""".stripMargin
-      )
-    }
-
-    "there are duplicate array definitions" when {
-      "without inheritance" in {
+    "there is a single array definition" when {
+      "strict" in {
         goToDefinition()(
           """
             |Contract Test(>>array<<: [U256; 2])  {
-            |  fn main(>>array<<: [U256; 2]) -> () {
+            |  fn main() -> () {
             |    let head = arra@@y[0]
             |  }
             |}
             |""".stripMargin
         )
+      }
+
+      "soft" when {
+        "no function" in {
+          goToDefinitionSoft()(
+            """
+              |Contract Test(>>array<<: [U256; 2])  {
+              |  arra@@y[0]
+              |}
+              |""".stripMargin
+          )
+        }
+
+        "no contract" in {
+          goToDefinitionSoft()(
+            """
+              |let >>array<< = []
+              |arra@@y[0]
+              |""".stripMargin
+          )
+        }
+      }
+    }
+
+    "there are duplicate array definitions" when {
+      "without inheritance" when {
+        "strict" in {
+          goToDefinition()(
+            """
+              |Contract Test(>>array<<: [U256; 2])  {
+              |  fn main(>>array<<: [U256; 2]) -> () {
+              |    let head = arra@@y[0]
+              |  }
+              |}
+              |""".stripMargin
+          )
+        }
+
+        "soft" in {
+          goToDefinitionSoft()(
+            """
+              |Contract Test(>>array<<: [U256; 2])  {
+              |
+              |  let >>array<< = [0, 1]
+              |
+              |  fn main(>>array<<: [U256; 2]) {
+              |    let >>array<< = [0, 1]
+              |    let head = arra@@y[0]
+              |  }
+              |}
+              |""".stripMargin
+          )
+        }
       }
 
       "within inheritance" when {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArraySpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToArraySpec.scala
@@ -25,7 +25,7 @@ class GoToArraySpec extends AnyWordSpec with Matchers {
 
   "return non-empty" when {
     "there is a single array definition" in {
-      goToDefinitionStrict()(
+      goToDefinition()(
         """
           |Contract Test(>>array<<: [U256; 2])  {
           |  fn main() -> () {
@@ -38,7 +38,7 @@ class GoToArraySpec extends AnyWordSpec with Matchers {
 
     "there are duplicate array definitions" when {
       "without inheritance" in {
-        goToDefinitionStrict()(
+        goToDefinition()(
           """
             |Contract Test(>>array<<: [U256; 2])  {
             |  fn main(>>array<<: [U256; 2]) -> () {
@@ -51,7 +51,7 @@ class GoToArraySpec extends AnyWordSpec with Matchers {
 
       "within inheritance" when {
         "single source-file" in {
-          goToDefinitionStrict()(
+          goToDefinition()(
             """
               |Contract Parent(>>array<<: [U256; 2])  {
               |  fn main(array: [U256; 2]) -> () {
@@ -69,7 +69,7 @@ class GoToArraySpec extends AnyWordSpec with Matchers {
         }
 
         "multiple source-files" in {
-          goToDefinitionStrict()(
+          goToDefinition()(
             """
               |Contract Parent(>>array<<: [U256; 2])  {
               |  fn main(array: [U256; 2]) -> () {


### PR DESCRIPTION
- Towards #404 