### PR TITLE
Temporarily disable go-to-def for `SoftAST.Annotation`

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
@@ -88,6 +88,10 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
         // TODO: Process struct field assignments - Issue https://github.com/alephium/ralph-lsp/issues/322
         Iterator.empty
 
+      case Some(Node(annotation: SoftAST.Annotation, _)) if annotation.identifier contains identNode.data =>
+        // TODO: Support jump-definition for annotations: https://github.com/alephium/ralph-lsp/issues/589
+        Iterator.empty
+
       case Some(Node(assignment: SoftAST.TypeAssignment, _)) if assignment.expressionLeft == identNode.data =>
         self()
 
@@ -122,7 +126,7 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
           case Some(grandParentNode @ Node(_: SoftAST.Group[_, _, _], _)) =>
             grandParentNode.parent match {
               case Some(Node(_: SoftAST.Annotation, _)) =>
-                // TODO: Support jump-definition for annotations.
+                // TODO: Support jump-definition for annotations: https://github.com/alephium/ralph-lsp/issues/589
                 Iterator.empty
 
               case _ =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
@@ -119,6 +119,17 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
           case Some(Node(_: SoftAST.VariableDeclaration | _: SoftAST.Const, _)) =>
             self()
 
+          case Some(grandParentNode @ Node(_: SoftAST.Group[_, _, _], _)) =>
+            grandParentNode.parent match {
+              case Some(Node(_: SoftAST.Annotation, _)) =>
+                // TODO: Support jump-definition for annotations.
+                Iterator.empty
+
+              case _ =>
+                // invoke full scope search.
+                runFullSearch()
+            }
+
           case _ =>
             // invoke full scope search.
             runFullSearch()

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/AnnotationFieldSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/AnnotationFieldSpec.scala
@@ -1,0 +1,71 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.pc.search.gotodef
+
+import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class AnnotationFieldSpec extends AnyWordSpec with Matchers {
+
+  "return empty" when {
+    "the annotation assignment property has a duplicate definition" when {
+
+      /**
+       * GROUP: Duplicate is a function
+       */
+      "function" when {
+        "without syntax errors" in {
+          goToDefinition() {
+            """
+              |{
+              |  @annotation(propert@@y = value)
+              |  fn property() -> () {}
+              |}
+              |""".stripMargin
+          }
+        }
+
+        "with syntax errors" in {
+          goToDefinition() {
+            """
+              |{
+              |  @annotation(propert@@y = )
+              |  fn property
+              |}
+              |""".stripMargin
+          }
+        }
+      }
+
+      /**
+       * GROUP: Duplicate is a variable
+       */
+      "variable" when {
+        "without syntax errors" in {
+          goToDefinition() {
+            """
+              |{
+              |  @annotation(propert@@y = value)
+              |  let property = 1
+              |}
+              |""".stripMargin
+          }
+        }
+
+        "with syntax errors" in {
+          goToDefinition() {
+            """
+              |{
+              |  @annotation(propert@@y = )
+              |  let property =
+              |}
+              |""".stripMargin
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/AnnotationSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/AnnotationSpec.scala
@@ -1,0 +1,71 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.pc.search.gotodef
+
+import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class AnnotationSpec extends AnyWordSpec with Matchers {
+
+  "return empty" when {
+    "the annotation name has another definition with the same name" when {
+
+      /**
+       * GROUP: Duplicate is a function
+       */
+      "function" when {
+        "without syntax errors" in {
+          goToDefinition() {
+            """
+              |{
+              |  @annotati@@on
+              |  fn annotation() -> () {}
+              |}
+              |""".stripMargin
+          }
+        }
+
+        "with syntax errors" in {
+          goToDefinition() {
+            """
+              |{
+              |  @annotati@@on(
+              |  fn annotation
+              |}
+              |""".stripMargin
+          }
+        }
+      }
+
+      /**
+       * GROUP: Duplicate is a variable
+       */
+      "variable" when {
+        "without syntax errors" in {
+          goToDefinition() {
+            """
+              |{
+              |  @annotati@@on(property = value)
+              |  let annotation = 1
+              |}
+              |""".stripMargin
+          }
+        }
+
+        "with syntax errors" in {
+          goToDefinition() {
+            """
+              |{
+              |  @annotat@@ion(property = )
+              |  let annotation =
+              |}
+              |""".stripMargin
+          }
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
- Resolves the misbehaviour in #585.
- To be implemented in #589.