### PR TITLE
Replace dynamic parsing of infix tokens with static

### DIFF
--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/InfixCallParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/InfixCallParser.scala
@@ -15,7 +15,7 @@ private object InfixCallParser {
       Index ~
         leftExpression ~
         SpaceParser.parseOrFail.? ~
-        TokenParser.InfixOperatorOrFail ~
+        InfixTokenParser.parseOrFail ~
         SpaceParser.parseOrFail.? ~
         ExpressionParser.parseSubset(rightExpression) ~
         Index

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/InfixTokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/InfixTokenParser.scala
@@ -1,0 +1,95 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.access.compiler.parser.soft
+
+import fastparse._
+import fastparse.NoWhitespace.noWhitespaceImplicit
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.range
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.{SoftAST, Token}
+
+object InfixTokenParser {
+
+  /**
+   * Parses all tokens of type [[Token.InfixOperator]] and also their comments.
+   */
+  def parseOrFail[Unknown: P]: P[SoftAST.TokenDocumented[Token.InfixOperator]] =
+    P {
+      Index ~
+        CommentParser.parseOrFail.? ~
+        Index ~
+        infixToken ~
+        Index
+    } map {
+      case (commentFrom, documentation, tokenFrom, token, to) =>
+        SoftAST.TokenDocumented(
+          index = range(commentFrom, to),
+          documentation = documentation,
+          code = SoftAST.CodeToken(
+            index = range(tokenFrom, to),
+            token = token
+          )
+        )
+    }
+
+  /**
+   * Parses all infix tokens defined in [[Token.infix]] and returns the first match.
+   *
+   * Prefix check is not required here because [[Token.infix]] contains all infix tokens and are sorted.
+   */
+  private def infixToken[Unknown: P]: P[Token.InfixOperator] =
+    staticTokens.! flatMap {
+      string =>
+        Token.infix.find(_.lexeme == string) match {
+          case Some(token) =>
+            Pass(token)
+
+          case None =>
+            Fail(s"Unable to find infix token for string '$string'")
+        }
+    }
+
+  /**
+   * Static string parser is used for reserved tokens because it's faster.
+   *
+   * Test-cases will report if a token ([[Token.InfixOperator]]) is missing from this list.
+   *
+   * __Note__: The order is important here so use the following commented out `regenerate` function
+   *           to print the tokens to add in order.
+   *
+   * TODO: This parser should be macro generated for easier management when new tokens are added.
+   */
+  private def staticTokens[Unknown: P]: P[Unit] =
+    StringIn(
+      """|**|""",
+      """|-|""",
+      """|+|""",
+      """|*|""",
+      """||""",
+      """>>""",
+      """>=""",
+      """==""",
+      """<=""",
+      """<<""",
+      """/=""",
+      """-=""",
+      """+=""",
+      """++""",
+      """*=""",
+      """**""",
+      """&&""",
+      """!=""",
+      """|""",
+      """^""",
+      """\""",
+      """>""",
+      """<""",
+      """/""",
+      """-""",
+      """+""",
+      """*""",
+      """&""",
+      """%"""
+    )
+
+}

--- a/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
+++ b/compiler-access/src/main/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParser.scala
@@ -71,17 +71,6 @@ private object TokenParser {
     }
 
   /**
-   * Parses all tokens of type [[Token.InfixOperator]] and also their comments.
-   */
-  def InfixOperatorOrFail[Unknown: P]: P[SoftAST.TokenDocumented[Token.InfixOperator]] =
-    P {
-      parseOrFailOneOf(
-        prefixCheck = false,
-        tokens = Token.infix.iterator
-      )
-    }
-
-  /**
    * Reads characters until at least one of the input tokens is matched.
    *
    * If none of the tokens are found, the parser fails.

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TestParser.scala
@@ -54,8 +54,8 @@ object TestParser {
   def parseReservedToken()(code: String): Token.Reserved =
     runAnyParser(ReservedTokenParser.parseOrFail(_))(code)
 
-  def parseInfixOperatorOrFail(code: String): SoftAST.TokenDocumented[Token.InfixOperator] =
-    runAnyParser(TokenParser.InfixOperatorOrFail(_))(code)
+  def parseInfixOperator(code: String): SoftAST.TokenDocumented[Token.InfixOperator] =
+    runAnyParser(InfixTokenParser.parseOrFail(_))(code)
 
   def parseReservedTokenOrError()(code: String): Either[Parsed.Failure, Token.Reserved] =
     runAnyParserOrError(ReservedTokenParser.parseOrFail(_))(code)

--- a/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParserSpec.scala
+++ b/compiler-access/src/test/scala/org/alephium/ralph/lsp/access/compiler/parser/soft/TokenParserSpec.scala
@@ -17,7 +17,7 @@ class TokenParserSpec extends AnyWordSpec {
     "ForwardSlash" should {
       "not parse double forward slash as it is reserved for comments" in {
         assertThrows[Exception](
-          parseInfixOperatorOrFail("//")
+          parseInfixOperator("//")
         )
       }
     }
@@ -29,7 +29,7 @@ class TokenParserSpec extends AnyWordSpec {
 
         infixOperators foreach {
           infix =>
-            parseInfixOperatorOrFail(infix.lexeme) shouldBe
+            parseInfixOperator(infix.lexeme) shouldBe
               TokenDocumented(
                 index = range(0, infix.lexeme.length),
                 token = infix


### PR DESCRIPTION
- Applies the same performance optimisation used for reserved token in #605 to infix tokens.
