### PR TITLE
Remove `getOneOrAll`

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PCStates.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/PCStates.scala
@@ -70,9 +70,9 @@ case class PCStates(states: ArraySeq[PCState]) extends AnyVal {
           case workspace: WorkspaceState.IsSourceAware if CompilerAccess.isRalphFileExtension(fileURI) =>
             /*
              * When the workspace is source-aware and the file is a `.ral` source-file, the file must processed
-             * be within the configured `contractURI` or the configured `dependencyPath`. Any other file is must not be processed.
+             * be within the configured `contractURI` or the configured `dependencyPath`. Any other file must not be processed.
              *
-             * This must be a `contractURI` and `dependencyPath` and not upper level check on `state.workspace.workspaceURI`
+             * The check must on `contractURI` and `dependencyPath`, and not an upper level check on `state.workspace.workspaceURI`
              * because if there is a "Workspace-A" containing a `dependencies` folders that it itself does not point to,
              * but another "Workspace-B" uses "Workspace-A"'s `dependencies` path as its dependency, then simply
              * invoking `state.workspace.workspaceURI contains fileURI` will return "Workspace-A"'s `PCState`

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/inlayhints/multi/InlayHintsMultiCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/inlayhints/multi/InlayHintsMultiCodeProvider.scala
@@ -34,7 +34,7 @@ private[search] case object InlayHintsMultiCodeProvider extends MultiCodeProvide
       case Left(error) =>
         // Dependency files are not part of the active workspace but should still support inlay hints.
         // For now, instead of triggering an IDE error notification, log the reason.
-        logger.info(s"Inlay hints are not available for this file. Reason: ${error.message}.")
+        logger.info(s"${InlayHintsMultiCodeProvider.productPrefix} not available for this file. Reason: ${error.message}.")
         Future.successful(Right(ArraySeq.empty))
 
       case Right(pcState) =>

--- a/utils/src/main/scala/org/alephium/ralph/lsp/utils/URIUtil.scala
+++ b/utils/src/main/scala/org/alephium/ralph/lsp/utils/URIUtil.scala
@@ -19,6 +19,16 @@ object URIUtil {
 
   }
 
+  implicit class PathURIUtilImplicits(val path: Path) extends AnyVal {
+
+    def contains(child: URI): Boolean =
+      URIUtil.contains(
+        parent = path,
+        child = child
+      )
+
+  }
+
   /**
    * Build URI and clean it from escaped characters. Happen on Windows
    */


### PR DESCRIPTION
- Resolves #527.
- Noticeable improvements in IDE response time (Towards #566)
- Final PR for [performance](https://github.com/alephium/ralph-lsp/issues?q=is%3Aissue%20state%3Aopen%20label%3Atype%3Aperformance%20label%3Aproject%3Astable-soft-parser) improvements targeting the release of #561.
- Pending unit test for [this case](https://github.com/alephium/ralph-lsp/pull/580/files#diff-c3c8ebff18582482942e463fe5f483b1d2e4ce06b1d33fa2e51f8b3c97fe0b18R81). Currently only IDE tested.