### PR TITLE
Allow configuring `DependencyDownloaders` in `TestMultiCodeProvider`

### DIFF
--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/hover/multi/HoverMultiSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/hover/multi/HoverMultiSpec.scala
@@ -22,7 +22,7 @@ class HoverMultiSpec extends AnyWordSpec with Matchers {
   implicit val ec: ExecutionContext     = ExecutionContext.Implicits.global
 
   "return only one hover info" in {
-    val result = hoverMulti(
+    val result = hoverMultiWithNativeDependency(
       workspaces = ArraySeq(
         """
             |Contract HoverTest() {


### PR DESCRIPTION
- Targets multi-root test issue in #517.
- **Cause**: Currently `TestMultiCodeProvider` only allows custom dependencies. This PR allows native dependencies (`std` and `built-in`) to also be configured within multi-workspace test-cases.
