### PR TITLE
Performance (29.84% gain): Replace dynamic with static parsing for reserved token

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/IdentifierParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/IdentifierParser.scala
@@ -44,7 +44,7 @@ private object IdentifierParser {
         CommentParser.parseOrFail.? ~
         // disallow reserved names such as `let mut = 1`.
         // also handle cases where tail is the end of file `let mut`.
-        !(TokenParser.Reserved() ~ TokenParser.isBoundary()) ~
+        !(ReservedTokenParser.parseOrFail ~ TokenParser.isBoundary()) ~
         CodeParser.parseOrFail(isDevDefinedName.!) ~
         Index
     } map {

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReservedTokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReservedTokenParser.scala
@@ -129,6 +129,11 @@ object ReservedTokenParser {
       """!"""
     )
 
+//  /**
+//   * Use this function to print the tokens to paste into the above [[staticReservedToken]].
+//   *
+//   * TODO: Move this to a macro.
+//   */
 //  private def regenerate(): Unit = {
 //    val string =
 //      Token

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReservedTokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/ReservedTokenParser.scala
@@ -1,0 +1,145 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse._
+import fastparse.NoWhitespace.noWhitespaceImplicit
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.Token
+
+object ReservedTokenParser {
+
+  //  /**
+  //   * This code dynamically parses tokens which are much slower than statically defined parser [[reservedToken]].
+  //   *
+  //   * This code benchmarked on LOC: 1000 yields an average time of:
+  //   * 0.1550185278599999997 seconds
+  //   *
+  //   * Using static tokens yields:
+  //   * 0.1087630216499999994  seconds
+  //   */
+  //  def parseOrFail[Unknown: P]: P[Token.Reserved] =
+  //    ParserUtil.orTokenCombinator(
+  //      prefixCheck = false,
+  //      tokens = Token.reserved.iterator
+  //    )
+
+  /**
+   * Parses all reserved tokens defined in [[Token.reserved]] and returns the first match.
+   *
+   * Prefix check is not required here because [[Token.reserved]] contains all tokens and are sorted.
+   */
+  def parseOrFail[Unknown: P]: P[Token.Reserved] =
+    staticReservedToken.! flatMap {
+      string =>
+        Token.reserved.find(_.lexeme == string) match {
+          case Some(token) =>
+            Pass(token)
+
+          case None =>
+            Fail(s"Unable to find reserved token for string '$string'")
+        }
+    }
+
+  /**
+   * Static string parser is used for reserved tokens because it increases by approximately 30% (29.84%).
+   *
+   * Test-cases will report if a reserved token ([[Token.Reserved]]) is missing from this list.
+   *
+   * __Note__: The order is important here so use the following commented out `regenerate` function
+   *           to print the tokens to add in order.
+   *
+   * TODO: This parser should be macro generated for easier management when new tokens are added.
+   */
+  private def staticReservedToken[Unknown: P]: P[Unit] =
+    StringIn(
+      """AssetScript""",
+      """implements""",
+      """Interface""",
+      """TxScript""",
+      """Contract""",
+      """Abstract""",
+      """mapping""",
+      """extends""",
+      """struct""",
+      """return""",
+      """import""",
+      """while""",
+      """false""",
+      """event""",
+      """const""",
+      """|**|""",
+      """true""",
+      """enum""",
+      """else""",
+      """alph""",
+      """ALPH""",
+      """|-|""",
+      """|+|""",
+      """|*|""",
+      """pub""",
+      """mut""",
+      """let""",
+      """for""",
+      """||""",
+      """if""",
+      """fn""",
+      """>>""",
+      """>=""",
+      """==""",
+      """<=""",
+      """<<""",
+      """/=""",
+      """//""",
+      """->""",
+      """-=""",
+      """+=""",
+      """++""",
+      """*=""",
+      """**""",
+      """&&""",
+      """!=""",
+      """}""",
+      """|""",
+      """{""",
+      """`""",
+      """^""",
+      """]""",
+      """\""",
+      """[""",
+      """@""",
+      """>""",
+      """=""",
+      """<""",
+      """;""",
+      """:""",
+      """/""",
+      """.""",
+      """-""",
+      """,""",
+      """+""",
+      """*""",
+      """)""",
+      """(""",
+      """&""",
+      """%""",
+      """$""",
+      """#""",
+      """"""",
+      """!"""
+    )
+
+//  private def regenerate(): Unit = {
+//    val string =
+//      Token
+//        .reserved
+//        .map {
+//          token =>
+//            s"""\"\"\"${token.lexeme}\"\"\""""
+//        }
+//        .mkString(", ")
+//
+//    println(string)
+//  }
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -71,17 +71,6 @@ private object TokenParser {
     }
 
   /**
-   * Parses all reserved tokens defined in [[Token.reserved]] and returns the first match.
-   *
-   * Prefix check is not required here because [[Token.reserved]] contains all tokens and are sorted.
-   */
-  def Reserved[Unknown: P](): P[Token.Reserved] =
-    ParserUtil.orTokenCombinator(
-      prefixCheck = false,
-      tokens = Token.reserved.iterator
-    )
-
-  /**
    * Parses all tokens of type [[Token.InfixOperator]] and also their comments.
    */
   def InfixOperatorOrFail[Unknown: P]: P[SoftAST.TokenDocumented[Token.InfixOperator]] =

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
@@ -52,13 +52,13 @@ object TestParser {
     runSoftParser(CommentParser.parseOrFail(_))(code)
 
   def parseReservedToken()(code: String): Token.Reserved =
-    runAnyParser(TokenParser.Reserved()(_))(code)
+    runAnyParser(ReservedTokenParser.parseOrFail(_))(code)
 
   def parseInfixOperatorOrFail(code: String): SoftAST.TokenDocumented[Token.InfixOperator] =
     runAnyParser(TokenParser.InfixOperatorOrFail(_))(code)
 
   def parseReservedTokenOrError()(code: String): Either[Parsed.Failure, Token.Reserved] =
-    runAnyParserOrError(TokenParser.Reserved()(_))(code)
+    runAnyParserOrError(ReservedTokenParser.parseOrFail(_))(code)
 
   def parseIdentifier(code: String): SoftAST.IdentifierAST =
     runSoftParser(IdentifierParser.parseOrFail(_))(code)


### PR DESCRIPTION
- Recent changes slows parser performance by about `20%` (from `0.12` seconds to `0.15` seconds for the same code).
- This PR implements part of the second point mentioned in issue #535, cutting the time down to `0.10s` - a `29.84%` improvement over the current `0.15s`, and about `12.29%` faster than the original `0.12s`.
- Not as convenient, but it performs better.

**Cause:** Renaming across multiple `.ral` files was noticeably slow. This and following changes should improve speed. 

Exact time in seconds:
- 0.1240083174299999988 (original from issue #535)
- 0.1550185278599999997 (current performance on master)
- 0.1087630216499999994 (this PR)