### PR TITLE
Store `Ast.GlobalState` when compilation error

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/CompilerAccess.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/CompilerAccess.scala
@@ -62,6 +62,6 @@ trait CompilerAccess {
       parsedSource: Seq[Ast.GlobalDefinition],
       options: CompilerOptions,
       workspaceErrorURI: URI
-    )(implicit logger: ClientLogger): Either[CompilerMessage.AnyError, CompilerRunResult]
+    )(implicit logger: ClientLogger): CompilerRunResult
 
 }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/CompilerRunGlobalState.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/CompilerRunGlobalState.scala
@@ -8,7 +8,7 @@ import org.alephium.ralph.Ast
 
 object CompilerRunGlobalState {
 
-  def apply(state: Option[Ast.GlobalState[StatefulContext]]): CompilerRunGlobalState =
+  def apply(state: Ast.GlobalState[StatefulContext]): CompilerRunGlobalState =
     new CompilerRunGlobalState(state)
 
 }
@@ -16,10 +16,10 @@ object CompilerRunGlobalState {
 /**
  * Exposes the APIs of ralphc returned global state ([[Ast.GlobalState]]) from a completed compiler run.
  */
-class CompilerRunGlobalState private (globalState: Option[Ast.GlobalState[StatefulContext]]) {
+class CompilerRunGlobalState private (globalState: Ast.GlobalState[StatefulContext]) {
 
   def getStruct(typeId: Ast.TypeId): Option[Ast.Struct] =
-    globalState.flatMap(_.tryGetStruct(typeId))
+    globalState.tryGetStruct(typeId)
 
   /**
    * LSP does not assert the contents of [[Ast.GlobalState]]. This is managed by ralphc.

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/CompilerRunResult.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/CompilerRunResult.scala
@@ -4,12 +4,31 @@
 package org.alephium.ralph.lsp.access.compiler
 
 import org.alephium.ralph.{CompiledContract, CompiledScript, Warning}
+import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 
-/**
- * Result of a completed compiler run.
- */
-case class CompilerRunResult(
-    contracts: Array[CompiledContract],
-    scripts: Array[CompiledScript],
-    warnings: Array[Warning],
-    globalState: CompilerRunGlobalState)
+sealed trait CompilerRunResult
+
+object CompilerRunResult {
+
+  /**
+   * Result of a successful compiler run.
+   */
+  case class Compiled(
+      contracts: Array[CompiledContract],
+      scripts: Array[CompiledScript],
+      warnings: Array[Warning],
+      globalState: CompilerRunGlobalState)
+    extends CompilerRunResult
+
+  /**
+   * Result of an errored compiler run.
+   *
+   * @param error       Error representing the exception throw by ralphc.
+   * @param globalState Partially successful compilation state.
+   */
+  case class Errored(
+      error: CompilerMessage.AnyError,
+      globalState: Option[CompilerRunGlobalState])
+    extends CompilerRunResult
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/util/TryUtil.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/util/TryUtil.scala
@@ -12,12 +12,21 @@ import java.net.URI
 object TryUtil {
 
   /** Catch all exceptions thrown by `ralphc` and file-io */
-  def catchAllThrows[T](fileURI: URI): PartialFunction[Throwable, Either[CompilerMessage.AnyError, T]] = {
-    case error: FormattableError =>
-      Left(FormattedError(error))
-
-    case error: Throwable =>
-      Left(ThrowableError(error, fileURI))
+  def catchAllThrows[T](fileURI: URI): PartialFunction[Throwable, Left[CompilerMessage.AnyError, T]] = {
+    case throwable: Throwable =>
+      Left(toCompilerMessage(fileURI, throwable))
   }
+
+  /** Converts ralphc thrown exceptions to [[CompilerMessage.AnyError]] */
+  def toCompilerMessage(
+      fileURI: URI,
+      throwable: Throwable): CompilerMessage.AnyError =
+    throwable match {
+      case error: FormattableError =>
+        FormattedError(error)
+
+      case error: Throwable =>
+        ThrowableError(error, fileURI)
+    }
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/sourcecode/SourceCode.scala
@@ -4,7 +4,7 @@
 package org.alephium.ralph.lsp.pc.sourcecode
 
 import org.alephium.ralph.CompilerOptions
-import org.alephium.ralph.lsp.access.compiler.CompilerAccess
+import org.alephium.ralph.lsp.access.compiler.{CompilerAccess, CompilerRunResult}
 import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, SourceIndexExtra}
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.sourcecode.imports.Importer
@@ -181,7 +181,7 @@ private[pc] object SourceCode {
       compilerOptions: CompilerOptions,
       workspaceErrorURI: URI
     )(implicit compiler: CompilerAccess,
-      logger: ClientLogger): Either[CompilerMessage.AnyError, SourceCodeCompilerRun] =
+      logger: ClientLogger): Either[CompilerRunResult.Errored, SourceCodeCompilerRun] =
     Importer.typeCheck(
       sourceCode = sourceCode,
       dependency = dependency
@@ -233,7 +233,7 @@ private[pc] object SourceCode {
       compilerOptions: CompilerOptions,
       workspaceErrorURI: URI
     )(implicit compiler: CompilerAccess,
-      logger: ClientLogger): Either[CompilerMessage.AnyError, SourceCodeCompilerRun] = {
+      logger: ClientLogger): Either[CompilerRunResult.Errored, SourceCodeCompilerRun] = {
     val sourceTreesOnly =
       sourceTrees.map(_.tree)
 

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceStateBuilder.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceStateBuilder.scala
@@ -3,7 +3,7 @@
 
 package org.alephium.ralph.lsp.pc.workspace
 
-import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
+import org.alephium.ralph.lsp.access.compiler.CompilerRunResult
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeCompilerRun, SourceCodeState}
 
 import scala.collection.immutable.ArraySeq
@@ -13,15 +13,15 @@ private object WorkspaceStateBuilder {
   /** @see [[org.alephium.ralph.lsp.pc.sourcecode.SourceCodeStateBuilder.toSourceCodeState]] */
   def toWorkspaceState(
       currentState: WorkspaceState.Parsed,
-      compilationResult: Either[CompilerMessage.AnyError, SourceCodeCompilerRun]): WorkspaceState.IsCompiled =
+      compilationResult: Either[CompilerRunResult.Errored, SourceCodeCompilerRun]): WorkspaceState.IsCompiled =
     compilationResult match {
       case Left(workspaceError) =>
         // File or sourcePosition position information is not available for this error,
         // report it at project error.
         WorkspaceState.Errored(
           sourceCode = currentState.sourceCode, // SourceCode remains the same as existing state
-          compilerRunGlobalState = None,
-          workspaceErrors = ArraySeq(workspaceError), // errors to report
+          compilerRunGlobalState = workspaceError.globalState,
+          workspaceErrors = ArraySeq(workspaceError.error), // errors to report
           parsed = currentState
         )
 

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/PCEventsSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/PCEventsSpec.scala
@@ -90,7 +90,7 @@ class PCEventsSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenProper
                 // expected workspace
                 workspace = WorkspaceState.Compiled(
                   sourceCode = ArraySeq.empty, // there is no source code
-                  compilerRunGlobalState = Some(CompilerRunGlobalState(None)),
+                  compilerRunGlobalState = Some(CompilerRunGlobalState(null)),
                   parsed = WorkspaceState.Parsed( // Workspace is successfully parsed
                     build = BuildState.Compiled(
                       dependencies = build.dependencies,               // default dependencies are written

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsTupledVariableSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsTupledVariableSpec.scala
@@ -41,8 +41,6 @@ class InlayHintsTupledVariableSpec extends AnyWordSpec with Matchers {
           |  fn test() -> () {
           |    let (one>>: U256<<,
           |         mut bool>>: Bool<<) = tuple()
-          |
-          |    bool = true
           |  }
           |
           |  fn tuple() -> (U256, Bool) {
@@ -62,8 +60,6 @@ class InlayHintsTupledVariableSpec extends AnyWordSpec with Matchers {
           |    @@
           |    let (mut one>>: U256<<,
           |         bool>>: Bool<<) = tuple()
-          |
-          |    one = 1
           |  }
           |
           |  fn tuple() -> (U256, Bool) {


### PR DESCRIPTION
- Resolves #518
- Stores `Ast.GlobalState` even when there are compilation errors.