### PR TITLE
Allow built-in searches on tests

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
@@ -471,13 +471,13 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
     // Inheritance search must include all built-in interfaces.
     val builtInTrees =
       sourceCode.part match {
-        case _: SoftAST.Template =>
-          // Built-in trees are only searchable for contracts
-          cache.builtInTrees
+        case _: SoftAST.Enum | _: SoftAST.Event | _: SoftAST.Struct =>
+          // Disable for enum, structs, events
+          ArraySeq.empty
 
         case _ =>
-          // Disable for enum, structs, events etc
-          ArraySeq.empty
+          // Allow built-in searches for everything else
+          cache.builtInTrees
       }
 
     // Merge both the actual inherited trees and the built-in trees.

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToBuiltInUnitTests.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToBuiltInUnitTests.scala
@@ -25,7 +25,7 @@ class GoToBuiltInUnitTests extends AnyWordSpec with Matchers {
     }
 
     "soft" when {
-      "no contract" ignore {
+      "no contract" in {
         goToDefBuiltIn(
           code = """
               |test "simple test" {
@@ -36,7 +36,7 @@ class GoToBuiltInUnitTests extends AnyWordSpec with Matchers {
         )
       }
 
-      "contains syntax errors" ignore {
+      "contains syntax errors" in {
         goToDefBuiltIn(
           code = """
               |test "simple test" {


### PR DESCRIPTION
- Quick fix to allow built-in search on unit-tests disabled by #592
- This PR will be reverted once #581 is implemented.