### PR TITLE
Implement go-to-definition for `struct` deconstructor fields

### DIFF
--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToStructDeconstructorField_From_VariableSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToStructDeconstructorField_From_VariableSpec.scala
@@ -1,0 +1,211 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.pc.search.gotodef
+
+import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/**
+ * Targets test-cases that
+ * - execute search on an external variable,
+ * - jumping to its declaration in a struct deconstructor.
+ *
+ * {{{
+ *   let MyStruct { >>field<< } = instance // deconstructor
+ *   @@field
+ * }}}
+ */
+class GoToStructDeconstructorField_From_VariableSpec extends AnyWordSpec with Matchers {
+
+  "no fields are copied (no rereference created with colon)" when {
+    "one field" when {
+      "no duplicate variables" in {
+        goToDefinition() {
+          """
+            |let Struct { >>field<< } = instance
+            |@@field
+            |""".stripMargin
+        }
+      }
+
+      "a duplicate variable exists" in {
+        goToDefinition() {
+          """
+            |let >>field<< = 1
+            |let Struct { >>field<< } = instance
+            |@@field
+            |""".stripMargin
+        }
+      }
+    }
+
+    "two fields" when {
+      "first field is searched" when {
+        "no duplicate variable" in {
+          goToDefinition() {
+            """
+              |let Struct { >>field1<<, field2 } = instance
+              |@@field1
+              |""".stripMargin
+          }
+        }
+
+        "a duplicate variable exists" in {
+          goToDefinition() {
+            """
+              |let >>field1<< = 1
+              |let Struct { >>field1<<, field2 } = instance
+              |@@field1
+              |""".stripMargin
+          }
+        }
+      }
+
+      "second field is searched" when {
+        "no duplicate variable exists" in {
+          goToDefinition() {
+            """
+              |let Struct { field1, >>field2<< } = instance
+              |@@field2
+              |""".stripMargin
+          }
+        }
+
+        "a duplicate variable exists" in {
+          goToDefinition() {
+            """
+              |let >>field2<< = 2
+              |let Struct { field1, >>field2<< } = instance
+              |@@field2
+              |""".stripMargin
+          }
+        }
+      }
+
+      "both fields are duplicated" when {
+        "no duplicate variable exists" in {
+          goToDefinition() {
+            """
+              |let Struct { >>field<<,
+              |             >>field<< } = instance
+              |@@field
+              |""".stripMargin
+          }
+        }
+
+        "a duplicate variable exists" in {
+          goToDefinition() {
+            """
+              |let >>field<< = 1
+              |let Struct { >>field<<,
+              |             >>field<< } = instance
+              |@@field
+              |""".stripMargin
+          }
+        }
+      }
+    }
+  }
+
+  "fields are copied (rereference are created with colon)" when {
+    "one field" in {
+      goToDefinition() {
+        """
+          |let Struct { field: >>copy<< } = instance
+          |@@copy
+          |""".stripMargin
+      }
+    }
+
+    "two fields" when {
+      "first field is copied" should {
+        "jump to the copied declaration" in {
+          goToDefinition() {
+            """
+              |let Struct { field1: >>copy<<, field2 } = instance
+              |@@copy
+              |""".stripMargin
+          }
+        }
+
+        "not jump to the original `field1`" in {
+          goToDefinition() {
+            """
+              |let Struct { field1: copy, field2 } = instance
+              |
+              |// field1 is no longer a local variable, its reference is copied to `copy`
+              |f@@ield1
+              |""".stripMargin
+          }
+        }
+      }
+
+      "second field is copied" should {
+        "jump to the copied declaration" in {
+          goToDefinition() {
+            """
+              |let Struct { field1, field2: >>copy<< } = instance
+              |@@copy
+              |""".stripMargin
+          }
+        }
+
+        "not jump to the original `field1`" in {
+          goToDefinition() {
+            """
+              |let Struct { field1, field2: copy } = instance
+              |
+              |// field2 is no longer a local variable, its reference is copied to `copy`
+              |f@@ield2
+              |""".stripMargin
+          }
+        }
+      }
+
+      "all fields are copied" should {
+        "jump to the first copied declaration" in {
+          goToDefinition() {
+            """
+              |let Struct { field1: >>copy1<<, field2: copy2 } = instance
+              |@@copy1
+              |""".stripMargin
+          }
+        }
+
+        "jump to the second copied declaration" in {
+          goToDefinition() {
+            """
+              |let Struct { field1: copy1, field2: >>copy2<< } = instance
+              |@@copy2
+              |""".stripMargin
+          }
+        }
+
+        "not jump to the original first field" in {
+          goToDefinition() {
+            """
+              |let Struct { field1: copy1, field2: copy2 } = instance
+              |
+              |// field1 is no longer a local variable, its reference is copied to `copy1`
+              |f@@ield1
+              |""".stripMargin
+          }
+        }
+
+        "not jump to the original second field" in {
+          goToDefinition() {
+            """
+              |let Struct { field1: copy1, field2: copy2 } = instance
+              |
+              |// field2 is no longer a local variable, its reference is copied to `copy2`
+              |f@@ield2
+              |""".stripMargin
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToStructField_From_StructFieldBindingSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToStructField_From_StructFieldBindingSpec.scala
@@ -7,6 +7,17 @@ import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+/**
+ * Targets test-cases that
+ * - execute search on the struct-field,
+ * - jumping to its declaration.
+ *
+ * {{{
+ *   struct MyStruct { >>field<<: Type }
+ *   let instance = MyStruct { @@field: Value} // constructor
+ *   let MyStruct { @@field } = instance       // deconstructor
+ * }}}
+ */
 class GoToStructField_From_StructFieldBindingSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
@@ -46,25 +57,79 @@ class GoToStructField_From_StructFieldBindingSpec extends AnyWordSpec with Match
       }
 
       "duplicate struct field name and variable name" when {
-        "variable is defined before the struct" in {
-          goToDefinition() {
-            """
-              |{
-              |  let value = 1
-              |  let instance = Struct { v@@alue: 2 }
-              |}
-              |""".stripMargin
+        "variable is defined before the struct" when {
+          "constructor" in {
+            goToDefinition() {
+              """
+                |{
+                |  let value = 1
+                |  let instance = Struct { v@@alue: 2 }
+                |}
+                |""".stripMargin
+            }
+          }
+
+          "deconstructor" when {
+            "copied identifier is unique" in {
+              goToDefinition() {
+                """
+                  |{
+                  |  let value = 1
+                  |  let Struct { v@@alue: copy } = instance
+                  |}
+                  |""".stripMargin
+              }
+            }
+
+            "copied identifier is duplicate" in {
+              // Special Case: It does not return "non-empty", but this test belongs here.
+              goToDefinition() {
+                """
+                  |{
+                  |  let value = 1
+                  |  let Struct { value: >>va@@lue<< } = instance
+                  |}
+                  |""".stripMargin
+              }
+            }
           }
         }
 
-        "variable is defined after the struct" in {
-          goToDefinition() {
-            """
-              |{
-              |  let instance = Struct { v@@alue: 2 }
-              |  let value = 1
-              |}
-              |""".stripMargin
+        "variable is defined after the struct" when {
+          "constructor" in {
+            goToDefinition() {
+              """
+                |{
+                |  let instance = Struct { v@@alue: 2 }
+                |  let value = 1
+                |}
+                |""".stripMargin
+            }
+          }
+
+          "deconstructor" when {
+            "copied identifier is unique" in {
+              goToDefinition() {
+                """
+                  |{
+                  |  let Struct { v@@alue: copy } = instance
+                  |  let value = 1
+                  |}
+                  |""".stripMargin
+              }
+            }
+
+            "copied identifier is duplicate" in {
+              // Special Case: It does not return "non-empty", but this test belongs here.
+              goToDefinition() {
+                """
+                  |{
+                  |  let Struct { value: >>va@@lue<< } = instance
+                  |  let value = 1
+                  |}
+                  |""".stripMargin
+              }
+            }
           }
         }
       }
@@ -72,251 +137,525 @@ class GoToStructField_From_StructFieldBindingSpec extends AnyWordSpec with Match
   }
 
   "struct field values" when {
-    "variable is defined before the struct" in {
-      goToDefinition() {
-        """
-          |{
-          |  let >>value<< = 1
-          |  let instance = Struct { value: val@@ue }
-          |}
-          |""".stripMargin
+    "variable is defined before the struct" when {
+      "constructor" in {
+        goToDefinition() {
+          """
+            |{
+            |  let >>value<< = 1
+            |  let instance = Struct { value: val@@ue }
+            |}
+            |""".stripMargin
+        }
+      }
+
+      "deconstructor" in {
+        goToDefinition() {
+          """
+            |{
+            |  let value = 1
+            |  let Struct { value: >>val@@ue<< } = instance
+            |}
+            |""".stripMargin
+        }
       }
     }
 
-    "variable is defined after the struct" in {
-      goToDefinition() {
-        """
-          |{
-          |  let instance = Struct { value: v@@alue }
-          |  let >>value<< = 1
-          |}
-          |""".stripMargin
+    "variable is defined after the struct" when {
+      "constructor" in {
+        goToDefinition() {
+          """
+            |{
+            |  let instance = Struct { value: v@@alue }
+            |  let >>value<< = 1
+            |}
+            |""".stripMargin
+        }
+      }
+
+      "deconstructor" in {
+        goToDefinition() {
+          """
+            |{
+            |  let Struct { value: >>v@@alue<< } = instance
+            |  let value = 1
+            |}
+            |""".stripMargin
+        }
       }
     }
   }
 
   "go to the struct field" when {
     "syntax is well defined" when {
-      "one struct field" in {
-        goToDefinition() {
-          """
-            |struct MyStruct { >>field<<: Value }
-            |MyStruct { @@field: 123 }
-            |""".stripMargin
+      "one struct field" when {
+        "constructor" in {
+          goToDefinition() {
+            """
+              |struct MyStruct { >>field<<: Value }
+              |MyStruct { @@field: 123 }
+              |""".stripMargin
+          }
+        }
+
+        "deconstructor" when {
+          "original reference" in {
+            goToDefinition() {
+              """
+                |struct MyStruct { >>field<<: Value }
+                |let MyStruct { @@field } = instance
+                |""".stripMargin
+            }
+          }
+
+          "field reference is copied" in {
+            goToDefinition() {
+              """
+                |struct MyStruct { >>field<<: Value }
+                |let MyStruct { @@field: 123 } = instance
+                |""".stripMargin
+            }
+          }
         }
       }
 
       "two struct field" when {
-        "first field is searched" in {
-          goToDefinition() {
-            """
-              |struct MyStruct {
-              |  >>field1<<: Value,
-              |  field2: Value
-              |}
-              |
-              |MyStruct {
-              |  @@field1: 123,
-              |  field2: 123
-              |}
-              |""".stripMargin
+        "first field is searched" when {
+          "constructor" in {
+            goToDefinition() {
+              """
+                |struct MyStruct {
+                |  >>field1<<: Value,
+                |  field2: Value
+                |}
+                |
+                |MyStruct {
+                |  @@field1: 123,
+                |  field2: 123
+                |}
+                |""".stripMargin
+            }
+          }
+
+          "deconstructor" in {
+            goToDefinition() {
+              """
+                |struct MyStruct {
+                |  >>field1<<: Value,
+                |  field2: Value
+                |}
+                |
+                |let MyStruct {
+                |  @@field1: 123,
+                |  field2: 123
+                |} = instance
+                |""".stripMargin
+            }
           }
         }
 
-        "second field is searched" in {
-          goToDefinition() {
-            """
-              |struct MyStruct {
-              |  field1: Value,
-              |  >>field2<<: Value
-              |}
-              |
-              |MyStruct {
-              |  field1: 123,
-              |  f@@ield2: 123
-              |}
-              |""".stripMargin
+        "second field is searched" when {
+          "constructor" in {
+            goToDefinition() {
+              """
+                |struct MyStruct {
+                |  field1: Value,
+                |  >>field2<<: Value
+                |}
+                |
+                |MyStruct {
+                |  field1: 123,
+                |  f@@ield2: 123
+                |}
+                |""".stripMargin
+            }
+          }
+
+          "deconstructor" in {
+            goToDefinition() {
+              """
+                |struct MyStruct {
+                |  field1: Value,
+                |  >>field2<<: Value
+                |}
+                |
+                |let MyStruct {
+                |  field1: ref1,
+                |  f@@ield2: ref2
+                |} = instance
+                |""".stripMargin
+            }
           }
         }
 
-        "nested struct's, first field is searched" in {
-          goToDefinition() {
-            """
-              |struct MyStruct {
-              |  >>field1<<: Value,
-              |  field2: Value,
-              |  field3: MyStruct
-              |}
-              |
-              |MyStruct {
-              |  field1: 123,
-              |  field2: 123,
-              |  field3:
-              |    MyStruct {
-              |      f@@ield1: Value,
-              |      field2: 123,
-              |    }
-              |}
-              |""".stripMargin
+        "nested struct's, first field is searched" when {
+          "constructor" in {
+            goToDefinition() {
+              """
+                |struct MyStruct {
+                |  >>field1<<: Value,
+                |  field2: Value,
+                |  field3: MyStruct
+                |}
+                |
+                |MyStruct {
+                |  field1: 123,
+                |  field2: 123,
+                |  field3:
+                |    MyStruct {
+                |      f@@ield1: Value,
+                |      field2: 123,
+                |    }
+                |}
+                |""".stripMargin
+            }
+          }
+
+          "deconstructor" in {
+            goToDefinition() {
+              """
+                |struct MyStruct {
+                |  >>field1<<: Value,
+                |  field2: Value,
+                |  field3: MyStruct
+                |}
+                |
+                |let MyStruct {
+                |  field1: 123,
+                |  field2: 123,
+                |  field3:
+                |    MyStruct {
+                |      f@@ield1: Value,
+                |      field2: 123,
+                |    }
+                |} = instance
+                |""".stripMargin
+            }
           }
         }
 
-        "nested struct's, second field is searched" in {
-          goToDefinition() {
-            """
-              |struct MyStruct {
-              |  field1: Value,
-              |  >>field2<<: Value,
-              |  field3:
-              |}
-              |
-              |MyStruct {
-              |  field1: 123,
-              |  field2: 123,
-              |  field3:
-              |    MyStruct {
-              |      field1: Value,
-              |      f@@ield2: 123,
-              |    }
-              |}
-              |""".stripMargin
+        "nested struct's, second field is searched" when {
+          "constructor" in {
+            goToDefinition() {
+              """
+                |struct MyStruct {
+                |  field1: Value,
+                |  >>field2<<: Value,
+                |  field3:
+                |}
+                |
+                |MyStruct {
+                |  field1: 123,
+                |  field2: 123,
+                |  field3:
+                |    MyStruct {
+                |      field1: Value,
+                |      f@@ield2: 123,
+                |    }
+                |}
+                |""".stripMargin
+            }
+          }
+
+          "deconstructor" in {
+            goToDefinition() {
+              """
+                |struct MyStruct {
+                |  field1: Value,
+                |  >>field2<<: Value,
+                |  field3:
+                |}
+                |
+                |let MyStruct {
+                |  field1: 123,
+                |  field2: 123,
+                |  field3:
+                |    MyStruct {
+                |      field1: Value,
+                |      f@@ield2: 123,
+                |    }
+                |} = instance
+                |""".stripMargin
+            }
           }
         }
 
-        "nested struct's, third field is searched with the third field's type param not defined" in {
-          goToDefinition() {
-            """
-              |struct MyStruct {
-              |  field1: Value,
-              |  field2: Value,
-              |  >>field3<<:
-              |}
-              |
-              |MyStruct {
-              |  field1: 123,
-              |  field2: ,
-              |  field3:
-              |    MyStruct {
-              |      field1: Value,
-              |      field2: ,
-              |      f@@ield3: 123,
-              |    }
-              |}
-              |""".stripMargin
+        "nested struct's, third field is searched with the third field's type param not defined" when {
+          "constructor" in {
+            goToDefinition() {
+              """
+                |struct MyStruct {
+                |  field1: Value,
+                |  field2: Value,
+                |  >>field3<<:
+                |}
+                |
+                |MyStruct {
+                |  field1: 123,
+                |  field2: ,
+                |  field3:
+                |    MyStruct {
+                |      field1: Value,
+                |      field2: ,
+                |      f@@ield3: 123,
+                |    }
+                |}
+                |""".stripMargin
+            }
+          }
+
+          "deconstructor" in {
+            goToDefinition() {
+              """
+                |struct MyStruct {
+                |  field1: Value,
+                |  field2: Value,
+                |  >>field3<<:
+                |}
+                |
+                |let MyStruct {
+                |  field1: 123,
+                |  field2: ,
+                |  field3:
+                |    MyStruct {
+                |      field1: Value,
+                |      field2: ,
+                |      f@@ield3: 123,
+                |    }
+                |} = instance
+                |""".stripMargin
+            }
           }
         }
       }
     }
 
     "field values are not provided" when {
-      "one field" in {
-        goToDefinition() {
-          """
-            |struct MyStruct { >>field<< }
-            |MyStruct { @@field }
-            |""".stripMargin
-        }
-      }
-
-      "two fields" when {
-        "the first field is searched" in {
+      "one field" when {
+        "constructor" in {
           goToDefinition() {
             """
-              |struct MyStruct {
-              |  >>field1<<,
-              |    field2
-              |}
-              |
-              |MyStruct {
-              |  @@field1,
-              |  field2
-              |}
+              |struct MyStruct { >>field<< }
+              |MyStruct { @@field }
               |""".stripMargin
           }
         }
 
-        "the second field is searched" in {
+        "deconstructor" in {
           goToDefinition() {
             """
-              |struct MyStruct {
-              |  field1,
-              |  >>field2<<
-              |}
-              |
-              |MyStruct {
-              |  field1, 
-              |  @@field2
-              |}
+              |struct MyStruct { >>field<< }
+              |let MyStruct { @@field } = instance
               |""".stripMargin
+          }
+        }
+      }
+
+      "two fields" when {
+        "the first field is searched" when {
+          "constructor" in {
+            goToDefinition() {
+              """
+                |struct MyStruct {
+                |  >>field1<<,
+                |    field2
+                |}
+                |
+                |MyStruct {
+                |  @@field1,
+                |  field2
+                |}
+                |""".stripMargin
+            }
+          }
+
+          "def constructor" in {
+            goToDefinition() {
+              """
+                |struct MyStruct {
+                |  >>field1<<,
+                |    field2
+                |}
+                |
+                |let MyStruct {
+                |  @@field1,
+                |  field2
+                |} = instance
+                |""".stripMargin
+            }
+          }
+        }
+
+        "the second field is searched" when {
+          "constructor" in {
+            goToDefinition() {
+              """
+                |struct MyStruct {
+                |  field1,
+                |  >>field2<<
+                |}
+                |
+                |MyStruct {
+                |  field1,
+                |  @@field2
+                |}
+                |""".stripMargin
+            }
+          }
+
+          "deconstructor" in {
+            goToDefinition() {
+              """
+                |struct MyStruct {
+                |  field1,
+                |  >>field2<<
+                |}
+                |
+                |let MyStruct {
+                |  field1,
+                |  @@field2
+                |} = instance
+                |""".stripMargin
+            }
           }
         }
       }
     }
 
     "constructor's closing brace is missing" when {
-      "one field" in {
-        goToDefinition() {
-          """
-            |struct MyStruct { >>field<< }
-            |MyStruct { @@field
-            |""".stripMargin
+      "one field" when {
+        "constructor" in {
+          goToDefinition() {
+            """
+              |struct MyStruct { >>field<< }
+              |MyStruct { @@field
+              |""".stripMargin
+          }
+        }
+
+        "deconstructor" in {
+          goToDefinition() {
+            """
+              |struct MyStruct { >>field<< }
+              |let MyStruct { @@field = instance
+              |""".stripMargin
+          }
         }
       }
 
       "two fields" when {
-        "first field is searched" in {
-          goToDefinition() {
-            """
-              |struct MyStruct {
-              |  >>field1<<,
-              |  field2
-              |}
-              |
-              |MyStruct {
-              |  @@field1,
-              |  field2
-              |""".stripMargin
+        "first field is searched" when {
+          "constructor" in {
+            goToDefinition() {
+              """
+                |struct MyStruct {
+                |  >>field1<<,
+                |  field2
+                |}
+                |
+                |MyStruct {
+                |  @@field1,
+                |  field2
+                |""".stripMargin
+            }
+          }
+
+          "deconstructor" in {
+            goToDefinition() {
+              """
+                |struct MyStruct {
+                |  >>field1<<,
+                |  field2
+                |}
+                |
+                |let MyStruct { @@field1, field2 = instance
+                |""".stripMargin
+            }
           }
         }
 
-        "second field is searched" in {
-          goToDefinition() {
-            """
-              |struct MyStruct {
-              |  field1,
-              |  >>field2<<
-              |}
-              |
-              |MyStruct {
-              |  field1,
-              |  @@field2
-              |""".stripMargin
+        "second field is searched" when {
+          "constructor" in {
+            goToDefinition() {
+              """
+                |struct MyStruct {
+                |  field1,
+                |  >>field2<<
+                |}
+                |
+                |MyStruct {
+                |  field1,
+                |  @@field2
+                |""".stripMargin
+            }
+          }
+
+          "deconstructor" in {
+            goToDefinition() {
+              """
+                |struct MyStruct {
+                |  field1,
+                |  >>field2<<
+                |}
+                |
+                |let MyStruct { field1, @@field2 = instance
+                |""".stripMargin
+            }
           }
         }
       }
     }
 
-    "definitions closing brace is missing" in {
-      goToDefinition() {
-        """
-          |struct MyStruct { >>field<<
-          |{MyStruct { @@field }
-          |""".stripMargin
+    "definitions closing brace is missing" when {
+      "constructor" in {
+        goToDefinition() {
+          """
+            |struct MyStruct { >>field<<
+            |{MyStruct { @@field }
+            |""".stripMargin
+        }
       }
+
+      "deconstructor" in {
+        goToDefinition() {
+          """
+            |struct MyStruct { >>field<<
+            |{let MyStruct { @@field } = instance
+            |""".stripMargin
+        }
+      }
+
     }
 
-    "duplicate fields" in {
-      goToDefinition() {
-        """
-          |struct MyStruct {
-          |  >>field<<,
-          |  >>field<<,
-          |  ,
-          |  ,
-          |}
-          |
-          |MyStruct { @@field }
-          |""".stripMargin
+    "duplicate fields" when {
+      "constructor" in {
+        goToDefinition() {
+          """
+            |struct MyStruct {
+            |  >>field<<,
+            |  >>field<<,
+            |  ,
+            |  ,
+            |}
+            |
+            |MyStruct { @@field }
+            |""".stripMargin
+        }
+      }
+
+      "deconstructor" in {
+        goToDefinition() {
+          """
+            |struct MyStruct {
+            |  >>field<<,
+            |  >>field<<,
+            |  ,
+            |  ,
+            |}
+            |
+            |let MyStruct { @@field } =
+            |""".stripMargin
+        }
       }
     }
 
@@ -368,26 +707,53 @@ class GoToStructField_From_StructFieldBindingSpec extends AnyWordSpec with Match
           |
           |""".stripMargin
 
-      "first field is searched" in {
-        goToDefinition() {
-          s"""
-            |$duplicateStructs
-            |
-            |MyStruct { @@field }
-            |""".stripMargin
+      "first field is searched" when {
+        "constructor" in {
+          goToDefinition() {
+            s"""
+               |$duplicateStructs
+               |
+               |MyStruct { @@field }
+               |""".stripMargin
+          }
+        }
+
+        "deconstructor" in {
+          goToDefinition() {
+            s"""
+               |$duplicateStructs
+               |
+               |let MyStruct { @@field } = instance
+               |""".stripMargin
+          }
         }
       }
 
-      "second field is searched" in {
-        goToDefinition() {
-          s"""
-            |$duplicateStructs
-            |
-            |MyStruct {
-            |  field,
-            |  @@field
-            |}
-            |""".stripMargin
+      "second field is searched" when {
+        "constructor" in {
+          goToDefinition() {
+            s"""
+               |$duplicateStructs
+               |
+               |MyStruct {
+               |  field,
+               |  @@field
+               |}
+               |""".stripMargin
+          }
+        }
+
+        "deconstructor" in {
+          goToDefinition() {
+            s"""
+               |$duplicateStructs
+               |
+               |MyStruct {
+               |  field,
+               |  @@field
+               |}
+               |""".stripMargin
+          }
         }
       }
     }

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToStructField_From_StructFieldBindingSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotodef/GoToStructField_From_StructFieldBindingSpec.scala
@@ -7,7 +7,7 @@ import org.alephium.ralph.lsp.pc.search.TestCodeProvider._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class GoToStructFieldSpec extends AnyWordSpec with Matchers {
+class GoToStructField_From_StructFieldBindingSpec extends AnyWordSpec with Matchers {
 
   "return empty" when {
     "a struct field and an assignment value have duplicate names" when {


### PR DESCRIPTION
- Extends struct-constructor field search to also work on struct-deconstructors.
- Struct-deconstructor's `AST` was created in the previous PR #600.