### PR TITLE
Return both to resolve ambiguity

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -173,9 +173,9 @@ object SoftAST {
           false
       }
 
-    def is_RefCall_Or_TypeAssignsType(): Boolean =
+    def is_RefCall_TypeAssignsType_Or_MethodCall(): Boolean =
       node.parent match {
-        case Some(Node(_: SoftAST.ReferenceCall, _)) =>
+        case Some(Node(_: SoftAST.ReferenceCall | _: SoftAST.MethodCall, _)) =>
           true
 
         case Some(Node(assignment: SoftAST.TypeAssignment, _)) if assignment.expressionRight.contains(node) =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
@@ -844,7 +844,7 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
       sourceCode: SourceLocation.CodeSoft,
       detectCallSyntax: Boolean): Iterator[SourceLocation.NodeSoft[SoftAST.CodeString]] =
     // Check if the name matches the identifier.
-    if (!detectCallSyntax || (target.is_RefCall_Or_TypeAssignsType() && !target.isWithinEmit()))
+    if (!detectCallSyntax || (target.is_RefCall_TypeAssignsType_Or_MethodCall() && !target.isWithinEmit()))
       searchIdentifier(
         identifier = templateIdentifier.identifier,
         target = target,

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/DetectCallSyntaxSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/DetectCallSyntaxSpec.scala
@@ -182,12 +182,14 @@ class DetectCallSyntaxSpec extends AnyWordSpec with Matchers {
     "call is a value call" in {
       goToDefinition() {
         """
-          |Contract variable() {}
+          |Contract >>variable<<() {}
+          |enum >>variable<< {}
           |event variable(a: Bool)
           |struct variable { a: Bool }
           |
           |Contract Test(>>variable<<: Var) {
-          |  Contract variable() {}
+          |  Contract >>variable<<() {}
+          |  enum >>variable<< {}
           |  event variable(a: Bool)
           |  struct variable { a: Bool }
           |
@@ -230,12 +232,14 @@ class DetectCallSyntaxSpec extends AnyWordSpec with Matchers {
     "call is method call" in {
       goToDefinition() {
         """
-          |Contract variable() {}
+          |Contract >>variable<<() {}
+          |enum >>variable<< {}
           |event variable(a: Bool)
           |struct variable { a: Bool }
           |
           |Contract Test(>>variable<<: Var) {
-          |  Contract variable() {}
+          |  Contract >>variable<<() {}
+          |  enum >>variable<< {}
           |  event variable(a: Bool)
           |  struct variable { a: Bool }
           |

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumTypeSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEnumTypeSpec.scala
@@ -295,10 +295,12 @@ class GoToEnumTypeSpec extends AnyWordSpec with Matchers {
     "enum is called" in {
       goToDefinition()(
         """
-          |Contract Enum {
+          |Contract >>Enum<< {
           |
           |  enum >>Enum<< {}
           |  const Enum = 1
+          |  event Enum()
+          |  struct Enum {}
           |
           |  fn main() -> () {
           |     Enu@@m.One

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEventSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToEventSpec.scala
@@ -238,13 +238,13 @@ class GoToEventSpec extends AnyWordSpec with Matchers {
             |
             |  event TransferNotUsed(to: Address, amount: U256)
             |
-            |  event >>Transfer<<(to: Address, amount: U256)
+            |  event Transfer(to: Address, amount: U256)
             |
             |}
             |
             |Contract >>Transfer<<() extends Parent() {
             |
-            |  event >>Transfer<<(to: Address, amount: U256)
+            |  event Transfer(to: Address, amount: U256)
             |
             |  pub fn function() -> () {
             |    emit (Transfe@@r.function(), b, c)
@@ -330,9 +330,9 @@ class GoToEventSpec extends AnyWordSpec with Matchers {
                 """
                   |Contract >>transfer<<() {
                   |
-                  |  event >>transfer<<(to: Address)
+                  |  event transfer(to: Address)
                   |
-                  |  pub fn >>transfer<<() -> () { }
+                  |  pub fn transfer() -> () { }
                   |
                   |  pub fn function() -> () {
                   |    emit transf@@er.transfer().transfer
@@ -347,12 +347,12 @@ class GoToEventSpec extends AnyWordSpec with Matchers {
                 goToDefinition()(
                   """
                     |Contract parent {
-                    | event >>transfer<<(to: Address)
+                    | event transfer(to: Address)
                     |}
                     |
                     |Contract >>transfer<<() extends parent {
                     |
-                    |  pub fn >>transfer<<() -> () { }
+                    |  pub fn transfer() -> () { }
                     |
                     |  pub fn function() -> () {
                     |    emit transf@@er.transfer().transfer
@@ -366,12 +366,12 @@ class GoToEventSpec extends AnyWordSpec with Matchers {
                 goToDefinition()(
                   """
                     |Contract parent {
-                    | event >>transfer<<
+                    | event transfer
                     |}
                     |
                     |Contract >>transfer<<() extends parent {
                     |
-                    |  pub fn >>transfer<<() -> () { }
+                    |  pub fn transfer() -> () { }
                     |
                     |  pub fn function() -> () {
                     |    emit transf@@er.transfer().transfer
@@ -385,11 +385,11 @@ class GoToEventSpec extends AnyWordSpec with Matchers {
             "event is defined globally" in {
               goToDefinition()(
                 """
-                  |event >>transfer<<(to: Address)
+                  |event transfer(to: Address)
                   |
                   |Contract >>transfer<<() extends parent {
                   |
-                  |  pub fn >>transfer<<() -> () { }
+                  |  pub fn transfer() -> () { }
                   |
                   |  pub fn function() -> () {
                   |    emit transf@@er.transfer().transfer

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToStaticCall.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToStaticCall.scala
@@ -139,4 +139,17 @@ class GoToStaticCall extends AnyWordSpec with Matchers {
     }
   }
 
+  "issue #586" in {
+    // https://github.com/alephium/ralph-lsp/issues/586
+    goToDefinition() {
+      """
+        |Contract >>Test<< {
+        |  enum >>Test<< { }
+        |
+        |  @@Test.encodeFields!()
+        |}
+        |""".stripMargin
+    }
+  }
+
 }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToTemplateSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToTemplateSpec.scala
@@ -216,7 +216,7 @@ class GoToTemplateSpec extends AnyWordSpec with Matchers {
       "variable exists, but the call is a method call" in {
         goToDefinition() {
           """
-            |Contract variable() { }
+            |Contract >>variable<<() { }
             |
             |Contract Test(instance: variable) {
             |  let >>variable<< = instance


### PR DESCRIPTION
A temporary solution for the misbehaviour described in issue #586. A proper solution is postponed and described in the [second comment](https://github.com/alephium/ralph-lsp/issues/586#issuecomment-3208888293).

## Post Release Status
All [mis-behaviour](https://github.com/alephium/ralph-lsp/issues?q=is%3Aissue%20label%3Aproject%3Astable-soft-parser%20label%3Atype%3Amisbehaviour)s found via #566 post `SoftParser` release in [project:stable-soft-parser](https://github.com/alephium/ralph-lsp/issues?q=is%3Aissue%20state%3Aopen%20label%3Aproject%3Astable-soft-parser) now have a solution. I don't think there is anything of high priority (misbehaviours & bugs) left to resolve.

## Updated Priorities
1. Implement go-to-def for [struct fields](https://github.com/alephium/ralph-lsp/issues/551).
1. Implement pending parsers.
1. Start #568.