### PR TITLE
Initial version of `SoftAST` enabled Go-to-References

### DIFF
--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/CodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/CodeProvider.scala
@@ -9,7 +9,7 @@ import org.alephium.ralph.lsp.access.util.StringUtil
 import org.alephium.ralph.lsp.pc.search.completion.{CodeCompletionProvider, Suggestion}
 import org.alephium.ralph.lsp.pc.search.gotodef.GoToDefSetting
 import org.alephium.ralph.lsp.pc.search.gotodef.GoToDefCodeProvider
-import org.alephium.ralph.lsp.pc.search.gotoref.{GoToRefCodeProvider, GoToRefSetting}
+import org.alephium.ralph.lsp.pc.search.gotoref.{GoToRefCodeProvider, GoToRefSetting, GoToRefSoftCodeProvider}
 import org.alephium.ralph.lsp.pc.search.gototypedef.GoToTypeDefCodeProvider
 import org.alephium.ralph.lsp.pc.search.hover.HoverCodeProvider
 import org.alephium.ralph.lsp.pc.search.inlayhints.InlayHintsCodeProvider
@@ -134,6 +134,10 @@ object CodeProvider {
   /** The go-to references implementation of [[CodeProvider]]. */
   implicit val goToRef: CodeProvider[SourceCodeState.Parsed, GoToRefSetting, SourceLocation.GoToRefStrict] =
     GoToRefCodeProvider
+
+  /** The [[SoftAST]] enabled go-to references implementation of [[CodeProvider]]. */
+  implicit val goToRefSoft: CodeProvider[SourceCodeState.IsParsed, (SoftAST.type, GoToRefSetting), SourceLocation.GoToRefSoft] =
+    GoToRefSoftCodeProvider
 
   /** The rename request implementation of [[CodeProvider]]. */
   implicit val goToRename: CodeProvider[SourceCodeState.Parsed, Unit, SourceLocation.GoToRenameStrict] =

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefIdentifier.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefIdentifier.scala
@@ -1,0 +1,217 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.pc.search.gotoref
+
+import org.alephium.ralph.lsp.access.compiler.message.SourceIndexExtra.SourceIndexExtension
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.access.util.StringUtil
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
+import org.alephium.ralph.lsp.pc.search.CodeProvider
+import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
+import org.alephium.ralph.lsp.pc.workspace.{WorkspaceSearcher, WorkspaceState}
+import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
+import org.alephium.ralph.lsp.utils.Node
+
+import scala.collection.immutable.ArraySeq
+
+private object GoToRefIdentifier extends StrictImplicitLogging {
+
+  /**
+   * Searches for references at the given cursor position by delegating
+   * to the go-to-definition provider ([[CodeProvider.goToDef]]).
+   *
+   * @param cursorIndex    The index (character offset) in the source code representing the cursor position.
+   * @param sourceCode     The source code state where the search is executed.
+   * @param workspace      The workspace state where the source-code is located.
+   * @param searchSettings Provider-specific settings.
+   * @return References of the token defined at the cursor position.
+   */
+  def search(
+      cursorIndex: Int,
+      sourceCode: SourceCodeState.IsParsed,
+      workspace: WorkspaceState.IsSourceAware,
+      searchSettings: GoToRefSetting
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): ArraySeq[SourceLocation.GoToRefSoft] = {
+    val definitionsOption =
+      CodeProvider
+        .goToDef
+        .search( // find definitions for the token at the given `cursorIndex`.
+          // TODO: CodeProvider converts `LinePosition` to `cursorIndex` which here gets converted back to `LinePosition`.
+          //       Send `LinePosition` directly to `GoToRefSoftCodeProvider`.
+          linePosition = StringUtil.buildLineRange(sourceCode.code, cursorIndex, cursorIndex).from,
+          fileURI = sourceCode.fileURI,
+          workspace = workspace,
+          searchSettings = (SoftAST, searchSettings.goToDefSetting)
+        )
+
+    val definitions =
+      definitionsOption match {
+        case Some(Right(definitions)) =>
+          definitions
+            .collect {
+              case SourceLocation.NodeSoft(codeString: SoftAST.CodeString, source) =>
+                SourceLocation.NodeSoft(codeString, source)
+
+              // TODO: Support go-to-references for import statements.
+              // case _: SourceLocation.File => ???
+            }
+            .to(ArraySeq)
+
+        case Some(Left(error)) =>
+          logger.error {
+            s"""Error: Failed goToDef search in searchDelegate.
+               |File: ${sourceCode.fileURI}
+               |Error Message: ${error.message}""".stripMargin
+          }
+
+          ArraySeq.empty
+
+        case None =>
+          logger.debug(s"Definition does not exist for index $cursorIndex")
+          ArraySeq.empty
+      }
+
+    val references =
+      searchWorkspaceReferences(
+        definitions = definitions,
+        workspace = workspace,
+        searchSettings = searchSettings
+      )
+
+    if (searchSettings.includeDeclaration)
+      references ++ definitions
+    else
+      references
+  }
+
+  /**
+   * Searches all references to the given definitions across the entire workspace.
+   *
+   * @param definitions    The definitions whose references should be searched.
+   * @param workspace      The workspace state where the source-code is located.
+   * @param searchSettings Provider-specific settings.
+   * @return All references for the given definitions.
+   */
+  private def searchWorkspaceReferences(
+      definitions: ArraySeq[SourceLocation.NodeSoft[SoftAST.CodeString]],
+      workspace: WorkspaceState.IsSourceAware,
+      searchSettings: GoToRefSetting
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): ArraySeq[SourceLocation.NodeSoft[SoftAST.CodeString]] =
+    if (definitions.isEmpty)
+      ArraySeq.empty
+    else
+      WorkspaceSearcher
+        .collectAllIsParsed(workspace)
+        .flatMap {
+          isParsed =>
+            searchSourceCodeReferences(
+              isParsed = isParsed,
+              definitions = definitions,
+              workspace = workspace,
+              searchSettings = searchSettings
+            )
+        }
+        .distinct
+        .diff(definitions)
+
+  /**
+   * Searches all references to the given definitions across all code blocks within a single source code file.
+   *
+   * TODO: Performance optimisations is required here because this performs a naive linear scan
+   *       over the entire workspace - every source file, every code block in each file, and every
+   *       AST node within each block, and is therefore inefficient.
+   *       Suggestions:
+   *         - 1) Execute the search in parallel across all source files, and each code block within the source file.
+   *         - 2) Introduce an inverted-index-based cache.
+   *
+   * @param isParsed       The source code file to search.
+   * @param definitions    The definitions whose references should be searched.
+   * @param workspace      The workspace state where the source-code is located.
+   * @param searchSettings Provider-specific settings.
+   * @return All references for the given definitions.
+   */
+  private def searchSourceCodeReferences(
+      isParsed: SourceCodeState.IsParsed,
+      definitions: ArraySeq[SourceLocation.NodeSoft[SoftAST.CodeString]],
+      workspace: WorkspaceState.IsSourceAware,
+      searchSettings: GoToRefSetting
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Seq[SourceLocation.NodeSoft[SoftAST.CodeString]] =
+    if (definitions.isEmpty)
+      Seq.empty
+    else
+      isParsed.astSoft.fetch() match {
+        case Right(block) =>
+          // TODO: Execute in parallel.
+          block.parts.flatMap {
+            part =>
+              // TODO: Replace `walk` with an inverted-index.
+              part.toNode.walk.collect {
+                case Node(ast: SoftAST.Identifier, _) if isMatchingIdentifier(ast, isParsed, definitions, workspace, searchSettings) =>
+                  SourceLocation.NodeSoft(
+                    ast = ast.code,
+                    source = SourceLocation.CodeSoft(
+                      part = part,
+                      parsed = isParsed
+                    )
+                  )
+              }
+          }
+
+        case Left(error) =>
+          logger.error {
+            s"""SoftParser Error: Failed to parse source code.
+               |File: ${isParsed.fileURI}
+               |Error Message: ${error.message}""".stripMargin
+          }
+
+          Seq.empty
+      }
+
+  /**
+   * Checks whether the given identifier is a reference to any of the provided definitions.
+   *
+   * @param identifier     The identifier candidate to check.
+   * @param isParsed       The source file that contains the identifier.
+   * @param definitions    The target definitions to match the identifier against.
+   * @param workspace      The workspace state where the source-code is located.
+   * @param searchSettings Provider-specific settings.
+   * @return `true` if the identifier's definition matches the given definitions, `false` otherwise.
+   */
+  private def isMatchingIdentifier(
+      identifier: SoftAST.Identifier,
+      isParsed: SourceCodeState.IsParsed,
+      definitions: ArraySeq[SourceLocation.NodeSoft[SoftAST.CodeString]],
+      workspace: WorkspaceState.IsSourceAware,
+      searchSettings: GoToRefSetting
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Boolean =
+    if (definitions.exists(_.ast.text == identifier.code.text))
+      CodeProvider
+        .goToDef
+        .search( // find definitions for the token at the given cursorIndex.
+          linePosition = identifier.index.toLineRange(isParsed.code).from,
+          fileURI = isParsed.fileURI,
+          workspace = workspace,
+          searchSettings = (SoftAST, searchSettings.goToDefSetting)
+        )
+        .exists {
+          case Right(thisDefinition) =>
+            thisDefinition exists definitions.contains
+
+          case Left(error) =>
+            logger.error {
+              s"""Error: Failed to search goToDef in isMatchingAST.
+                 |File: ${isParsed.fileURI}
+                 |Error Message: ${error.message}""".stripMargin
+            }
+
+            false
+        }
+    else
+      false
+
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefSoftCodeProvider.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToRefSoftCodeProvider.scala
@@ -1,0 +1,37 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.ralph.lsp.pc.search.gotoref
+
+import org.alephium.ralph.lsp.access.compiler.parser.soft.ast.SoftAST
+import org.alephium.ralph.lsp.pc.search.CodeProvider
+import org.alephium.ralph.lsp.pc.search.cache.SearchCache
+import org.alephium.ralph.lsp.pc.sourcecode.{SourceCodeState, SourceLocation}
+import org.alephium.ralph.lsp.pc.workspace.WorkspaceState
+import org.alephium.ralph.lsp.utils.log.{ClientLogger, StrictImplicitLogging}
+
+/**
+ * Implements [[CodeProvider]] that provides go-to references results of type [[SourceLocation.GoToRefSoft]].
+ */
+private[search] case object GoToRefSoftCodeProvider
+  extends CodeProvider[SourceCodeState.IsParsed, (SoftAST.type, GoToRefSetting), SourceLocation.GoToRefSoft]
+     with StrictImplicitLogging {
+
+  /** @inheritdoc */
+  override def searchLocal(
+      cursorIndex: Int,
+      sourceCode: SourceCodeState.IsParsed,
+      workspace: WorkspaceState.IsSourceAware,
+      searchSettings: (SoftAST.type, GoToRefSetting)
+    )(implicit searchCache: SearchCache,
+      logger: ClientLogger): Iterator[SourceLocation.GoToRefSoft] =
+    GoToRefIdentifier
+      .search(
+        cursorIndex = cursorIndex,
+        sourceCode = sourceCode,
+        workspace = workspace,
+        searchSettings = searchSettings._2
+      )
+      .iterator
+
+}

--- a/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
+++ b/presentation-compiler/src/main/scala/org/alephium/ralph/lsp/pc/workspace/WorkspaceSearcher.scala
@@ -326,6 +326,19 @@ object WorkspaceSearcher {
   }
 
   /**
+   * Collects ALL [[SourceCodeState.IsParsed]] source code from the workspace and dependencies.
+   *
+   * @param workspace The workspace to collect parsed code for.
+   * @return All Parsed source files in all workspaces.
+   */
+  def collectAllIsParsed(workspace: WorkspaceState.IsSourceAware): ArraySeq[SourceCodeState.IsParsed] = {
+    val dependencySources = workspace.build.dependencies.flatMap(_.sourceCode)
+    val workspaceSources  = workspace.sourceCode
+    val allSources        = workspaceSources ++ dependencySources
+    SourceCodeSearcher.collectIsParsed(allSources)
+  }
+
+  /**
    * Collects all parsed source files, excluding `std` dependency source files
    * that are not imported.
    *

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToArgumentUsageInContractSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToArgumentUsageInContractSpec.scala
@@ -109,7 +109,7 @@ class GoToArgumentUsageInContractSpec extends AnyWordSpec with Matchers {
       "from the template" when {
         "parameter is defined in Parent" when {
           "there are no template argument duplicate names" in {
-            goToReferences() {
+            goToReferencesStrict() {
               """
                 |Abstract Contract Parent(param1@@: ParamType) {
                 |
@@ -161,7 +161,7 @@ class GoToArgumentUsageInContractSpec extends AnyWordSpec with Matchers {
           }
 
           "there are duplicate names" in {
-            goToReferences() {
+            goToReferencesStrict() {
               """
                 |Abstract Contract Parent(param1@@: ParamType) {
                 |
@@ -189,7 +189,7 @@ class GoToArgumentUsageInContractSpec extends AnyWordSpec with Matchers {
 
         "in Child" when {
           "parameter is defined in Child" in {
-            goToReferences() {
+            goToReferencesStrict() {
               """
                 |// Parent should not have any usages
                 |Abstract Contract Parent(param1: ParamType) {
@@ -221,7 +221,7 @@ class GoToArgumentUsageInContractSpec extends AnyWordSpec with Matchers {
 
     "template argument overrides are included" when {
       "definition is selected" in {
-        goToReferences(settings = testGoToRefSetting.copy(includeTemplateArgumentOverrides = true)) {
+        goToReferencesStrict(settings = testGoToRefSetting.copy(includeTemplateArgumentOverrides = true)) {
           """
             |Abstract Contract Parent(>>para@@m1<<: ParamType) { }
             |
@@ -231,7 +231,7 @@ class GoToArgumentUsageInContractSpec extends AnyWordSpec with Matchers {
       }
 
       "overridden definition is selected" in {
-        goToReferences(settings = testGoToRefSetting.copy(includeTemplateArgumentOverrides = true)) {
+        goToReferencesStrict(settings = testGoToRefSetting.copy(includeTemplateArgumentOverrides = true)) {
           """
               |Abstract Contract Parent(>>param1<<: ParamType) { }
               |

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToConstantUsagesSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToConstantUsagesSpec.scala
@@ -80,7 +80,7 @@ class GoToConstantUsagesSpec extends AnyWordSpec with Matchers {
 
       "global constants" when {
         def doTest(contractName: String) =
-          goToReferences() {
+          goToReferencesStrict() {
             s"""
                |const MyCons@@tant = 0
                |const MyConstant_B = 1

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToEnumFieldUsageSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToEnumFieldUsageSpec.scala
@@ -57,7 +57,7 @@ class GoToEnumFieldUsageSpec extends AnyWordSpec with Matchers {
               |}
               |""".stripMargin
 
-          goToReferencesForAll(">>Field0<<".r, ">>Fie@@ld0<<")(
+          goToReferencesStrictForAll(">>Field0<<".r, ">>Fie@@ld0<<")(
             s"""
               |${if (global) enumDef else ""}
               |
@@ -100,7 +100,7 @@ class GoToEnumFieldUsageSpec extends AnyWordSpec with Matchers {
               |}
               |""".stripMargin
 
-          goToReferencesForAll(">>Field1<<".r, ">>Fie@@ld1<<")(
+          goToReferencesStrictForAll(">>Field1<<".r, ">>Fie@@ld1<<")(
             s"""
                |${if (global) enumDef else ""}
                |
@@ -143,7 +143,7 @@ class GoToEnumFieldUsageSpec extends AnyWordSpec with Matchers {
               |}
               |""".stripMargin
 
-          goToReferencesForAll(">>Field1<<".r, ">>Fie@@ld1<<")(
+          goToReferencesStrictForAll(">>Field1<<".r, ">>Fie@@ld1<<")(
             s"""
                |${if (global) enumDef else ""}
                |

--- a/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToEventFieldUsageSpec.scala
+++ b/presentation-compiler/src/test/scala/org/alephium/ralph/lsp/pc/search/gotoref/GoToEventFieldUsageSpec.scala
@@ -60,7 +60,7 @@ class GoToEventFieldUsageSpec extends AnyWordSpec with Matchers {
 
   "return non-empty for an event field" when {
     "it has a usage" in {
-      goToReferences() {
+      goToReferencesStrict() {
         """
           |Contract Test() {
           |
@@ -75,7 +75,7 @@ class GoToEventFieldUsageSpec extends AnyWordSpec with Matchers {
     }
 
     "it has multiple usages" in {
-      goToReferences() {
+      goToReferencesStrict() {
         """
           |Contract Test() {
           |
@@ -94,7 +94,7 @@ class GoToEventFieldUsageSpec extends AnyWordSpec with Matchers {
     }
 
     "there is inheritance" in {
-      goToReferences() {
+      goToReferencesStrict() {
         """
           |Abstract Contract Parent() {
           |


### PR DESCRIPTION
- First PR towards the approach in draft PR #613.
- **Performance**: Initial version performs naive **linear scan**. It should eventually use an Inverted-Index and  [`Future`](https://github.com/alephium/ralph-lsp/issues/298)s. See TODO comments in code for performance optimisations.
- **Unplugged**: The existing strict-AST implementation of go-to-references remains active. This implementation stays unplugged until it's complete and fully tested with test-cases for incomplete/error code scenarios.
- Towards #568.
