### PR TITLE
Allow expression in sized arrays

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ArrayParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ArrayParser.scala
@@ -18,7 +18,7 @@ private object ArrayParser {
       Index ~
         TokenParser.parseOrFail(Token.OpenBracket) ~
         SpaceParser.parseOrFail.? ~
-        IdentifierParser.parse ~
+        ExpressionParser.parse ~
         SpaceParser.parseOrFail.? ~
         TokenParser.parseOrFail(Token.Semicolon) ~
         SpaceParser.parseOrFail.? ~

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -777,7 +777,7 @@ object SoftAST {
       index: SourceIndex,
       openBracket: TokenDocumented[Token.OpenBracket.type],
       preTypeSpace: Option[Space],
-      tpe: IdentifierAST,
+      tpe: ExpressionAST,
       preSemiColonSpace: Option[Space],
       semiColon: TokenDocumented[Token.Semicolon.type],
       preSizeSpace: Option[Space],

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ArraySizedParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ArraySizedParserSpec.scala
@@ -22,7 +22,7 @@ class ArraySizedParserSpec extends AnyWordSpec with Matchers {
           index = indexOf(">>[;]<<"),
           openBracket = OpenBracket(">>[<<;]"),
           preTypeSpace = None,
-          tpe = IdentifierExpected("[>><<;]"),
+          tpe = ExpressionExpected("[>><<;]"),
           preSemiColonSpace = None,
           semiColon = Semicolon("[>>;<<]"),
           preSizeSpace = None,
@@ -41,7 +41,7 @@ class ArraySizedParserSpec extends AnyWordSpec with Matchers {
           index = indexOf(">>[;<<"),
           openBracket = OpenBracket(">>[<<;"),
           preTypeSpace = None,
-          tpe = IdentifierExpected("[>><<;"),
+          tpe = ExpressionExpected("[>><<;"),
           preSemiColonSpace = None,
           semiColon = Semicolon("[>>;<<"),
           preSizeSpace = None,
@@ -74,6 +74,33 @@ class ArraySizedParserSpec extends AnyWordSpec with Matchers {
         preCloseBracketSpace = None,
         closeBracket = BlockBracket("[Type; Size>>]<<")
       )
+  }
+
+  "allow expressions" in {
+    val _ast =
+      parseArray("[if(true) true else false; getSize()]")
+
+    val ast = _ast.asInstanceOf[SoftAST.ArraySized]
+
+    ast.copy(tpe = null, size = null) shouldBe
+      SoftAST.ArraySized(
+        index = indexOf(">>[if(true) true else false; getSize()]<<"),
+        openBracket = OpenBracket(">>[<<if(true) true else false; getSize()]"),
+        preTypeSpace = None,
+        tpe = null,
+        preSemiColonSpace = None,
+        semiColon = Semicolon("[if(true) true else false>>;<< getSize()]"),
+        preSizeSpace = Some(Space("[if(true) true else false;>> <<getSize()]")),
+        size = null,
+        preCloseBracketSpace = None,
+        closeBracket = BlockBracket("[if(true) true else false; getSize()>>]<<")
+      )
+
+    ast.tpe shouldBe a[SoftAST.IfElse]
+    ast.tpe.toCode() shouldBe "if(true) true else false"
+
+    ast.size shouldBe a[SoftAST.ReferenceCall]
+    ast.size.toCode() shouldBe "getSize()"
   }
 
 }


### PR DESCRIPTION
Currently, the sized array parser expects the type to be a concrete type (string identifier). 

```rust
let array = [TheType; Size]
```

But expressions are allowed in ralphc:

```rust
let array = [if(true) true else false; 2]
```