### PR TITLE
Reusable `SearchCache`

### DIFF
--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/RalphLangServer.scala
@@ -9,6 +9,7 @@ import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.pc.{PC, PCState, PCStates}
 import org.alephium.ralph.lsp.pc.diagnostic.Diagnostics
 import org.alephium.ralph.lsp.pc.search.MultiCodeProvider
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.pc.search.gotoref.multi.GoToRefMultiSetting
 import org.alephium.ralph.lsp.pc.workspace._
 import org.alephium.ralph.lsp.pc.workspace.build.error.ErrorUnknownFileType
@@ -47,6 +48,7 @@ object RalphLangServer extends StrictImplicitLogging {
         client = Some(client),
         listener = Some(listener),
         pcStates = PCStates.empty,
+        searchCache = SearchCache(maxWorkspaces = 1),
         clientAllowsWatchedFilesDynamicRegistration = clientAllowsWatchedFilesDynamicRegistration,
         trace = Trace.Off,
         shutdownReceived = false
@@ -64,6 +66,7 @@ object RalphLangServer extends StrictImplicitLogging {
         client = None,
         listener = None,
         pcStates = PCStates.empty,
+        searchCache = SearchCache(maxWorkspaces = 1),
         clientAllowsWatchedFilesDynamicRegistration = false,
         trace = Trace.Off,
         shutdownReceived = false
@@ -182,6 +185,9 @@ class RalphLangServer private (
       client = getClient(),
       trace = state.trace
     )
+
+  private implicit def searchCache: SearchCache =
+    thisServer.state.searchCache
 
   /**
    * An initial call to this function is required before this server can start processing request.

--- a/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/state/ServerState.scala
+++ b/lsp-server/src/main/scala/org/alephium/ralph/lsp/server/state/ServerState.scala
@@ -4,6 +4,7 @@
 package org.alephium.ralph.lsp.server.state
 
 import org.alephium.ralph.lsp.pc.{PCState, PCStates}
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.server.RalphLangClient
 
 import java.net.URI
@@ -23,6 +24,7 @@ case class ServerState(
     client: Option[RalphLangClient],
     listener: Option[JFuture[Void]],
     pcStates: PCStates,
+    searchCache: SearchCache,
     clientAllowsWatchedFilesDynamicRegistration: Boolean,
     trace: Trace,
     shutdownReceived: Boolean) {

--- a/lsp-server/src/test/scala/org/alephium/ralph/lsp/server/RalphLangServerSpec.scala
+++ b/lsp-server/src/test/scala/org/alephium/ralph/lsp/server/RalphLangServerSpec.scala
@@ -5,7 +5,8 @@ package org.alephium.ralph.lsp.server
 
 import org.alephium.ralph.lsp.access.compiler.CompilerAccess
 import org.alephium.ralph.lsp.access.file.FileAccess
-import org.alephium.ralph.lsp.pc.{PCStates, PCState}
+import org.alephium.ralph.lsp.pc.{PCState, PCStates}
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.server.state.{ServerState, Trace}
 import org.eclipse.lsp4j._
@@ -82,6 +83,7 @@ class RalphLangServerSpec extends AnyWordSpec with Matchers with MockFactory wit
                 )
               )
             ),
+          searchCache = SearchCache(maxWorkspaces = 1),
           clientAllowsWatchedFilesDynamicRegistration = false,
           trace = Trace.Off,
           shutdownReceived = false

--- a/lsp-server/src/test/scala/org/alephium/ralph/lsp/server/TestServerState.scala
+++ b/lsp-server/src/test/scala/org/alephium/ralph/lsp/server/TestServerState.scala
@@ -3,7 +3,8 @@
 
 package org.alephium.ralph.lsp.server
 
-import org.alephium.ralph.lsp.pc.{PCStates, PCState}
+import org.alephium.ralph.lsp.pc.{PCState, PCStates}
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.server.state.{ServerState, Trace}
 
@@ -28,6 +29,7 @@ object TestServerState {
       client = None,
       listener = None,
       pcStates = PCStates(pcStates.to(ArraySeq)),
+      searchCache = SearchCache(maxWorkspaces = pcStates.size),
       clientAllowsWatchedFilesDynamicRegistration = Random.nextBoolean(),
       trace = Random.shuffle(Trace.all.toList).head,
       shutdownReceived = Random.nextBoolean()

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PCSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PCSearcher.scala
@@ -4,6 +4,7 @@
 package org.alephium.ralph.lsp.pc
 
 import org.alephium.ralph.lsp.pc.search.CodeProvider
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.utils.URIUtil.isFileScheme
@@ -37,6 +38,7 @@ object PCSearcher extends StrictImplicitLogging {
       isCancelled: IsCancelled,
       state: PCState
     )(implicit provider: CodeProvider[S, I, O],
+      searchCache: SearchCache,
       logger: ClientLogger): Iterator[O] =
     if (!isFileScheme(fileURI) || isCancelled.check())
       Iterator.empty

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/CodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/CodeProvider.scala
@@ -15,6 +15,7 @@ import org.alephium.ralph.lsp.pc.search.hover.HoverCodeProvider
 import org.alephium.ralph.lsp.pc.search.inlayhints.InlayHintsCodeProvider
 import org.alephium.ralph.lsp.pc.search.rename.GoToRenameCodeProvider
 import org.alephium.ralph.lsp.pc.search.CodeProvider.{searchWorkspace, searchWorkspaceAndDependencies}
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
 import org.alephium.ralph.lsp.pc.workspace.{WorkspaceSearcher, WorkspaceState}
 import org.alephium.ralph.lsp.utils.log.ClientLogger
@@ -49,6 +50,7 @@ trait CodeProvider[S, I, O] extends Product {
       workspace: WorkspaceState.IsSourceAware,
       searchSettings: I
     )(implicit provider: CodeProvider[S, I, O],
+      searchCache: SearchCache,
       logger: ClientLogger): Option[Either[CompilerMessage.Error, Iterator[O]]] =
     search(
       line = linePosition.line,
@@ -77,6 +79,7 @@ trait CodeProvider[S, I, O] extends Product {
       workspace: WorkspaceState.IsSourceAware,
       searchSettings: I
     )(implicit provider: CodeProvider[S, I, O],
+      searchCache: SearchCache,
       logger: ClientLogger): Option[Either[CompilerMessage.Error, Iterator[O]]] =
     // if the fileURI belongs to the workspace, then search just within that workspace
     if (URIUtil.contains(workspace.build.contractURI, fileURI))
@@ -113,7 +116,8 @@ trait CodeProvider[S, I, O] extends Product {
       sourceCode: S,
       workspace: WorkspaceState.IsSourceAware,
       searchSettings: I
-    )(implicit logger: ClientLogger): Iterator[O]
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[O]
 
 }
 
@@ -165,6 +169,7 @@ object CodeProvider {
       workspace: WorkspaceState.IsSourceAware,
       searchSettings: I
     )(implicit provider: CodeProvider[S, I, O],
+      searchCache: SearchCache,
       logger: ClientLogger): Option[Either[CompilerMessage.Error, Iterator[O]]] =
     // Search on dependencies should only run for go-to definitions and hover requests. Code-completion is ignored.
     if (provider == CodeProvider.goToDef || provider == CodeProvider.goToRef || provider == CodeProvider.hover)
@@ -223,6 +228,7 @@ object CodeProvider {
       workspace: WorkspaceState.IsSourceAware,
       searchSettings: I
     )(implicit provider: CodeProvider[S, I, O],
+      searchCache: SearchCache,
       logger: ClientLogger): Option[Either[CompilerMessage.Error, Iterator[O]]] =
     getParsedStateForCodeProvider(
       fileURI = fileURI,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/MultiCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/MultiCodeProvider.scala
@@ -5,6 +5,7 @@ package org.alephium.ralph.lsp.pc.search
 
 import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, LinePosition}
 import org.alephium.ralph.lsp.pc.PCStates
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.pc.search.completion.multi.CompletionMultiCodeProvider
 import org.alephium.ralph.lsp.pc.search.completion.Suggestion
 import org.alephium.ralph.lsp.pc.search.gotodef.multi.GoToDefMultiCodeProvider
@@ -50,7 +51,8 @@ trait MultiCodeProvider[I, O] {
       isCancelled: IsCancelled,
       pcStates: PCStates,
       settings: I
-    )(implicit logger: ClientLogger,
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger,
       ec: ExecutionContext): Future[Either[CompilerMessage.Error, ArraySeq[O]]]
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/cache/SearchCache.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/cache/SearchCache.scala
@@ -9,7 +9,17 @@ import org.alephium.ralph.lsp.utils.WeakHashMapBase
 
 import java.util
 
-case class SearchCache() extends WeakHashMapBase[WorkspaceState.IsSourceAware, WorkspaceSearchCache](new util.WeakHashMap(1, 1)) {
+/**
+ * A cache that stores [[WorkspaceState]] related search information.
+ *
+ * The [[util.WeakHashMap]] is configured to `initialCapacity` and `loadFactor` both set to `1` because
+ * workspace are not expected to often and dynamically.
+ *
+ * `loadFactor = 1` because the workspaces are expected to be mostly single-root workspaces, rather than multi-root workspaces.
+ *
+ * TODO: Check if setting [[maxWorkspaces]] to the currently configured multi-root workspaces improves performance.
+ */
+case class SearchCache(maxWorkspaces: Int) extends WeakHashMapBase[WorkspaceState.IsSourceAware, WorkspaceSearchCache](new util.WeakHashMap(maxWorkspaces, 1)) {
 
   def get(
       workspace: WorkspaceState.IsSourceAware

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/cache/SearchCache.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/cache/SearchCache.scala
@@ -1,7 +1,7 @@
 // Copyright (c) Alephium
 // SPDX-License-Identifier: LGPL-3.0-only
 
-package org.alephium.ralph.lsp.pc.search.gotodef.soft
+package org.alephium.ralph.lsp.pc.search.cache
 
 import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
 import org.alephium.ralph.lsp.pc.workspace.{WorkspaceSearcher, WorkspaceState}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/cache/SearchCache.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/cache/SearchCache.scala
@@ -3,51 +3,20 @@
 
 package org.alephium.ralph.lsp.pc.search.cache
 
-import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
-import org.alephium.ralph.lsp.pc.workspace.{WorkspaceSearcher, WorkspaceState}
-import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
+import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.utils.log.ClientLogger
+import org.alephium.ralph.lsp.utils.WeakHashMapBase
 
-import scala.collection.immutable.ArraySeq
+import java.util
 
-object SearchCache {
+case class SearchCache() extends WeakHashMapBase[WorkspaceState.IsSourceAware, WorkspaceSearchCache](new util.WeakHashMap(1, 1)) {
 
-  def apply(workspaceState: WorkspaceState.IsSourceAware)(implicit logger: ClientLogger): SearchCache =
-    new SearchCache(workspaceState)
-
-}
-
-/**
- * Caches data created and reused when searching local, inherited and global scopes.
- *
- * A single search may accesses these scopes multiple times.
- *
- * TODO: Move this to a centralised cache to increase reusability.
- *
- * @param workspace The workspace being search.
- */
-final class SearchCache(val workspace: WorkspaceState.IsSourceAware)(implicit logger: ClientLogger) {
-
-  /**
-   * All workspace source trees in-scope.
-   */
-  lazy val trees: ArraySeq[SourceLocation.CodeSoft] =
-    WorkspaceSearcher.collectAllTreesSoft(workspace)
-
-  /**
-   * All built-in trees excluding the primitives.
-   */
-  lazy val builtInTrees: ArraySeq[SourceLocation.CodeSoft] =
-    WorkspaceSearcher.collectAllDependencyTreesSoft(
-      dependencyID = DependencyID.BuiltIn,
-      build = workspace.build
-    ) match {
-      case Some((builtIn, builtInTrees)) =>
-        // Primitives should not be included within inheritance search.
-        builtInTrees.filter(!_.parsed.isPrimitive(builtIn))
-
-      case None =>
-        ArraySeq.empty
-    }
+  def get(
+      workspace: WorkspaceState.IsSourceAware
+    )(implicit logger: ClientLogger): WorkspaceSearchCache =
+    getOrPut(
+      key = workspace,
+      value = new WorkspaceSearchCache(workspace)
+    )
 
 }

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/cache/WorkspaceSearchCache.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/cache/WorkspaceSearchCache.scala
@@ -1,0 +1,51 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.pc.search.cache
+
+import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
+import org.alephium.ralph.lsp.pc.workspace.{WorkspaceSearcher, WorkspaceState}
+import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
+import org.alephium.ralph.lsp.utils.log.ClientLogger
+
+import scala.collection.immutable.ArraySeq
+
+object WorkspaceSearchCache {
+
+  def apply(workspaceState: WorkspaceState.IsSourceAware)(implicit logger: ClientLogger): WorkspaceSearchCache =
+    new WorkspaceSearchCache(workspaceState)
+
+}
+
+/**
+ * Caches data created and reused when searching local, inherited and global scopes.
+ *
+ * A single search may access these scopes multiple times.
+ *
+ * @param workspace The workspace being search.
+ */
+final class WorkspaceSearchCache(val workspace: WorkspaceState.IsSourceAware)(implicit logger: ClientLogger) {
+
+  /**
+   * All workspace source trees in-scope.
+   */
+  lazy val trees: ArraySeq[SourceLocation.CodeSoft] =
+    WorkspaceSearcher.collectAllTreesSoft(workspace)
+
+  /**
+   * All built-in trees excluding the primitives.
+   */
+  lazy val builtInTrees: ArraySeq[SourceLocation.CodeSoft] =
+    WorkspaceSearcher.collectAllDependencyTreesSoft(
+      dependencyID = DependencyID.BuiltIn,
+      build = workspace.build
+    ) match {
+      case Some((builtIn, builtInTrees)) =>
+        // Primitives should not be included within inheritance search.
+        builtInTrees.filter(!_.parsed.isPrimitive(builtIn))
+
+      case None =>
+        ArraySeq.empty
+    }
+
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/CodeCompletionProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/CodeCompletionProvider.scala
@@ -7,7 +7,8 @@ import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra._
 import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.lsp.pc.search.CodeProvider
-import org.alephium.ralph.lsp.pc.sourcecode.{SourceLocation, SourceCodeState}
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
+import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 
@@ -22,7 +23,8 @@ private[search] case object CodeCompletionProvider extends CodeProvider[SourceCo
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware,
       searchSettings: Unit
-    )(implicit logger: ClientLogger): Iterator[Suggestion] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[Suggestion] =
     // find the statement where this cursorIndex sits.
     sourceCode.astStrict.statements.find(_.index contains cursorIndex) match {
       case Some(statement) =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/multi/CompletionMultiCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/completion/multi/CompletionMultiCodeProvider.scala
@@ -7,6 +7,7 @@ import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.pc.search.{CodeProvider, MultiCodeProvider}
 import org.alephium.ralph.lsp.pc.search.completion.Suggestion
 import org.alephium.ralph.lsp.pc.PCStates
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.lsp.utils.IsCancelled
@@ -27,7 +28,8 @@ private[search] case object CompletionMultiCodeProvider extends MultiCodeProvide
       isCancelled: IsCancelled,
       pcStates: PCStates,
       settings: Unit
-    )(implicit logger: ClientLogger,
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger,
       ec: ExecutionContext): Future[Either[CompilerMessage.Error, ArraySeq[Suggestion]]] =
     if (isCancelled.check() || !isFileScheme(fileURI))
       Future.successful(Right(ArraySeq.empty))
@@ -68,7 +70,8 @@ private[search] case object CompletionMultiCodeProvider extends MultiCodeProvide
       character: Int,
       isCancelled: IsCancelled,
       workspace: WorkspaceState
-    )(implicit logger: ClientLogger): ArraySeq[Suggestion] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): ArraySeq[Suggestion] =
     if (isCancelled.check())
       ArraySeq.empty
     else

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToDefCodeProvider.scala
@@ -7,7 +7,8 @@ import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra._
 import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.lsp.pc.search.CodeProvider
-import org.alephium.ralph.lsp.pc.sourcecode.{SourceLocation, SourceCodeState}
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
+import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.pc.workspace.build.dependency.DependencyID
 
@@ -22,7 +23,8 @@ private[search] case object GoToDefCodeProvider extends CodeProvider[SourceCodeS
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware,
       searchSettings: GoToDefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToDefStrict] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.GoToDefStrict] =
     // find the statement where this cursorIndex sits.
     sourceCode.astStrict.statements.find(_.index contains cursorIndex) match {
       case Some(statement) =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/multi/GoToDefMultiCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/multi/GoToDefMultiCodeProvider.scala
@@ -10,6 +10,7 @@ import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
 import org.alephium.ralph.lsp.pc.PCSearcher.goTo
 import org.alephium.ralph.lsp.pc.search.gotodef.GoToDefSetting
 import org.alephium.ralph.lsp.pc.search.MultiCodeProvider
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.utils.IsCancelled
 import org.alephium.ralph.lsp.utils.log.ClientLogger
 
@@ -42,7 +43,8 @@ private[search] case object GoToDefMultiCodeProvider extends MultiCodeProvider[U
       isCancelled: IsCancelled,
       pcStates: PCStates,
       settings: Unit
-    )(implicit logger: ClientLogger,
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger,
       ec: ExecutionContext): Future[Either[CompilerMessage.Error, ArraySeq[SourceLocation.GoToDef]]] = {
     val settings =
       GoToDefSetting(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefCodeProviderSoft.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefCodeProviderSoft.scala
@@ -6,6 +6,7 @@ package org.alephium.ralph.lsp.pc.search.gotodef.soft
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.SourceIndexExtension
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
 import org.alephium.ralph.lsp.pc.search.CodeProvider
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.pc.search.gotodef.GoToDefSetting
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
@@ -23,7 +24,8 @@ case object GoToDefCodeProviderSoft extends CodeProvider[SourceCodeState.IsParse
       sourceCode: SourceCodeState.IsParsed,
       workspace: WorkspaceState.IsSourceAware,
       searchSettings: (SoftAST.type, GoToDefSetting)
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToDefSoft] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.GoToDefSoft] =
     sourceCode.astSoft.fetch() match {
       case Left(error) =>
         // This will be removed when integration is complete,
@@ -77,7 +79,8 @@ case object GoToDefCodeProviderSoft extends CodeProvider[SourceCodeState.IsParse
       workspace: WorkspaceState.IsSourceAware,
       settings: GoToDefSetting,
       allowLeftShift: Boolean
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToDefSoft] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.GoToDefSoft] =
     blockPart.toNode.findLastChild(_.data.index contains cursorIndex) match {
       case Some(Node(token: SoftAST.CodeToken[_], _)) =>
         if (allowLeftShift && token.index.from == cursorIndex)

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
@@ -12,7 +12,7 @@ import org.alephium.ralph.lsp.utils.Node
 import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.SourceIndex
 import org.alephium.ralph.lsp.pc.search.CodeProvider
-import org.alephium.ralph.lsp.pc.search.cache.SearchCache
+import org.alephium.ralph.lsp.pc.search.cache.{SearchCache, WorkspaceSearchCache}
 
 import scala.annotation.tailrec
 import scala.collection.immutable.ArraySeq
@@ -38,7 +38,7 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
       identNode = identNode,
       parent = identNode.parent,
       sourceCode = sourceCode,
-      cache = SearchCache(workspace),
+      cache = SearchCache().get(workspace),
       settings = settings
     )
 
@@ -61,7 +61,7 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
       identNode: Node[SoftAST.Identifier, SoftAST],
       parent: Option[Node[SoftAST, SoftAST]],
       sourceCode: SourceLocation.CodeSoft,
-      cache: SearchCache,
+      cache: WorkspaceSearchCache,
       settings: GoToDefSetting
     )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToDefSoft] = {
     @inline def runFullSearch() =
@@ -190,7 +190,7 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
   private def search(
       identNode: Node[SoftAST.Identifier, SoftAST],
       sourceCode: SourceLocation.CodeSoft,
-      cache: SearchCache,
+      cache: WorkspaceSearchCache,
       settings: GoToDefSetting,
       detectCallSyntax: Boolean
     )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeSoft[SoftAST.CodeString]] = {
@@ -438,7 +438,7 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
   private def searchInheritance(
       target: Node[SoftAST.Identifier, SoftAST],
       sourceCode: SourceLocation.CodeSoft,
-      cache: SearchCache,
+      cache: WorkspaceSearchCache,
       includeAbstractFuncDef: Boolean,
       detectCallSyntax: Boolean
     )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeSoft[SoftAST.CodeString]] = {
@@ -948,7 +948,7 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
       group: Node[SoftAST.Group[_, _, _], SoftAST],
       identNode: Node[SoftAST.Identifier, SoftAST],
       sourceCode: SourceLocation.CodeSoft,
-      cache: SearchCache,
+      cache: WorkspaceSearchCache,
       settings: GoToDefSetting,
       detectCallSyntax: Boolean
     )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeSoft[SoftAST.CodeString]] =
@@ -1009,7 +1009,7 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
       methodCallNode: Node[SoftAST.MethodCall, SoftAST],
       identNode: Node[SoftAST.Identifier, SoftAST],
       sourceCode: SourceLocation.CodeSoft,
-      cache: SearchCache,
+      cache: WorkspaceSearchCache,
       settings: GoToDefSetting,
       detectCallSyntax: Boolean
     )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeSoft[SoftAST.CodeString]] =
@@ -1159,7 +1159,7 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
       left: Node[SoftAST.Identifier, SoftAST],
       right: Node[SoftAST.Identifier, SoftAST],
       sourceCode: SourceLocation.CodeSoft,
-      cache: SearchCache,
+      cache: WorkspaceSearchCache,
       settings: GoToDefSetting,
       detectCallSyntax: Boolean
     )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeSoft[SoftAST.CodeString]] = {
@@ -1225,7 +1225,7 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
   private def searchTypeDefinitionSoft(
       typeIdentifier: Node[SoftAST.Identifier, SoftAST],
       sourceCode: SourceLocation.CodeSoft,
-      cache: SearchCache,
+      cache: WorkspaceSearchCache,
       settings: GoToDefSetting,
       detectCallSyntax: Boolean
     )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeSoft[SoftAST.TypeDefinitionAST]] = {
@@ -1279,7 +1279,7 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
       theType: SoftAST.Identifier,
       typeProperty: Node[SoftAST.Identifier, SoftAST],
       sourceCode: SourceLocation.CodeSoft,
-      cache: SearchCache,
+      cache: WorkspaceSearchCache,
       settings: GoToDefSetting,
       detectCallSyntax: Boolean
     )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeSoft[SoftAST.CodeString]] = {

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
@@ -12,6 +12,7 @@ import org.alephium.ralph.lsp.utils.Node
 import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.SourceIndex
 import org.alephium.ralph.lsp.pc.search.CodeProvider
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 
 import scala.annotation.tailrec
 import scala.collection.immutable.ArraySeq

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
@@ -33,12 +33,13 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
       sourceCode: SourceLocation.CodeSoft,
       workspace: WorkspaceState.IsSourceAware,
       settings: GoToDefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToDefSoft] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.GoToDefSoft] =
     searchParent(
       identNode = identNode,
       parent = identNode.parent,
       sourceCode = sourceCode,
-      cache = SearchCache().get(workspace),
+      cache = searchCache.get(workspace),
       settings = settings
     )
 
@@ -63,7 +64,8 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
       sourceCode: SourceLocation.CodeSoft,
       cache: WorkspaceSearchCache,
       settings: GoToDefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToDefSoft] = {
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.GoToDefSoft] = {
     @inline def runFullSearch() =
       search(
         identNode = identNode,
@@ -1012,7 +1014,8 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
       cache: WorkspaceSearchCache,
       settings: GoToDefSetting,
       detectCallSyntax: Boolean
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeSoft[SoftAST.CodeString]] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.NodeSoft[SoftAST.CodeString]] =
     (methodCallNode.data.leftExpression, methodCallNode.data.rightExpression) match {
       case (left @ (_: SoftAST.ReferenceCall | _: SoftAST.Identifier), _) if left contains identNode =>
         /*
@@ -1282,7 +1285,8 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
       cache: WorkspaceSearchCache,
       settings: GoToDefSetting,
       detectCallSyntax: Boolean
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeSoft[SoftAST.CodeString]] = {
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.NodeSoft[SoftAST.CodeString]] = {
     // Find all the type definitions.
     val typeDefs =
       CodeProvider

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefCodeProvider.scala
@@ -7,7 +7,8 @@ import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra._
 import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.lsp.pc.search.CodeProvider
-import org.alephium.ralph.lsp.pc.sourcecode.{SourceLocation, SourceCodeState}
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
+import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 
 /**
@@ -21,7 +22,8 @@ private[search] case object GoToRefCodeProvider extends CodeProvider[SourceCodeS
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware,
       searchSettings: GoToRefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToRefStrict] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.GoToRefStrict] =
     // find the statement where this cursorIndex sits.
     sourceCode.astStrict.statements.find(_.index contains cursorIndex) match {
       case Some(statement) =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefIdent.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefIdent.scala
@@ -7,6 +7,7 @@ import org.alephium.ralph.Ast
 import org.alephium.ralph.lsp.access.compiler.ast.Tree
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.SourceIndexExtension
 import org.alephium.ralph.lsp.pc.search.CodeProvider
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.pc.search.gotodef.{GoToDefIdent, GoToDefSetting}
 import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
 import org.alephium.ralph.lsp.pc.workspace.{WorkspaceSearcher, WorkspaceState}
@@ -28,7 +29,8 @@ private object GoToRefIdent extends StrictImplicitLogging {
       sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       settings: GoToRefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     definition.parent match {
       case Some(parent) =>
         parent match {
@@ -228,7 +230,8 @@ private object GoToRefIdent extends StrictImplicitLogging {
       sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       goToDefSetting: GoToDefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Ident]] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Ident]] =
     goToNearestBlockInScope(fromNode, sourceCode.tree)
       .iterator
       .flatMap {
@@ -255,7 +258,8 @@ private object GoToRefIdent extends StrictImplicitLogging {
       sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       settings: GoToRefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Ident]] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Ident]] =
     goToNearestFuncDef(argumentNode) match {
       case Some(functionNode) =>
         // It's a function argument, search within this function's body.
@@ -290,7 +294,8 @@ private object GoToRefIdent extends StrictImplicitLogging {
       sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       settings: GoToRefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Ident]] = {
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Ident]] = {
     val contractInheritanceUsage =
       goToArgumentsUsageInInheritanceDefinition(
         argument = argument,
@@ -362,7 +367,8 @@ private object GoToRefIdent extends StrictImplicitLogging {
       sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       goToDefSetting: GoToDefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Ident]] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Ident]] =
     WorkspaceSearcher
       .collectImplementingChildren(sourceCode, workspace)
       .childTrees
@@ -518,7 +524,8 @@ private object GoToRefIdent extends StrictImplicitLogging {
       sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       goToDefSetting: GoToDefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Ident]] = {
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Ident]] = {
     val children =
       if (sourceCode.tree.ast == constantDef)
         // Is a global constant, fetch all workspace trees.
@@ -556,7 +563,8 @@ private object GoToRefIdent extends StrictImplicitLogging {
       sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       goToDefSetting: GoToDefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Ident]] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Ident]] =
     from
       .walkDown
       .collect {
@@ -596,7 +604,8 @@ private object GoToRefIdent extends StrictImplicitLogging {
       sourceCode: SourceLocation.CodeStrict,
       workspace: WorkspaceState.IsSourceAware,
       goToDefSetting: GoToDefSetting
-    )(implicit logger: ClientLogger): Boolean =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Boolean =
     reference.ast.sourceIndex exists {
       referenceSourceIndex =>
         CodeProvider

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefSource.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefSource.scala
@@ -5,6 +5,7 @@ package org.alephium.ralph.lsp.pc.search.gotoref
 
 import org.alephium.ralph.Ast
 import org.alephium.ralph.lsp.pc.search.CodeProvider
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.utils.Node
@@ -26,7 +27,8 @@ private object GoToRefSource extends StrictImplicitLogging {
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware,
       settings: GoToRefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] =
     CodeProvider
       .goToDef
       .searchLocal( // find definitions for the token at the given cursorIndex.
@@ -64,7 +66,8 @@ private object GoToRefSource extends StrictImplicitLogging {
       defLocation: SourceLocation.NodeStrict[Ast.Positioned],
       workspace: WorkspaceState.IsSourceAware,
       settings: GoToRefSetting
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] = {
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.NodeStrict[Ast.Positioned]] = {
     val defNode =
       defLocation
         .source

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/multi/GoToRefMultiCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/multi/GoToRefMultiCodeProvider.scala
@@ -10,6 +10,7 @@ import org.alephium.ralph.lsp.pc.{PCSearcher, PCStates}
 import org.alephium.ralph.lsp.pc.search.gotodef.GoToDefSetting
 import org.alephium.ralph.lsp.pc.search.gotoref.GoToRefSetting
 import org.alephium.ralph.lsp.pc.search.MultiCodeProvider
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
 import org.alephium.ralph.lsp.utils.IsCancelled
 import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
@@ -43,7 +44,8 @@ private[search] case object GoToRefMultiCodeProvider extends MultiCodeProvider[G
       isCancelled: IsCancelled,
       pcStates: PCStates,
       settings: GoToRefMultiSetting
-    )(implicit logger: ClientLogger,
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger,
       ec: ExecutionContext): Future[Either[CompilerMessage.Error, ArraySeq[SourceLocation.GoToRefStrict]]] =
     MultiCodeProvider
       .goToDef
@@ -103,7 +105,8 @@ private[search] case object GoToRefMultiCodeProvider extends MultiCodeProvider[G
       settings: GoToRefSetting,
       isCancelled: IsCancelled,
       pcStates: PCStates
-    )(implicit logger: ClientLogger,
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger,
       ec: ExecutionContext): Future[ArraySeq[SourceLocation.GoToRefStrict]] =
     definition.index match {
       case Some(index) =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gototypedef/GoToTypeDefCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gototypedef/GoToTypeDefCodeProvider.scala
@@ -10,6 +10,7 @@ import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.Ast
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.utils.Node
 
 case object GoToTypeDefCodeProvider extends CodeProvider[SourceCodeState.Parsed, Unit, SourceLocation.GoToTypeDef] with StrictImplicitLogging {
@@ -28,7 +29,8 @@ case object GoToTypeDefCodeProvider extends CodeProvider[SourceCodeState.Parsed,
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware,
       searchSettings: Unit
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToTypeDef] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.GoToTypeDef] =
     sourceCode.astStrict.statements.find(_.index contains cursorIndex) match {
       case Some(statement) =>
         statement match {

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/hover/HoverCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/hover/HoverCodeProvider.scala
@@ -5,8 +5,9 @@ package org.alephium.ralph.lsp.pc.search.hover
 
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
 import org.alephium.ralph.lsp.pc.search.CodeProvider
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.pc.search.gotodef._
-import org.alephium.ralph.lsp.pc.sourcecode.{SourceLocation, SourceCodeState}
+import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.utils.Node
 import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
@@ -24,7 +25,8 @@ private[search] case object HoverCodeProvider extends CodeProvider[SourceCodeSta
       sourceCode: SourceCodeState.IsParsed,
       workspace: WorkspaceState.IsSourceAware,
       searchSettings: (SoftAST.type, GoToDefSetting)
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.Hover] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.Hover] =
     CodeProvider
       .goToDefSoft
       .searchLocal(

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/hover/HoverExpression.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/hover/HoverExpression.scala
@@ -7,6 +7,7 @@ import org.alephium.ralph.{Ast, SourceIndex}
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra._
 import org.alephium.ralph.lsp.access.compiler.parser.soft.ast._
 import org.alephium.ralph.lsp.pc.search.CodeProvider
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.pc.sourcecode.SourceLocation
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
@@ -29,7 +30,8 @@ private case object HoverExpression extends StrictImplicitLogging {
       expression: SoftAST.ExpressionAST,
       sourceCode: SourceLocation.CodeSoft,
       workspace: WorkspaceState.IsSourceAware
-    )(implicit logger: ClientLogger): Option[SourceLocation.Hover] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Option[SourceLocation.Hover] =
     expression match {
       case assignment: SoftAST.Assignment =>
         hoverAssignment(assignment, sourceCode, workspace)
@@ -67,7 +69,8 @@ private case object HoverExpression extends StrictImplicitLogging {
       assignment: SoftAST.Assignment,
       sourceCode: SourceLocation.CodeSoft,
       workspace: WorkspaceState.IsSourceAware
-    )(implicit logger: ClientLogger): Option[SourceLocation.Hover] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Option[SourceLocation.Hover] =
     // Assignment can be a `let` or a `const`.
     assignment.toNode.parent match {
       case Some(Node(variableDeclaration: SoftAST.VariableDeclaration, _)) =>
@@ -94,7 +97,8 @@ private case object HoverExpression extends StrictImplicitLogging {
       mutableBinding: SoftAST.MutableBinding,
       sourceCode: SourceLocation.CodeSoft,
       workspace: WorkspaceState.IsSourceAware
-    )(implicit logger: ClientLogger): Option[SourceLocation.Hover] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Option[SourceLocation.Hover] =
     mutableBinding.toNode.parent match {
       case Some(Node(assignment: SoftAST.Assignment, _)) =>
         hoverAssignment(assignment, sourceCode, workspace)
@@ -118,7 +122,8 @@ private case object HoverExpression extends StrictImplicitLogging {
       variableDeclaration: SoftAST.VariableDeclaration,
       sourceCode: SourceLocation.CodeSoft,
       workspace: WorkspaceState.IsSourceAware
-    )(implicit logger: ClientLogger): Option[SoftAST.VariableDeclaration] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Option[SoftAST.VariableDeclaration] =
     findAssignmentType(variableDeclaration.assignment, sourceCode, workspace) match {
       case Some(typeId) =>
         Some(hoverVariableDeclarationWithType(variableDeclaration, typeId))
@@ -189,7 +194,8 @@ private case object HoverExpression extends StrictImplicitLogging {
       assignment: SoftAST.Assignment,
       sourceCode: SourceLocation.CodeSoft,
       workspace: WorkspaceState.IsSourceAware
-    )(implicit logger: ClientLogger): Option[Ast.TypeId] = {
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Option[Ast.TypeId] = {
     // Find all the type definitions
     val typeDefs = CodeProvider
       .goToTypeDef

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/hover/multi/HoverMultiCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/hover/multi/HoverMultiCodeProvider.scala
@@ -10,6 +10,7 @@ import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
 import org.alephium.ralph.lsp.pc.search.gotodef.GoToDefSetting
 import org.alephium.ralph.lsp.pc.PCSearcher.goTo
 import org.alephium.ralph.lsp.pc.search.MultiCodeProvider
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.utils.IsCancelled
 import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
 
@@ -42,7 +43,8 @@ private[search] case object HoverMultiCodeProvider extends MultiCodeProvider[Uni
       isCancelled: IsCancelled,
       pcStates: PCStates,
       settings: Unit
-    )(implicit logger: ClientLogger,
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger,
       ec: ExecutionContext): Future[Either[CompilerMessage.Error, ArraySeq[SourceLocation.Hover]]] = {
     /*
      * Hover information relies on the definition of the symbol at the cursor position.

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/inlayhints/InlayHintsCodeProvider.scala
@@ -9,6 +9,7 @@ import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, LinePosi
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra._
 import org.alephium.ralph.lsp.access.util.StringUtil
 import org.alephium.ralph.lsp.pc.search.CodeProvider
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
@@ -27,7 +28,8 @@ private[search] case object InlayHintsCodeProvider extends CodeProvider[SourceCo
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware,
       rangeEnd: LinePosition
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.InlayHint] = {
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.InlayHint] = {
     val eligibleNodes =
       collectHintEligibleNodesInRange(
         rangeStart = rangeStart,
@@ -92,7 +94,8 @@ private[search] case object InlayHintsCodeProvider extends CodeProvider[SourceCo
       node: Node[Ast.VarDeclaration, Ast.Positioned],
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware
-    )(implicit logger: ClientLogger): Iterator[(SourceIndex, Option[Either[CompilerMessage.Error, Iterator[SourceLocation.GoToTypeDef]]])] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[(SourceIndex, Option[Either[CompilerMessage.Error, Iterator[SourceLocation.GoToTypeDef]]])] =
     // Collect all identifiers in the assignment.
     node
       .walkDown

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/inlayhints/multi/InlayHintsMultiCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/inlayhints/multi/InlayHintsMultiCodeProvider.scala
@@ -8,6 +8,7 @@ import org.alephium.ralph.lsp.pc.PCStates
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
 import org.alephium.ralph.lsp.pc.PCSearcher.goTo
 import org.alephium.ralph.lsp.pc.search.MultiCodeProvider
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.utils.IsCancelled
 import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
 
@@ -26,7 +27,8 @@ private[search] case object InlayHintsMultiCodeProvider extends MultiCodeProvide
       isCancelled: IsCancelled,
       pcStates: PCStates,
       settings: LinePosition
-    )(implicit logger: ClientLogger,
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger,
       ec: ExecutionContext): Future[Either[CompilerMessage.Error, ArraySeq[SourceLocation.InlayHint]]] =
     pcStates.get(fileURI) match {
       case Left(error) =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/rename/GoToRenameAll.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/rename/GoToRenameAll.scala
@@ -6,6 +6,7 @@ package org.alephium.ralph.lsp.pc.search.rename
 import org.alephium.ralph.SourceIndex
 import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.SourceIndexExtension
 import org.alephium.ralph.lsp.pc.search.CodeProvider
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.pc.search.gotodef.GoToDefSetting
 import org.alephium.ralph.lsp.pc.search.gotoref.GoToRefSetting
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
@@ -31,7 +32,8 @@ private object GoToRenameAll extends StrictImplicitLogging {
       cursorIndex: Int,
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToRenameStrict] = {
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.GoToRenameStrict] = {
     val references =
       collectReferences(
         cursorIndex = cursorIndex,
@@ -73,7 +75,8 @@ private object GoToRenameAll extends StrictImplicitLogging {
       cursorIndex: Int,
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware
-    )(implicit logger: ClientLogger): Iterable[SourceLocation.GoToRenameStrict] = {
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterable[SourceLocation.GoToRenameStrict] = {
     // collects all nodes that must be renamed
     val nodesToRename =
       ListBuffer.empty[(SourceLocation.GoToRenameStrict, SourceIndex)]

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/rename/GoToRenameCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/rename/GoToRenameCodeProvider.scala
@@ -5,7 +5,8 @@ package org.alephium.ralph.lsp.pc.search.rename
 
 import org.alephium.ralph.lsp.utils.log.ClientLogger
 import org.alephium.ralph.lsp.pc.search.CodeProvider
-import org.alephium.ralph.lsp.pc.sourcecode.{SourceLocation, SourceCodeState}
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
+import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
 import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
 
 /**
@@ -19,7 +20,8 @@ private[search] case object GoToRenameCodeProvider extends CodeProvider[SourceCo
       sourceCode: SourceCodeState.Parsed,
       workspace: WorkspaceState.IsSourceAware,
       searchSettings: Unit
-    )(implicit logger: ClientLogger): Iterator[SourceLocation.GoToRenameStrict] =
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.GoToRenameStrict] =
     GoToRenameAll.rename(
       cursorIndex = cursorIndex,
       sourceCode = sourceCode,

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/rename/multi/GoToRenameMultiCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/rename/multi/GoToRenameMultiCodeProvider.scala
@@ -6,6 +6,7 @@ package org.alephium.ralph.lsp.pc.search.rename.multi
 import org.alephium.ralph.lsp.access.compiler.message.CompilerMessage
 import org.alephium.ralph.lsp.pc.{PCSearcher, PCStates}
 import org.alephium.ralph.lsp.pc.search.MultiCodeProvider
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
 import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
 import org.alephium.ralph.lsp.utils.IsCancelled
@@ -36,7 +37,8 @@ case object GoToRenameMultiCodeProvider extends MultiCodeProvider[Unit, SourceLo
       isCancelled: IsCancelled,
       pcStates: PCStates,
       settings: Unit
-    )(implicit logger: ClientLogger,
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger,
       ec: ExecutionContext): Future[Either[CompilerMessage.Error, ArraySeq[SourceLocation.GoToRenameStrict]]] =
     Future {
       pcStates.findContains(fileURI) match {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestCodeProvider.scala
@@ -10,6 +10,7 @@ import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.access.util.{StringUtil, TestCodeUtil}
 import org.alephium.ralph.lsp.pc.client.TestClientLogger
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.pc.search.completion.Suggestion
 import org.alephium.ralph.lsp.pc.search.gotodef.GoToDefSetting
 import org.alephium.ralph.lsp.pc.search.gotoref.GoToRefSetting
@@ -920,6 +921,9 @@ object TestCodeProvider {
     // parse and compile workspace
     val compiledWorkspace =
       Workspace.parseAndCompile(workspace)
+
+    implicit val searchCache: SearchCache =
+      SearchCache(maxWorkspaces = 1)
 
     // execute code-provider.
     val result =

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestMultiCodeProvider.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/TestMultiCodeProvider.scala
@@ -9,6 +9,7 @@ import org.alephium.ralph.lsp.access.compiler.message.{CompilerMessage, LineRang
 import org.alephium.ralph.lsp.access.file.FileAccess
 import org.alephium.ralph.lsp.access.util.TestCodeUtil
 import org.alephium.ralph.lsp.pc.{PCState, PCStates}
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
 import org.alephium.ralph.lsp.pc.search.completion.Suggestion
 import org.alephium.ralph.lsp.pc.search.gotoref.multi.GoToRefMultiSetting
 import org.alephium.ralph.lsp.pc.sourcecode.{SourceLocation, TestSourceCode}
@@ -434,6 +435,9 @@ object TestMultiCodeProvider extends ScalaFutures {
             tsErrors = None
           )
       }
+
+    implicit val searchCache: SearchCache =
+      SearchCache(maxWorkspaces = 1)
 
     // Execute the multi-code provider on the `PCState`s
     val result =

--- a/utils/src/main/scala/org/alephium/ralph/lsp/utils/WeakHashMapBase.scala
+++ b/utils/src/main/scala/org/alephium/ralph/lsp/utils/WeakHashMapBase.scala
@@ -1,0 +1,35 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.utils
+
+import org.alephium.ralph.lsp.utils.log.StrictImplicitLogging
+
+import java.lang.ref.WeakReference
+import java.util
+
+abstract class WeakHashMapBase[K, V](cache: util.WeakHashMap[K, WeakReference[V]]) extends StrictImplicitLogging {
+
+  def getOrPut(
+      key: K,
+      value: => V): V =
+    cache.synchronized {
+      val ref =
+        cache.get(key)
+
+      val existingValue =
+        if (ref != null)
+          ref.get()
+        else
+          null
+
+      if (existingValue != null) {
+        existingValue.asInstanceOf[V]
+      } else {
+        val newCache = value
+        cache.put(key, new WeakReference(newCache))
+        newCache
+      }
+    }
+
+}

--- a/utils/src/main/scala/org/alephium/ralph/lsp/utils/WeakHashMapBase.scala
+++ b/utils/src/main/scala/org/alephium/ralph/lsp/utils/WeakHashMapBase.scala
@@ -12,7 +12,7 @@ import java.util
  */
 abstract class WeakHashMapBase[K, V](cache: util.WeakHashMap[K, WeakReference[V]]) {
 
-  def getOrPut(
+  protected def getOrPut(
       key: K,
       value: => V): V =
     cache.synchronized {

--- a/utils/src/main/scala/org/alephium/ralph/lsp/utils/WeakHashMapBase.scala
+++ b/utils/src/main/scala/org/alephium/ralph/lsp/utils/WeakHashMapBase.scala
@@ -3,12 +3,14 @@
 
 package org.alephium.ralph.lsp.utils
 
-import org.alephium.ralph.lsp.utils.log.StrictImplicitLogging
-
 import java.lang.ref.WeakReference
 import java.util
 
-abstract class WeakHashMapBase[K, V](cache: util.WeakHashMap[K, WeakReference[V]]) extends StrictImplicitLogging {
+/**
+ * The value are also stored as [[WeakReference]]s to handle cyclic cases
+ * where the value stores a strong reference back to the key.
+ */
+abstract class WeakHashMapBase[K, V](cache: util.WeakHashMap[K, WeakReference[V]]) {
 
   def getOrPut(
       key: K,
@@ -26,9 +28,9 @@ abstract class WeakHashMapBase[K, V](cache: util.WeakHashMap[K, WeakReference[V]
       if (existingValue != null) {
         existingValue.asInstanceOf[V]
       } else {
-        val newCache = value
-        cache.put(key, new WeakReference(newCache))
-        newCache
+        val newValue = value
+        cache.put(key, new WeakReference(newValue))
+        newValue
       }
     }
 


### PR DESCRIPTION
- Resolves #571
- Resolves #523

The response time improves dramatically with this cache. But to populate the cache, an initial warm-up search is required, so for now the first search request is expected to be slow. At least the performance bottleneck is now known to be these two cache [`lazy val`](https://github.com/alephium/ralph-lsp/blob/cfc777413232593f236216330955e2306ac4ef6c/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/cache/WorkspaceSearchCache.scala#L32-L49)s. Optimising them is require but not urgent right now, because `SoftParser` is parsed and searched on demand, but when we enable `SoftParser` for code-completion, these they will require optimisations.