### PR TITLE
Disallow inheritance search on anything other than `Contract`s

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
@@ -470,7 +470,15 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
 
     // Inheritance search must include all built-in interfaces.
     val builtInTrees =
-      cache.builtInTrees
+      sourceCode.part match {
+        case _: SoftAST.Template =>
+          // Built-in trees are only searchable for contracts
+          cache.builtInTrees
+
+        case _ =>
+          // Disable for enum, structs, events etc
+          ArraySeq.empty
+      }
 
     // Merge both the actual inherited trees and the built-in trees.
     val allInheritedTrees =
@@ -1192,7 +1200,12 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
           case Some(virtualNode) =>
             search(
               identNode = virtualNode,
-              sourceCode = source,
+              sourceCode =
+                // Search within this found definition.
+                SourceLocation.CodeSoft(
+                  part = definition,
+                  parsed = source.parsed
+                ),
               cache = cache,
               settings = settings,
               detectCallSyntax = detectCallSyntax

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToBuiltInFunctionsSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToBuiltInFunctionsSpec.scala
@@ -23,6 +23,19 @@ class GoToBuiltInFunctionsSpec extends AnyWordSpec with Matchers {
         expected = None
       )
     }
+
+    "invoked within an enum" when {
+      "enum" in {
+        goToDefBuiltIn(
+          code = """
+              |enum Test {
+              |  asse@@rt!()
+              |}
+              |""".stripMargin,
+          expected = None
+        )
+      }
+    }
   }
 
   "return non-empty" when {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToBuiltInUnitTests.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToBuiltInUnitTests.scala
@@ -25,7 +25,7 @@ class GoToBuiltInUnitTests extends AnyWordSpec with Matchers {
     }
 
     "soft" when {
-      "no contract" in {
+      "no contract" ignore {
         goToDefBuiltIn(
           code = """
               |test "simple test" {
@@ -36,7 +36,7 @@ class GoToBuiltInUnitTests extends AnyWordSpec with Matchers {
         )
       }
 
-      "contains syntax errors" in {
+      "contains syntax errors" ignore {
         goToDefBuiltIn(
           code = """
               |test "simple test" {

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToStaticCall.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToStaticCall.scala
@@ -3,11 +3,62 @@
 
 package org.alephium.ralph.lsp.pc.search.gotodef
 
+import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
 
 class GoToStaticCall extends AnyWordSpec with Matchers {
+
+  "return empty" when {
+    "encodeFields! is invoked" when {
+      "enum" in {
+        goToDefBuiltIn(
+          code = """
+              |Contract Test() {
+              |  
+              |  enum Target { }
+              |  
+              |  fn test() -> () {
+              |    Target.encodeFiel@@ds!()
+              |  }
+              |}
+              |""".stripMargin,
+          expected = None
+        )
+      }
+
+      "event" in {
+        goToDefBuiltIn(
+          code = """
+              |Contract Test() {
+              |
+              |  event Target(a: Type)
+              |
+              |  fn test() -> () {
+              |    Target.encodeFiel@@ds!()
+              |  }
+              |}
+              |""".stripMargin,
+          expected = None
+        )
+      }
+
+      "struct" in {
+        goToDefBuiltIn(
+          code = """
+              |struct Target { a: Type }
+              |
+              |Contract Test() {
+              |  fn test() -> () {
+              |    Target.encodeFiel@@ds!()
+              |  }
+              |}
+              |""".stripMargin,
+          expected = None
+        )
+      }
+    }
+  }
 
   "access single static functions" in {
     goToDefinition()(


### PR DESCRIPTION
- Towards #586.
- Currently, `MyEnum.encodeFields!()` is allowed. To fix this, this PR restricts inheritance search to only `Contract`s.
- This also means unit-tests will no longer be able to search inherited functions like `testEquals!`. But this is because tests do not parsed yet, which will be resolved in #581.