### PR TITLE
Enable `MapAssignmentParser` for go-to-definition (`SoftAST`)

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ExpressionParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ExpressionParser.scala
@@ -34,7 +34,8 @@ private object ExpressionParser {
 
   def parseOrFail[Unknown: P]: P[SoftAST.ExpressionAST] =
     P {
-      TypeAssignmentParser.parseOrFail |
+      MapAssignmentParser.parseOrFail |
+        TypeAssignmentParser.parseOrFail |
         AssignmentParser.parseOrFail |
         InfixCallParser.parseOrFail |
         MethodCallParser.parseOrFail |

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
@@ -101,6 +101,9 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
       case Some(Node(struct: SoftAST.Struct, _)) if struct.identifier == identNode.data =>
         self()
 
+      case Some(Node(map: SoftAST.MapAssignment, _)) if map.identifier == identNode.data =>
+        self()
+
       case Some(node @ Node(assignment: SoftAST.Assignment, _)) if assignment.expressionLeft == identNode.data =>
         node.parent match {
           // If it's an assignment, it must also be a variable declaration for the current node to be a self.
@@ -333,6 +336,13 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
       case Node(assignment: SoftAST.TypeAssignment, _) if !detectCallSyntax || (!target.isReferenceCall() && !target.isWithinEmit()) =>
         searchExpression(
           expression = assignment,
+          target = target,
+          sourceCode = sourceCode
+        )
+
+      case Node(map: SoftAST.MapAssignment, _) if !detectCallSyntax || (!target.isReferenceCall() && !target.isWithinEmit()) =>
+        searchExpression(
+          expression = map,
           target = target,
           sourceCode = sourceCode
         )
@@ -1308,6 +1318,14 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
         // expand type assigment and search within the left expression
         searchExpression(
           expression = ast.expressionLeft,
+          target = target,
+          sourceCode = sourceCode
+        )
+
+      case map: SoftAST.MapAssignment =>
+        // expand mapping assignment and search within the identifier
+        searchIdentifier(
+          identifier = map.identifier,
           target = target,
           sourceCode = sourceCode
         )

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToMapSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToMapSpec.scala
@@ -11,7 +11,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "map does not exist" in {
-      goToDefinitionStrict()(
+      goToDefinition()(
         """
           |Contract Test() {
           |
@@ -26,7 +26,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
 
   "return self" when {
     "map definition itself is selected" in {
-      goToDefinitionStrict()(
+      goToDefinition()(
         """
           |Abstract Contract Parent() {
           |  mapping[Address, U256] >>coun@@ters<<
@@ -37,7 +37,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
 
     "duplicate maps exist" when {
       "first map is selected" in {
-        goToDefinitionStrict()(
+        goToDefinition()(
           """
             |Abstract Contract Parent() {
             |  mapping[Address, U256] >>coun@@ters<<
@@ -48,7 +48,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
       }
 
       "second map is selected" in {
-        goToDefinitionStrict()(
+        goToDefinition()(
           """
             |Abstract Contract Parent() {
             |  mapping[Address, U256] counters
@@ -62,7 +62,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
 
   "return non-empty" when {
     "map value is extracted" in {
-      goToDefinitionStrict()(
+      goToDefinition()(
         """
           |Abstract Contract Parent() {
           |  mapping[Address, U256] >>counters<<
@@ -81,7 +81,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
     }
 
     "map value is set" in {
-      goToDefinitionStrict()(
+      goToDefinition()(
         """
           |Abstract Contract Parent() {
           |  mapping[Address, U256] >>counters<<
@@ -100,7 +100,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
     }
 
     "map is inserted" in {
-      goToDefinitionStrict()(
+      goToDefinition()(
         """
           |Abstract Contract Parent() {
           |  mapping[Address, U256] >>counters<<
@@ -119,7 +119,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
     }
 
     "map item is remove" in {
-      goToDefinitionStrict()(
+      goToDefinition()(
         """
           |Abstract Contract Parent() {
           |  mapping[Address, U256] >>counters<<
@@ -138,7 +138,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
     }
 
     "map is checked for contains" in {
-      goToDefinitionStrict()(
+      goToDefinition()(
         """
           |Abstract Contract Parent() {
           |  mapping[Address, U256] >>counters<<
@@ -157,7 +157,7 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
     }
 
     "map function is returned" in {
-      goToDefinitionStrict()(
+      goToDefinition()(
         """
           |Abstract Contract Parent() {
           |  mapping[Address, U256] >>counters<<

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToMapSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToMapSpec.scala
@@ -58,6 +58,48 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
         )
       }
     }
+
+    "soft parseable (contains syntax errors - not strict parseable)" when {
+      "duplicates exist" when {
+        "first map is selected" in {
+          goToDefinitionSoft() {
+            """
+              |mapping[U256, U256] >>ma@@p<<
+              |mapping[U256, U256] map
+              |""".stripMargin
+          }
+        }
+
+        "second map is selected" in {
+          goToDefinitionSoft() {
+            """
+              |mapping[U256, U256] map
+              |mapping[U256, U256] >>ma@@p<<
+              |""".stripMargin
+          }
+        }
+      }
+
+      "types are not provided" when {
+        "first map is selected" in {
+          goToDefinitionSoft() {
+            """
+              |mapping[] >>ma@@p<<
+              |mapping[] map
+              |""".stripMargin
+          }
+        }
+
+        "second map is selected" in {
+          goToDefinitionSoft() {
+            """
+              |mapping[] map
+              |mapping[] >>ma@@p<<
+              |""".stripMargin
+          }
+        }
+      }
+    }
   }
 
   "return non-empty" when {
@@ -173,6 +215,35 @@ class GoToMapSpec extends AnyWordSpec with Matchers {
           |}
           |""".stripMargin
       )
+    }
+
+    "soft parseable (contains syntax errors - not strict parseable)" when {
+      "the map is within" when {
+        "contract block" in {
+          goToDefinitionSoft() {
+            """
+              |Contract Main {
+              |  mapping[Blah, ] >>map<<
+              |  ma@@p
+              |""".stripMargin
+          }
+        }
+
+        "function block" in {
+          goToDefinitionSoft() {
+            """
+              |Contract Main {
+              |  mapping >>map<<
+              |
+              |  fn main {
+              |    mapping[] >>map<<
+              |    ma@@p
+              |  }
+              |}
+              |""".stripMargin
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
- Towards #404

## Status

- With this PR, all the features implemented for strict-AST's go-to-definition are now also supported for `SoftAST`.
- All go-to-definition test-cases pass for both strict-AST and `SoftAST` (no test-cases directly call `goToDefinitionStrict`).
- Two more parsers are pending in #403.
- After that, issue #387 remains before we can begin preparing `SoftParser` and `SoftAST` for a stable release.