### PR TITLE
Reduce `SearchCache` Invalidation

### DIFF
--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/cache/SearchCacheSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/cache/SearchCacheSpec.scala
@@ -1,0 +1,62 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.pc.search.cache
+
+import org.alephium.ralph.lsp.access.compiler.CompilerAccess
+import org.alephium.ralph.lsp.access.file.FileAccess
+import org.alephium.ralph.lsp.pc.client.TestClientLogger
+import org.alephium.ralph.lsp.pc.workspace.TestWorkspace
+import org.alephium.ralph.lsp.utils.log.ClientLogger
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.EitherValues._
+import org.scalatest.OptionValues._
+
+class SearchCacheSpec extends AnyWordSpec with Matchers {
+
+  implicit val clientLogger: ClientLogger = TestClientLogger
+  implicit val file: FileAccess           = FileAccess.disk
+  implicit val compiler: CompilerAccess   = CompilerAccess.ralphc
+
+  "Changes to `astSoft: LazyVal`" should {
+    "not invalidate existing cache" in {
+      // Generate a parsed workspace with one source file
+      val code      = "Abstract Contract Test() {}"
+      val workspace = TestWorkspace.genParsedOK(code).sample.value
+      workspace.sourceCode should have size 1
+
+      // The source code's `SoftAST` is not populated.
+      val source = workspace.sourceCode.head
+      source.astSoft.isEmpty shouldBe true
+
+      // Create a search cache
+      val searchCache = SearchCache(maxWorkspaces = 10)
+      searchCache.size shouldBe 0
+
+      def accessCache() = {
+        // Search the cache for the `workspace`
+        val result = searchCache.get(workspace)
+        // The resulting cache's workspace is created workspace
+        result.workspace shouldBe workspace
+        // the number of cache entire are always 1
+        searchCache.size shouldBe 1
+      }
+
+      // First access to the cache, this created an entry in the cache.
+      accessCache()
+
+      // Now populate the source's `SoftAST`.
+      source.astSoft.fetch().value.toCode() shouldBe code
+      source.astSoft.isDefined shouldBe true
+      workspace.sourceCode.head.astSoft.isDefined shouldBe true
+
+      // Second access to the cache, this will not create a new cache entry, the same workspace is returned.
+      // To test this access create 2 entries, remove the functions `equalityFields` and `equals` from [[SourceCodeState.Parsed]]
+      accessCache()
+
+      TestWorkspace delete workspace
+    }
+  }
+
+}

--- a/utils/src/main/scala/org/alephium/ralph/lsp/utils/LazyVal.scala
+++ b/utils/src/main/scala/org/alephium/ralph/lsp/utils/LazyVal.scala
@@ -21,6 +21,12 @@ class LazyVal[A] private (
     load: () => A,
     @volatile private var value: Option[A]) {
 
+  def isDefined: Boolean =
+    value.isDefined
+
+  def isEmpty: Boolean =
+    value.isEmpty
+
   def fetch(): A =
     this.value match {
       case None =>

--- a/utils/src/main/scala/org/alephium/ralph/lsp/utils/WeakHashMapBase.scala
+++ b/utils/src/main/scala/org/alephium/ralph/lsp/utils/WeakHashMapBase.scala
@@ -12,6 +12,9 @@ import java.util
  */
 abstract class WeakHashMapBase[K, V](cache: util.WeakHashMap[K, WeakReference[V]]) {
 
+  def size: Int =
+    cache.size()
+
   protected def getOrPut(
       key: K,
       value: => V): V =


### PR DESCRIPTION
- Towards #573
- Towards #547 
- Prevents unnecessary cache invalidation due to changes to the lazily evaluated `SoftAST`.