### PR TITLE
Improve struct-field search

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -140,7 +140,7 @@ object SoftAST {
      * @param ast The target [[SoftAST]] to find.
      * @return The matched node.
      */
-    final def findAST[A <: SoftAST](ast: A): Option[Node[A, SoftAST]] =
+    final def find[A <: SoftAST](ast: A): Option[Node[A, SoftAST]] =
       node
         .filterDown(_.data.index containsSoft ast.index) // drop trees that do not contain this index
         .collectFirst {

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ast/SoftAST.scala
@@ -127,6 +127,27 @@ object SoftAST {
         .filterDown(_.data.index containsSoft index)
         .find(_.data.index == index)
 
+    /**
+     * Finds a node that exactly matches the given [[SoftAST]],
+     * starting the search from this node, traversing downwards.
+     *
+     * It filters out all subtrees that do not contain the target [[SourceIndex]],
+     * avoiding unnecessary visits.
+     *
+     * @note [[SoftAST]] does not set or use [[SourceIndex.fileURI]],
+     *       therefore, this field is expected to be [[None]] for all cases.
+     *
+     * @param ast The target [[SoftAST]] to find.
+     * @return The matched node.
+     */
+    final def findAST[A <: SoftAST](ast: A): Option[Node[A, SoftAST]] =
+      node
+        .filterDown(_.data.index containsSoft ast.index) // drop trees that do not contain this index
+        .collectFirst {
+          case node @ Node(thisAST, _) if thisAST == ast =>
+            node upcast thisAST.asInstanceOf[A]
+        }
+
   }
 
   implicit class NodeIdentifierExtensions(val node: Node[SoftAST.Identifier, SoftAST]) extends AnyVal {

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
@@ -381,11 +381,6 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
                   source = source
                 )
             }
-
-          case definition: SourceLocation.GoToDefSoft =>
-            // FIXME: This will be removed once `goToDef` is enforced to always return `CodeString`.
-            logger.error(s"Invalid search result '$definition'. Expected `${classOf[SoftAST.CodeString].getSimpleName}`")
-            Iterator.empty
         }
 
       case Some(Node(_: SoftAST.IdentifierAST, _)) =>

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotodef/soft/GoToDefIdentifier.scala
@@ -361,7 +361,7 @@ private object GoToDefIdentifier extends StrictImplicitLogging {
       detectCallSyntax: Boolean
     )(implicit logger: ClientLogger): Iterator[SourceLocation.NodeSoft[SoftAST.Struct]] =
     // First, find this constructors' identifier `Node`.
-    constructor.toNode.findAST(constructor.identifier) match {
+    constructor.toNode.find(constructor.identifier) match {
       case Some(node @ Node(structIdent: SoftAST.Identifier, _)) =>
         // Find all definitions that match the given constructor's identifier.
         // Note: These could result in definitions that may not be structs.


### PR DESCRIPTION
- Improve struct-field search (constructor and deconstructor): Instead of searching via `CodeProvider.goToDefSoft`, execute a `search`.
- Towards #582.
