### PR TITLE
Parse if-else statements without blocked expressions

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ElseParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ElseParser.scala
@@ -16,15 +16,15 @@ private object ElseParser {
         TokenParser.parseOrFail(Token.Else) ~
         TokenParser.isBoundary(Token.OpenParen, Token.OpenCurly) ~
         SpaceParser.parseOrFail.? ~
-        BlockParser.parseOrFail.? ~
+        IfElseParser.parseBody ~
         Index
     } map {
-      case (from, elseToken, preBlockSpace, block, to) =>
+      case (from, elseToken, preBodySpace, body, to) =>
         SoftAST.Else(
           index = range(from, to),
           elseToken = elseToken,
-          preBlockSpace = preBlockSpace,
-          block = block
+          preBodySpace = preBodySpace,
+          body = body
         )
     }
 

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/IfElseParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/IfElseParser.scala
@@ -18,12 +18,12 @@ private object IfElseParser {
         SpaceParser.parseOrFail.? ~
         TupleParser.parse ~
         SpaceParser.parseOrFail.? ~
-        BlockParser.parseOrFail.? ~
+        (BlockParser.parseOrFail.map(Left(_)) | ExpressionParser.parse.map(Right(_))) ~
         // do not read the space if `else` is not provided
         (SpaceParser.parseOrFail.? ~ ElseParser.parseOrFail).? ~
         Index
     } map {
-      case (from, ifToken, preGroupSpace, group, preBlockSpace, block, elseStatement, to) =>
+      case (from, ifToken, preGroupSpace, group, preBodySpace, block, elseStatement, to) =>
         val (elseSpace, elseAST) =
           elseStatement match {
             case Some((space, statement)) =>
@@ -38,11 +38,15 @@ private object IfElseParser {
           ifToken = ifToken,
           preGroupSpace = preGroupSpace,
           group = group,
-          preBlockSpace = preBlockSpace,
-          block = block,
+          preBodySpace = preBodySpace,
+          body = block,
           preElseSpace = elseSpace,
           elseStatement = elseAST
         )
     }
+
+  /** Parses the body of an `if` or `else` expression */
+  def parseBody[Unknown: P]: P[Either[SoftAST.Block, SoftAST.ExpressionAST]] =
+    P(BlockParser.parseOrFail.map(Left(_)) | ExpressionParser.parse.map(Right(_)))
 
 }

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -750,8 +750,8 @@ object SoftAST {
       ifToken: TokenDocumented[Token.If.type],
       preGroupSpace: Option[Space],
       group: Group[Token.OpenParen.type, Token.CloseParen.type],
-      preBlockSpace: Option[Space],
-      block: Option[Block],
+      preBodySpace: Option[Space],
+      body: Either[Block, ExpressionAST],
       preElseSpace: Option[Space],
       elseStatement: Option[Else])
     extends ExpressionAST
@@ -759,8 +759,8 @@ object SoftAST {
   case class Else(
       index: SourceIndex,
       elseToken: TokenDocumented[Token.Else.type],
-      preBlockSpace: Option[Space],
-      block: Option[Block])
+      preBodySpace: Option[Space],
+      body: Either[Block, ExpressionAST])
     extends ExpressionAST
 
   sealed trait TypeParamsExpectedAST extends ExpressionAST

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ElseParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ElseParserSpec.scala
@@ -29,20 +29,20 @@ class ElseParserSpec extends AnyWordSpec with Matchers {
         SoftAST.Else(
           index = indexOf(">>else<<"),
           elseToken = Else(">>else<<"),
-          preBlockSpace = None,
-          block = None
+          preBodySpace = None,
+          body = Right(ExpressionExpected("else>><<"))
         )
     }
 
-    "fully defined" in {
+    "fully defined with a block" in {
       val elseAST = parseElse("else{ }")
 
       elseAST shouldBe
         SoftAST.Else(
           index = indexOf(">>else{ }<<"),
           elseToken = Else(">>else<<{ }"),
-          preBlockSpace = None,
-          block = Some(
+          preBodySpace = None,
+          body = Left(
             SoftAST.Block(
               index = indexOf("else>>{ }<<"),
               openCurly = OpenCurly("else>>{<< }"),
@@ -53,6 +53,18 @@ class ElseParserSpec extends AnyWordSpec with Matchers {
         )
     }
 
+    "fully defined with an unblocked expressions" in {
+      val elseAST = parseElse("else blah")
+
+      elseAST shouldBe
+        SoftAST.Else(
+          index = indexOf(">>else blah<<"),
+          elseToken = Else(">>else<< blah"),
+          preBodySpace = Some(Space("else>> <<blah")),
+          body = Right(Identifier("else >>blah<<"))
+        )
+    }
+
     "close curly is missing" in {
       val elseAST = parseElse("else{ ")
 
@@ -60,8 +72,8 @@ class ElseParserSpec extends AnyWordSpec with Matchers {
         SoftAST.Else(
           index = indexOf(">>else{ <<"),
           elseToken = Else(">>else<<{ "),
-          preBlockSpace = None,
-          block = Some(
+          preBodySpace = None,
+          body = Left(
             SoftAST.Block(
               index = indexOf("else>>{ <<"),
               openCurly = OpenCurly("else>>{<< "),


### PR DESCRIPTION
Current parser handles 

```rust
if (true) { a } else { b }
```

This update allows parsing the ones without a block

```rust
if (true) a else b
if (true) a else { b }
if (true) { a } else b
```
